### PR TITLE
Initial support for do notation

### DIFF
--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE RecursiveDo #-}
+bar = do
+  foo
+  bar
+
+baz = mdo
+  bar a
+  a <- foo
+  b <-
+    bar
+      1
+      2
+      3
+  return (a + b)
+
+baz = do
+  a <- foo
+  let b = a + 2
+      c = b + 3
+  bar c
+  let d = c + 2
+  return d

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE RecursiveDo #-}
+
+bar = do { foo; bar }
+
+baz =
+  mdo bar a
+      a <- foo
+      b <- bar
+        1 2 3
+      return (a + b)
+
+baz = do
+  a <- foo
+  let b = a + 2
+      c = b + 3
+  bar c
+  let d = c + 2
+  return d

--- a/data/examples/declaration/value/function/lambda-case-out.hs
+++ b/data/examples/declaration/value/function/lambda-case-out.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 foo :: Int -> Int
-foo =
-  \case
-    5 -> 10
-    _ -> 12
+foo = \case
+  5 -> 10
+  _ -> 12

--- a/data/examples/declaration/value/function/lambda-multi-line-out.hs
+++ b/data/examples/declaration/value/function/lambda-multi-line-out.hs
@@ -1,11 +1,9 @@
 foo :: a -> a -> a
-foo x =
-  \y ->
-    x
+foo x = \y ->
+  x
 
 bar :: Int -> Int -> Int
-bar x =
-  \y ->
-    if x > y
-    then 10
-    else 12
+bar x = \y ->
+  if x > y
+  then 10
+  else 12


### PR DESCRIPTION
I hacked something together until we can parse `do` notation.

It currently doesn't look pretty because I couldn't find a way to put the `do` keyword in the same line as the previous line; since, as far as I understand, `ormolu` thinks everything should be multi-lined since the whole construct spans multiple lines. I'd appreciate if you can point me to a solution.
