### PR TITLE
[#50] Standalone Deriving

### DIFF
--- a/data/examples/declaration/deriving/multiline-out.hs
+++ b/data/examples/declaration/deriving/multiline-out.hs
@@ -1,0 +1,44 @@
+deriving instance
+  Eq
+    Foo
+
+deriving stock instance
+  Show
+    Foo
+
+deriving anyclass instance
+  ToJSON
+    Foo
+
+deriving newtype instance
+  Data
+    Foo
+
+deriving instance
+  {-# OVERLAPPABLE #-}
+  Ord
+    Foo
+
+deriving instance
+  {-# OVERLAPPING #-}
+  Num
+    Foo
+
+deriving instance
+  {-# OVERLAPS #-}
+  Read
+    Foo
+
+deriving instance
+  {-# INCOHERENT #-}
+  Show
+    Foo
+
+deriving via
+  Foo
+    Int
+  instance
+    Triple
+      A
+      B
+      C

--- a/data/examples/declaration/deriving/multiline.hs
+++ b/data/examples/declaration/deriving/multiline.hs
@@ -1,0 +1,36 @@
+deriving instance Eq
+                    Foo
+
+deriving stock instance
+  Show
+    Foo
+deriving anyclass instance
+  ToJSON
+    Foo
+deriving newtype instance
+  Data
+    Foo
+
+deriving instance
+  {-# OVERLAPPABLE #-}
+    Ord
+      Foo
+deriving instance
+  {-# OVERLAPPING #-}
+    Num
+      Foo
+deriving instance
+  {-# OVERLAPS #-}
+    Read
+      Foo
+deriving instance
+  {-# INCOHERENT #-}
+    Show
+      Foo
+
+deriving via Foo
+               Int
+  instance Triple
+             A
+             B
+             C

--- a/data/examples/declaration/deriving/singleline-out.hs
+++ b/data/examples/declaration/deriving/singleline-out.hs
@@ -1,0 +1,17 @@
+deriving instance Eq Foo
+
+deriving stock instance Show Foo
+
+deriving anyclass instance ToJSON Foo
+
+deriving newtype instance Data Foo
+
+deriving instance {-# OVERLAPPABLE #-} Ord Foo
+
+deriving instance {-# OVERLAPPING #-} Num Foo
+
+deriving instance {-# OVERLAPS #-} Read Foo
+
+deriving instance {-# INCOHERENT #-} Show Foo
+
+deriving via Int instance Triple A B C

--- a/data/examples/declaration/deriving/singleline.hs
+++ b/data/examples/declaration/deriving/singleline.hs
@@ -1,0 +1,12 @@
+deriving instance Eq Foo
+
+deriving stock instance Show Foo
+deriving anyclass instance ToJSON Foo
+deriving newtype instance Data Foo
+
+deriving instance {-# OVERLAPPABLE #-} Ord Foo
+deriving instance {-# OVERLAPPING #-} Num Foo
+deriving instance {-# OVERLAPS #-} Read Foo
+deriving instance {-# INCOHERENT #-} Show Foo
+
+deriving via Int instance Triple A B C

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -27,7 +27,7 @@ p_hsDecl = \case
   ValD NoExt x -> p_valDecl x
   SigD NoExt x -> p_sigDecl x
   InstD NoExt x -> p_instDecl x
-  DerivD _ _ -> notImplemented "DerivD"
+  DerivD NoExt x -> p_derivDecl x
   DefD _ _ -> notImplemented "DefD"
   ForD _ _ -> notImplemented "ForD"
   WarningD _ _ -> notImplemented "WarningD"
@@ -61,4 +61,12 @@ p_instDecl = \case
   ClsInstD NoExt x -> p_clsInstDecl x
   TyFamInstD NoExt x -> p_tyFamInstDecl Free x
   DataFamInstD NoExt x -> p_dataFamInstDecl Free x
-  _ -> notImplemented "certain kinds of declarations"
+  XInstDecl _ -> notImplemented "XInstDecl"
+
+p_derivDecl :: DerivDecl GhcPs -> R ()
+p_derivDecl = \case
+  d@DerivDecl {..} -> p_standaloneDerivDecl d
+  XDerivDecl _ -> notImplemented "XDerivDecl standalone deriving"
+
+----------------------------------------------------------------------------
+-- Helpers


### PR DESCRIPTION
Hi, I hope you don't mind if I take a stab at this.     
I opened the PR just to check if I'm going in the right direction, there's a few things still missing:    
- still need to figure out when is `XDerivDecl` matched
- there might be a refactoring opportunity for the deriving strategy cases (e.g. in [Data.hs:140-165](https://github.com/tweag/ormolu/blob/fab9f15ad6e34165a57b0151de3503710b82898a/src/Ormolu/Printer/Meat/Declaration/Data.hs#L140-L165)) although I don't think all strategies are available \ compatible for standalone deriving (right?)
- it looks like `located (hsib_body (hswc_body deriv_type)) p_hsType` is too crude here since it's not parsing the `via` between the types and thus not triggering a newline