### PR TITLE
Implement rendering of instance declarations

### DIFF
--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TypeFamilies #-}
+instance Foo Int where
+  data Bar Int = IntBar Int Int
+
+instance Foo Double where
+  newtype Bar Double
+    = DoubleBar
+        Double
+        Double
+
+instance Foo [a] where
+  data Bar [a]
+    = ListBar [Bar a]
+  data Baz [a]
+    = ListBaz

--- a/data/examples/declaration/instance/associated-data.hs
+++ b/data/examples/declaration/instance/associated-data.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TypeFamilies #-}
+
+instance Foo Int where data Bar Int  =  IntBar Int Int
+
+instance Foo Double where
+    newtype
+      Bar
+        Double
+        =
+          DoubleBar
+            Double
+            Double
+
+instance Foo [a]
+  where
+    data Bar [a] =
+            ListBar [Bar a]
+    data Baz [a] =
+            ListBaz

--- a/data/examples/declaration/instance/associated-types-out.hs
+++ b/data/examples/declaration/instance/associated-types-out.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TypeFamilies #-}
+instance Foo Int where
+  type Bar Int = Double
+
+instance Foo Double where
+  type Bar Double =
+    [Double]
+  type Baz Double =
+    [Double]

--- a/data/examples/declaration/instance/associated-types.hs
+++ b/data/examples/declaration/instance/associated-types.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE TypeFamilies #-}
+
+instance Foo Int where type Bar Int = Double
+
+instance Foo Double
+  where
+    type
+      Bar
+        Double
+        =
+          [Double]
+    type instance Baz  Double
+      = [Double]

--- a/data/examples/declaration/instance/contexts-out.hs
+++ b/data/examples/declaration/instance/contexts-out.hs
@@ -1,0 +1,9 @@
+instance Eq a => Eq [a] where
+  (==) _ _ = False
+
+instance ( Ord a
+         , Ord b
+         )
+         => Ord
+              (a, b) where
+  compare _ _ = GT

--- a/data/examples/declaration/instance/contexts.hs
+++ b/data/examples/declaration/instance/contexts.hs
@@ -1,0 +1,7 @@
+instance Eq a=>Eq [a] where (==) _ _ = False
+
+instance (
+    Ord a,
+    Ord b
+  ) => Ord (a,b) where
+  compare _ _ = GT

--- a/data/examples/declaration/instance/data-family-instances-out.hs
+++ b/data/examples/declaration/instance/data-family-instances-out.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE TypeFamilies #-}
+data instance Foo Int = FooInt Int
+
+data instance Foo [Int]
+  = IntListFoo
+      ( Int
+      , Int
+      )
+      ( Double
+      , Double
+      )
+
+newtype instance Foo [Double]
+  = DoubleListFoo
+      { unDoubleListFoo :: Double
+      }
+
+data instance Bar Double a
+  = DoubleBar
+      Double
+      (Bar a)
+
+data instance Bar Int a where
+  SameBar
+    :: Bar Int
+         Int
+  CloseBar :: Bar Int Double
+  OtherBar
+    :: Bar Int
+         a

--- a/data/examples/declaration/instance/data-family-instances.hs
+++ b/data/examples/declaration/instance/data-family-instances.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE TypeFamilies #-}
+data instance Foo  Int  = FooInt  Int
+
+data instance
+    Foo [
+        Int
+    ] = IntListFoo (
+        Int,
+        Int
+    ) (
+        Double,
+        Double
+    )
+
+newtype instance Foo [Double] = DoubleListFoo {
+    unDoubleListFoo :: Double
+}
+
+data instance Bar Double a =
+    DoubleBar
+        Double
+        (Bar a)
+
+data instance Bar Int a where
+    SameBar
+      :: Bar Int
+           Int
+    CloseBar :: Bar Int Double
+    OtherBar
+      :: Bar Int
+           a

--- a/data/examples/declaration/instance/empty-instance-out.hs
+++ b/data/examples/declaration/instance/empty-instance-out.hs
@@ -1,0 +1,3 @@
+instance Typeable Int
+
+instance Generic Int

--- a/data/examples/declaration/instance/empty-instance.hs
+++ b/data/examples/declaration/instance/empty-instance.hs
@@ -1,0 +1,2 @@
+instance Typeable Int
+instance Generic Int where

--- a/data/examples/declaration/instance/instance-sigs-out.hs
+++ b/data/examples/declaration/instance/instance-sigs-out.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE InstanceSigs #-}
+instance Eq Int where
+  (==) :: Int -> Int -> Bool
+  (==) _ _ = False
+
+instance Ord Int where
+  compare
+    :: Int
+    -> Int
+    -> Ordering
+  compare
+    _
+    _ = GT
+
+instance Applicative [] where
+  pure
+    :: a
+    -> [a]
+  pure a = [a]
+  (<*>)
+    :: [a] -> [a] -> [a]
+  (<*>) _ _ = []

