### PR TITLE
Handle “prefixed blocks” when they go after an operator

### DIFF
--- a/data/examples/declaration/value/function/case-multi-line-out.hs
+++ b/data/examples/declaration/value/function/case-multi-line-out.hs
@@ -1,25 +1,21 @@
 foo :: Int -> Int
-foo x =
-  case x of
-    5 -> 10
-    _ -> 12
+foo x = case x of
+  5 -> 10
+  _ -> 12
 
 bar :: Int -> Int
-bar x =
-  case x of
-    5 ->
-      if x > 5
-      then 10
-      else 12
-    _ -> 12
+bar x = case x of
+  5 ->
+    if x > 5
+    then 10
+    else 12
+  _ -> 12
 
 baz :: Int -> Int
-baz x =
-  case x of
-    5 -> 10
-    _ -> 12
+baz x = case x of
+  5 -> 10
+  _ -> 12
 
 quux :: Int -> Int
-quux x =
-  case x of
-    x -> x
+quux x = case x of
+  x -> x

--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -20,3 +20,9 @@ baz = do
   bar c
   let d = c + 2
   return d
+
+quux =
+  something $ do
+    foo
+    bar
+    baz

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -16,3 +16,8 @@ baz = do
   bar c
   let d = c + 2
   return d
+
+quux = something $ do
+  foo
+  bar
+  baz

--- a/src/Ormolu/Printer/Meat/Declaration/Pat.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Pat.hs
@@ -55,10 +55,8 @@ p_pat = \case
               Nothing -> txt ".."
               Just x -> located x p_hsRecField
         inci . braces . velt . withSep comma f $ case dotdot of
-          Nothing ->
-            Just <$> fields
-          Just n -> do
-            (Just <$> take n fields) ++ [Nothing]
+          Nothing -> Just <$> fields
+          Just n -> (Just <$> take n fields) ++ [Nothing]
       InfixCon x y -> do
         located x p_pat
         space

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -279,7 +279,7 @@ p_hsExpr = \case
     located e p_hsExpr
     txt " of"
     breakpoint
-    inci (p_matchGroup Case mgroup)
+    p_matchGroup Case mgroup
   HsIf NoExt _ if' then' else' -> do
     txt "if "
     located if' p_hsExpr
@@ -447,6 +447,7 @@ isPrefixBlock _ = False
 isPrefixBlockExpr :: HsExpr GhcPs -> Bool
 isPrefixBlockExpr = \case
   HsLam NoExt _ -> True
+  HsCase NoExt _ _ -> True
   HsDo NoExt _ _ -> True
   HsLamCase NoExt _ -> True
   _ -> False

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -231,7 +231,9 @@ p_hsExpr = \case
     located x p_hsExpr
     space
     located op p_hsExpr
-    breakpoint
+    if isPrefixBlockExpr (unL y)
+      then space
+      else breakpoint
     inci (located y p_hsExpr)
   NegApp NoExt e _ -> do
     txt "-"
@@ -437,10 +439,14 @@ getGRHSSpan (XGRHS NoExt) = notImplemented "XGRHS"
 -- case expressions.
 
 isPrefixBlock :: [LGRHS GhcPs (LHsExpr GhcPs)] -> Bool
-isPrefixBlock [(L _ (GRHS NoExt _ (L _ e)))] =
-  case e of
-    HsLam NoExt _ -> True
-    HsDo NoExt _ _ -> True
-    HsLamCase NoExt _ -> True
-    _ -> False
+isPrefixBlock [(L _ (GRHS NoExt _ (L _ e)))] = isPrefixBlockExpr e
 isPrefixBlock _ = False
+
+-- | Similar to 'isPrefixBlock', but just for checking 'HsExpr' directly.
+
+isPrefixBlockExpr :: HsExpr GhcPs -> Bool
+isPrefixBlockExpr = \case
+  HsLam NoExt _ -> True
+  HsDo NoExt _ _ -> True
+  HsLamCase NoExt _ -> True
+  _ -> False


### PR DESCRIPTION
The change is obvious from the examples.