### PR TITLE
Implement TypeApplications and StaticPointers support

### DIFF
--- a/data/examples/declaration/value/function/static-pointers-out.hs
+++ b/data/examples/declaration/value/function/static-pointers-out.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE StaticPointers #-}
+foo :: StaticPtr Int
+foo = static 5
+
+bar :: StaticPtr [Int]
+bar =
+  static
+    [ 1
+    , 2
+    , 3
+    ]
+
+baz :: StaticPtr Bool
+baz =
+  static
+    ( fun 1
+      2
+    )

--- a/data/examples/declaration/value/function/static-pointers.hs
+++ b/data/examples/declaration/value/function/static-pointers.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE StaticPointers #-}
+
+foo :: StaticPtr Int
+foo = static 5
+
+bar :: StaticPtr [Int]
+bar = static [ 1
+             , 2, 3
+             ]
+
+baz :: StaticPtr Bool
+baz = static (fun 1
+                2)

--- a/data/examples/declaration/value/function/type-applications-out.hs
+++ b/data/examples/declaration/value/function/type-applications-out.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TypeApplications #-}
+foo = f @String a b c
+
+bar = f @(Maybe Int) a b
+
+baz =
+  f @Int @String
+    a
+    b

--- a/data/examples/declaration/value/function/type-applications.hs
+++ b/data/examples/declaration/value/function/type-applications.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TypeApplications #-}
+
+foo = f @String a b c
+
+bar = f @(Maybe Int) a b
+
+baz = f @Int @String
+  a b

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -13,6 +13,7 @@ import Data.List (sortOn)
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
+import Ormolu.Printer.Meat.Type
 import Ormolu.Printer.Meat.Declaration.Pat
 import Ormolu.Printer.Meat.Declaration.Signature
 import Ormolu.Utils
@@ -163,7 +164,12 @@ p_hsExpr = \case
     located f p_hsExpr
     breakpoint
     inci (located x p_hsExpr)
-  HsAppType {} -> notImplemented "HsAppType"
+  HsAppType a e -> do
+    located a p_hsExpr
+    breakpoint
+    inci $ do
+      txt "@"
+      located (hswc_body e) p_hsType
   HsAppTypeOut {} -> notImplemented "HsAppTypeOut"
   OpApp x op _ y -> do
     located x p_hsExpr
@@ -223,7 +229,10 @@ p_hsExpr = \case
   HsTcBracketOut {} -> notImplemented "HsTcBracketOut"
   HsSpliceE {} -> notImplemented "HsSpliceE"
   HsProc {} -> notImplemented "HsProc"
-  HsStatic {} -> notImplemented "HsStatic"
+  HsStatic _  e -> do
+    txt "static"
+    breakpoint
+    inci $ located e p_hsExpr
   HsArrApp {} -> notImplemented "HsArrApp"
   HsArrForm {} -> notImplemented "HsArrForm"
   HsTick {} -> notImplemented "HsTick"


### PR DESCRIPTION
Hey,

I tried to use ormolu on one my projects, and saw a few unimplemented constructs and decided to implement it.

These are pretty small changes, since StaticPointers is like an ordinary function application and TypeApplications is like an ordinary parameter.

I do not know if you prefer separate PR's for these two, but the change is small enough that a single PR can be easily reviewed/merged.

---

Also a quick question, I want to try implementing a few more constructs, however they are more complex. I believe I can still come up with working implementations, but they will be less than ideal and you will need to go through them again. Would you prefer that, or do you prefer you or someone else to implement them from scratch?