--- a/data/examples/declaration/instance/instance-sigs.hs
+++ b/data/examples/declaration/instance/instance-sigs.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE InstanceSigs #-}
+
+instance Eq Int
+  where
+    (==) :: Int -> Int -> Bool
+    (==) _ _ = False
+
+instance Ord Int where
+    compare ::
+           Int
+        -> Int
+        -> Ordering
+    compare
+        _
+        _
+        = GT
+
+instance Applicative [] where
+  pure ::
+       a
+    -> [a]
+  pure a = [a]
+  (<*>)
+    :: [ a ] -> [ a ] -> [ a ]
+  (<*>) _ _ = []

--- a/data/examples/declaration/instance/multi-parameter-out.hs
+++ b/data/examples/declaration/instance/multi-parameter-out.hs
@@ -1,0 +1,6 @@
+instance MonadReader a ((->) a) where
+  ask = id
+
+instance MonadState s (State s) where
+  get = State.get
+  put = State.put

--- a/data/examples/declaration/instance/multi-parameter.hs
+++ b/data/examples/declaration/instance/multi-parameter.hs
@@ -1,0 +1,6 @@
+instance MonadReader  a  ((->) a) where ask = id
+
+instance MonadState s (State s)
+  where
+    get = State.get
+    put = State.put

