### PR TITLE
Change formatting of operators and infix constructors

### DIFF
--- a/data/examples/declaration/value/function/guards-out.hs
+++ b/data/examples/declaration/value/function/guards-out.hs
@@ -6,9 +6,9 @@ foo x
 bar :: Int -> Int
 bar x
   | x == 5 =
-    foo x
-      + foo 10
+    foo x +
+      foo 10
   | x == 6 =
-    foo x
-      + foo 20
+    foo x +
+      foo 20
   | otherwise = foo 100

--- a/data/examples/declaration/value/function/if-multi-line-out.hs
+++ b/data/examples/declaration/value/function/if-multi-line-out.hs
@@ -8,8 +8,8 @@ bar :: Int -> Int
 bar x =
   if x > 5
   then
-    foo x
-      + 100
+    foo x +
+      100
   else
-    foo x
-      + 200
+    foo x +
+      200

--- a/data/examples/declaration/value/function/let-multi-line-out.hs
+++ b/data/examples/declaration/value/function/let-multi-line-out.hs
@@ -8,5 +8,5 @@ bar :: Int -> Int
 bar x =
   let z = y
       y = x
-  in z
-       + 100
+  in z +
+       100

--- a/src/Ormolu/Printer/Meat/Declaration/Pat.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Pat.hs
@@ -56,11 +56,10 @@ p_pat = \case
             braces $ velt (withSep comma (located' p_hsRecField) fields)
       InfixCon x y -> do
         located x p_pat
+        space
+        p_rdrName pat
         breakpoint
-        inci $ do
-          p_rdrName pat
-          space
-          located y p_pat
+        inci (located y p_pat)
   ConPatOut {} -> notImplemented "ConPatOut"
   ViewPat {} -> notImplemented "ViewPat"
   SplicePat {} -> notImplemented "SplicePat"

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -216,11 +216,10 @@ p_hsExpr = \case
       located (hswc_body a) p_hsType
   OpApp NoExt x op y -> do
     located x p_hsExpr
+    space
+    located op p_hsExpr
     breakpoint
-    inci $ do
-      located op p_hsExpr
-      space
-      located y p_hsExpr
+    inci (located y p_hsExpr)
   NegApp NoExt e _ -> do
     txt "-"
     located e p_hsExpr


### PR DESCRIPTION
This formatting scheme is more appropriate if you think of chaining multiple infix expressions and combining it with do-blocks. The operator should hang on previous line instead going first on the next line, e.g.:

```
foo +
  bar
```

instead of

```
foo
  + bar
```