--- a/data/examples/declaration/instance/overlappable-instances-out.hs
+++ b/data/examples/declaration/instance/overlappable-instances-out.hs
@@ -1,0 +1,16 @@
+-- Test should have tested different whitespaces inside pragma. However, the
+-- pragmas contain a "SourceText" which compares as equal only if the whitespace
+-- inside the pragma is printed exactly identically (i.e. including newlines and
+-- all.) In practice, removing this whitespace is desirable, so whitespace is
+-- not varied to avoid spurious and difficult-to-avoid test case errors.
+instance {-# OVERLAPPABLE #-} Eq Int where
+  (==) _ _ = False
+
+instance {-# OVERLAPPING #-} Ord Int where
+  compare _ _ = GT
+
+instance {-# OVERLAPS #-} Eq Double where
+  (==) _ _ = False
+
+instance {-# INCOHERENT #-} Ord Double where
+  compare _ _ = GT

--- a/data/examples/declaration/instance/overlappable-instances-out.hs
+++ b/data/examples/declaration/instance/overlappable-instances-out.hs
@@ -1,8 +1,3 @@
--- Test should have tested different whitespaces inside pragma. However, the
--- pragmas contain a "SourceText" which compares as equal only if the whitespace
--- inside the pragma is printed exactly identically (i.e. including newlines and
--- all.) In practice, removing this whitespace is desirable, so whitespace is
--- not varied to avoid spurious and difficult-to-avoid test case errors.
 instance {-# OVERLAPPABLE #-} Eq Int where
   (==) _ _ = False
 

--- a/data/examples/declaration/instance/overlappable-instances.hs
+++ b/data/examples/declaration/instance/overlappable-instances.hs
@@ -1,17 +1,11 @@
--- Test should have tested different whitespaces inside pragma. However, the
--- pragmas contain a "SourceText" which compares as equal only if the whitespace
--- inside the pragma is printed exactly identically (i.e. including newlines and
--- all.) In practice, removing this whitespace is desirable, so whitespace is
--- not varied to avoid spurious and difficult-to-avoid test case errors.
-
-instance {-# OVERLAPPABLE #-} Eq Int where (==) _ _ = False
+instance {-# OVERLAPPABLE   #-} Eq Int where (==) _ _ = False
 
 instance
-    {-# OVERLAPPING #-} Ord Int where compare _ _ = GT
+    {-#   OVERLAPPING #-} Ord Int where compare _ _ = GT
 
-instance {-# OVERLAPS #-} Eq Double where
+instance {-#  OVERLAPS  #-} Eq Double where
     (==) _ _ = False
 
 instance
-    {-# INCOHERENT #-} Ord Double where
+    {-# INCOHERENT  #-} Ord Double where
     compare _ _ = GT

--- a/data/examples/declaration/instance/overlappable-instances.hs
+++ b/data/examples/declaration/instance/overlappable-instances.hs
@@ -1,0 +1,17 @@
+-- Test should have tested different whitespaces inside pragma. However, the
+-- pragmas contain a "SourceText" which compares as equal only if the whitespace
+-- inside the pragma is printed exactly identically (i.e. including newlines and
+-- all.) In practice, removing this whitespace is desirable, so whitespace is
+-- not varied to avoid spurious and difficult-to-avoid test case errors.
+
+instance {-# OVERLAPPABLE #-} Eq Int where (==) _ _ = False
+
+instance
+    {-# OVERLAPPING #-} Ord Int where compare _ _ = GT
+
+instance {-# OVERLAPS #-} Eq Double where
+    (==) _ _ = False
+
+instance
+    {-# INCOHERENT #-} Ord Double where
+    compare _ _ = GT

--- a/data/examples/declaration/instance/single-parameter-out.hs
+++ b/data/examples/declaration/instance/single-parameter-out.hs
@@ -1,0 +1,7 @@
+instance Monoid Int where
+  (<>) x y = x + y
+
+instance Enum Int where
+  fromEnum x = x
+  toEnum = \x ->
+    x

--- a/data/examples/declaration/instance/single-parameter.hs
+++ b/data/examples/declaration/instance/single-parameter.hs
@@ -1,0 +1,8 @@
+instance Monoid Int where (<>) x y = x+y
+
+instance Enum Int
+  where
+    fromEnum x = x
+    toEnum
+      = \x ->
+        x

--- a/data/examples/declaration/instance/type-family-instances-out.hs
+++ b/data/examples/declaration/instance/type-family-instances-out.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TypeFamilies #-}
+type instance Foo Int = Int
+
+type instance Foo [Int] =
+  ( Int
+  , Int
+  )

--- a/data/examples/declaration/instance/type-family-instances-out.hs
+++ b/data/examples/declaration/instance/type-family-instances-out.hs
@@ -5,3 +5,10 @@ type instance Foo [Int] =
   ( Int
   , Int
   )
+
+type instance Bar Int [Int] Double = (Int, Double)
+
+type instance Bar [Int] [Int] Double =
+  ( Int
+  , Double
+  )

--- a/data/examples/declaration/instance/type-family-instances.hs
+++ b/data/examples/declaration/instance/type-family-instances.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TypeFamilies #-}
+
+type instance Foo  Int  = Int
+
+type instance
+  Foo
+    [Int] = ( Int,
+        Int
+    )

--- a/data/examples/declaration/instance/type-family-instances.hs
+++ b/data/examples/declaration/instance/type-family-instances.hs
@@ -7,3 +7,15 @@ type instance
     [Int] = ( Int,
         Int
     )
+
+type instance Bar  Int  [Int]  Double = ( Int, Double )
+
+type instance
+  Bar
+    [Int]
+    [Int]
+    Double
+    = (
+      Int,
+      Double
+    )

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -60,6 +60,7 @@ library
                     , Ormolu.Printer.Internal
                     , Ormolu.Printer.Meat.Common
                     , Ormolu.Printer.Meat.Declaration
+                    , Ormolu.Printer.Meat.Declaration.Instance
                     , Ormolu.Printer.Meat.Declaration.Data
                     , Ormolu.Printer.Meat.Declaration.Pat
                     , Ormolu.Printer.Meat.Declaration.Signature

--- a/src/Ormolu/Diff.hs
+++ b/src/Ormolu/Diff.hs
@@ -9,6 +9,7 @@ module Ormolu.Diff
   )
 where
 
+import BasicTypes (SourceText)
 import Data.Generics
 import GHC
 import Ormolu.CommentStream
@@ -33,7 +34,10 @@ matchIgnoringSrcSpans = genericQuery
   where
     genericQuery :: GenericQ (GenericQ Bool)
     genericQuery x y = (toConstr x == toConstr y)
-      && and (gzipWithQ (genericQuery `extQ` srcSpanEq `extQ` hsModuleEq) x y)
+      && and (gzipWithQ (genericQuery
+                           `extQ` srcSpanEq
+                           `extQ` hsModuleEq
+                           `extQ` sourceTextEq) x y)
 
     srcSpanEq :: SrcSpan -> GenericQ Bool
     srcSpanEq _ _ = True
@@ -46,3 +50,6 @@ matchIgnoringSrcSpans = genericQuery
           matchIgnoringSrcSpans
             hs0 { hsmodImports = sortImports (hsmodImports hs0) }
             hs1 { hsmodImports = sortImports (hsmodImports hs1) }
+
+    sourceTextEq :: SourceText -> GenericQ Bool
+    sourceTextEq _ _ = True

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -4,7 +4,8 @@
 -- | Rendering of commonly useful bits.
 
 module Ormolu.Printer.Meat.Common
-  ( p_hsmodName
+  ( FamilyStyle (..)
+  , p_hsmodName
   , p_ieWrappedName
   , p_rdrName
   , p_qualName
@@ -19,6 +20,12 @@ import Ormolu.Printer.Combinators
 import Ormolu.Printer.Internal (getAnns)
 import Ormolu.Utils (getSpan)
 import RdrName (RdrName (..))
+
+-- | Data and type family style.
+
+data FamilyStyle
+  = Associated
+  | Free
 
 p_hsmodName :: ModuleName -> R ()
 p_hsmodName mname = do

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -11,6 +11,7 @@ where
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Declaration.Data
+import Ormolu.Printer.Meat.Declaration.Instance
 import Ormolu.Printer.Meat.Declaration.Signature
 import Ormolu.Printer.Meat.Declaration.Type
 import Ormolu.Printer.Meat.Declaration.TypeFamily
@@ -22,6 +23,7 @@ p_hsDecl = \case
   TyClD NoExt x -> p_tyClDecl x
   ValD NoExt x -> p_valDecl x
   SigD NoExt x -> p_sigDecl x
+  InstD NoExt x -> p_instDecl x
   _ -> notImplemented "certain kinds of declarations"
 
 p_tyClDecl :: TyClDecl GhcPs -> R ()
@@ -29,4 +31,10 @@ p_tyClDecl = \case
   FamDecl NoExt x -> p_famDecl x
   SynDecl {..} -> p_synDecl tcdLName tcdTyVars tcdRhs
   DataDecl {..} -> p_dataDecl tcdLName tcdTyVars tcdDataDefn
+  _ -> notImplemented "certain kinds of declarations"
+
+p_instDecl :: InstDecl GhcPs -> R ()
+p_instDecl = \case
+  ClsInstD NoExt x -> p_clsInstDecl x
+  TyFamInstD NoExt x -> p_tyFamInstDecl Free x
   _ -> notImplemented "certain kinds of declarations"

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -10,6 +10,7 @@ where
 
 import GHC
 import Ormolu.Printer.Combinators
+import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration.Data
 import Ormolu.Printer.Meat.Declaration.Instance
 import Ormolu.Printer.Meat.Declaration.Signature
@@ -30,11 +31,29 @@ p_tyClDecl :: TyClDecl GhcPs -> R ()
 p_tyClDecl = \case
   FamDecl NoExt x -> p_famDecl x
   SynDecl {..} -> p_synDecl tcdLName tcdTyVars tcdRhs
-  DataDecl {..} -> p_dataDecl tcdLName tcdTyVars tcdDataDefn
+  DataDecl {..} ->
+    p_dataDecl Associated tcdLName (tyVarsToTypes tcdTyVars) tcdDataDefn
   _ -> notImplemented "certain kinds of declarations"
 
 p_instDecl :: InstDecl GhcPs -> R ()
 p_instDecl = \case
   ClsInstD NoExt x -> p_clsInstDecl x
   TyFamInstD NoExt x -> p_tyFamInstDecl Free x
+  DataFamInstD NoExt x -> p_dataFamInstDecl Free x
   _ -> notImplemented "certain kinds of declarations"
+
+----------------------------------------------------------------------------
+-- Helpers
+
+tyVarsToTypes :: LHsQTyVars GhcPs -> [LHsType GhcPs]
+tyVarsToTypes = \case
+  HsQTvs {..} -> fmap tyVarToType <$> hsq_explicit
+  XLHsQTyVars {} -> notImplemented "XLHsQTyVars"
+
+tyVarToType :: HsTyVarBndr GhcPs -> HsType GhcPs
+tyVarToType = \case
+  UserTyVar NoExt tvar -> HsTyVar NoExt NotPromoted tvar
+  KindedTyVar NoExt tvar kind ->
+    HsParTy NoExt $ noLoc $
+    HsKindSig NoExt (noLoc (HsTyVar NoExt NotPromoted tvar)) kind
+  XTyVarBndr {} -> notImplemented "XTyVarBndr"

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+-- | Type class instance declarations.
+
+module Ormolu.Printer.Meat.Declaration.Instance
+  ( p_clsInstDecl
+  , FamilyStyle (Associate, Free)
+  , p_tyFamInstDecl
+  )
+where
+
+import BasicTypes
+import Control.Arrow
+import Data.Foldable
+import Data.Function
+import Data.List (sortBy)
+import GHC
+import Ormolu.Printer.Combinators
+import Ormolu.Printer.Meat.Declaration.Signature
+import Ormolu.Printer.Meat.Declaration.TypeFamily
+import Ormolu.Printer.Meat.Declaration.Value
+import Ormolu.Printer.Meat.Type
+import Ormolu.Utils
+
+p_clsInstDecl :: ClsInstDecl GhcPs -> R ()
+p_clsInstDecl = \case
+  ClsInstDecl {..} -> do
+    txt "instance "
+    case unLoc <$> cid_overlap_mode of
+      Just Overlappable {} -> txt "{-# OVERLAPPABLE #-} "
+      Just Overlapping {} -> txt "{-# OVERLAPPING #-} "
+      Just Overlaps {} -> txt "{-# OVERLAPS #-} "
+      Just Incoherent {} -> txt "{-# INCOHERENT #-} "
+      _ -> pure ()
+    case cid_poly_ty of
+      HsIB {..} -> sitcc (located hsib_body p_hsType)
+      XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
+    -- GHC's AST does not necessarily store each kind of element in source
+    -- location order. This happens because different declarations are stored in
+    -- different lists. Consequently, to get all the declarations in proper
+    -- order, they need to be manually sorted.
+    let binds = (getLoc &&& located' p_valDecl) <$> cid_binds
+        sigs = (getLoc &&& located' p_sigDecl) <$> cid_sigs
+        tyfam_insts =
+          (getLoc &&& located' (p_tyFamInstDecl Associate)) <$> cid_tyfam_insts
+        decls =
+          snd <$>
+          sortBy (compare `on` fst) (toList binds <> sigs <> tyfam_insts)
+    if not (null decls)
+      then do
+        txt " where"
+        newline
+        inci (sequence_ decls)
+      else do
+        newline
+  XClsInstDecl NoExt -> notImplemented "XClsInstDecl"
+
+data FamilyStyle
+  = Associate
+  | Free
+
+p_tyFamInstDecl :: FamilyStyle -> TyFamInstDecl GhcPs -> R ()
+p_tyFamInstDecl style = \case
+  TyFamInstDecl {..} -> do
+    txt $ case style of
+      Associate -> "type "
+      Free -> "type instance "
+    p_tyFamInstEqn tfid_eqn
+    newline

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -10,6 +10,7 @@ module Ormolu.Printer.Meat.Declaration.Signature
   )
 where
 
+import Control.Monad
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
@@ -22,6 +23,9 @@ p_sigDecl = line . p_sigDecl'
 p_sigDecl' :: Sig GhcPs -> R ()
 p_sigDecl' = \case
   TypeSig NoExt names hswc -> p_typeSig names hswc
+  ClassOpSig NoExt def names hsib -> do
+    when def (txt "default ")
+    p_typeSig names HsWC {hswc_ext = NoExt, hswc_body = hsib}
   _ -> notImplemented "certain types of signature declarations"
 
 p_typeSig

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -6,6 +6,7 @@
 
 module Ormolu.Printer.Meat.Declaration.TypeFamily
   ( p_famDecl
+  , p_tyFamInstEqn
   )
 where
 


### PR DESCRIPTION
This pull request implements half of #49. Specifically, it deals with pretty printing instance declarations and most structures needed to support that. This includes pretty printing of associated types (and therefore also type family instances.) However, this _does not_ include pretty printing of associated data types.

Pretty printing of type class declarations is to be dealt with at a later time.

Instances are formatted such that indentation hangs after the `instance`. Namely,

```haskell
instance Eq a
         => Eq [a] where
```

To support pretty printing associated types, the function `p_tyFamInstEqn` was exported from the appropriate module. This was done to avoid redundant code duplication.

As for supporting pretty printing of associated data types: there is a potential (but unimplemented) solution that works while minimizing code duplication by changing the `p_dataDecl` function, which currently has the signature:

```haskell
p_dataDecl :: Located RdrName -> LHsQTyVars GhcPs -> HsDataDefn GhcPs -> R ()
```

If the parameters to `p_dataDecl` instead were any `HsType`, then the associated data patterns could be pretty printed using `p_dataDecl`. Fortunately, type variables can be directly represented in `HsType`s.

Furthermore, if `p_dataDecl` took an extra parameter to represent the context (or style) it is placed in, it would be trivial to support open data family instances as well, providing a final signature:

```haskell
p_dataDecl :: FamilyStyle -> Located RdrName -> [LHsType GhcPs] -> HsDataDefn GhcPs -> R ()
```

In principle, making this change should not take me long at all, and would give complete support for both associated data and open data family instances.

That said, I feel like larger changes to e.g. type signatures and use cases like this should be agreed upon ahead of time. Hence, why I have not implemented this yet.

This branch has had its commit history squashed. See [yumiova:yumiova/instance-declaration](https://github.com/yumiova/ormolu/tree/yumiova/instance-declaration) for the original commit history.