### PR TITLE
Implement rendering of type class declarations

### DIFF
--- a/data/examples/declaration/class/associated-data-out.hs
+++ b/data/examples/declaration/class/associated-data-out.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeFamilies #-}
+class Foo a where
+  data FooBar a
+
+-- | Something.
+class Bar a where
+  -- | Bar bar
+  data BarBar a
+  -- | Bar baz
+  data
+    BarBaz
+      a
+
+-- | Something more.
+class Baz a where
+  -- | Baz bar
+  data BazBar a b c
+  -- | Baz baz
+  data
+    BazBaz
+      b
+      a
+      c

--- a/data/examples/declaration/class/associated-data.hs
+++ b/data/examples/declaration/class/associated-data.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeFamilies #-}
+
+class Foo a where data FooBar a
+
+-- | Something.
+class Bar a
+  where
+    -- | Bar bar
+    data BarBar a
+    -- | Bar baz
+    data family BarBaz
+        a
+
+-- | Something more.
+class Baz a where
+    -- | Baz bar
+    data BazBar a b c
+
+    -- | Baz baz
+    data family BazBaz
+        b
+        a
+        c

--- a/data/examples/declaration/class/associated-type-defaults-out.hs
+++ b/data/examples/declaration/class/associated-type-defaults-out.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TypeFamilies #-}
+class Foo a where
+  type FooBar a = Int
+
+-- | Something.
+class Bar a where
+  -- Define bar
+  type
+    BarBar a =
+      BarBaz a
+  -- Define baz
+  type
+    BarBaz
+      a =
+      BarBar -- Middle comment
+        a
+
+class Baz a where
+  type
+    BazBar
+      a
+  type
+    BazBar a =
+      Bar a

--- a/data/examples/declaration/class/associated-type-defaults.hs
+++ b/data/examples/declaration/class/associated-type-defaults.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TypeFamilies #-}
+
+class Foo a where type FooBar a = Int
+
+-- | Something.
+class Bar a where
+  -- Define bar
+  type BarBar a
+    = BarBaz a
+  -- Define baz
+  type BarBaz
+         a = BarBar -- Middle comment
+          a
+
+class Baz a where
+  type BazBar
+         a
+
+  type BazBar a =
+         Bar a

--- a/data/examples/declaration/class/associated-types-out.hs
+++ b/data/examples/declaration/class/associated-types-out.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeFamilies #-}
+class Foo a where
+  type FooBar a
+
+-- | Something.
+class Bar a where
+  -- | Bar bar
+  type BarBar a
+  -- | Bar baz
+  type
+    BarBaz
+      a
+
+-- | Something more.
+class Baz a where
+  -- | Baz bar
+  type BazBar a b c
+  -- | Baz baz
+  type
+    BazBaz
+      b
+      a
+      c

--- a/data/examples/declaration/class/associated-types.hs
+++ b/data/examples/declaration/class/associated-types.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeFamilies #-}
+
+class Foo a where type FooBar a
+
+-- | Something.
+class Bar a
+  where
+    -- | Bar bar
+    type BarBar a
+    -- | Bar baz
+    type BarBaz
+        a
+
+-- | Something more.
+class Baz a where
+    -- | Baz bar
+    type BazBar a b c
+
+    -- | Baz baz
+    type BazBaz
+        b
+        a
+        c

--- a/data/examples/declaration/class/default-implementations-out.hs
+++ b/data/examples/declaration/class/default-implementations-out.hs
@@ -1,0 +1,31 @@
+-- | Foo
+class Foo a where
+  foo :: a -> a
+  foo a = a
+
+-- | Bar
+class Bar a where
+  bar
+    :: a
+    -> Int
+  bar = const 0
+
+-- | Baz
+class Baz a where
+  foobar :: a -> a
+  foobar a = barbaz (bazbar a)
+  -- | Bar baz
+  barbaz
+    :: a -> a
+  -- | Baz bar
+  bazbar
+    :: a
+    -> a
+  -- First comment
+  barbaz a =
+    bazbar -- Middle comment
+      a
+  -- Last comment
+  bazbar a =
+    barbaz
+      a

--- a/data/examples/declaration/class/default-implementations.hs
+++ b/data/examples/declaration/class/default-implementations.hs
@@ -1,0 +1,32 @@
+-- | Foo
+class Foo a where
+    foo :: a -> a
+    foo a = a
+
+-- | Bar
+class Bar a where
+    bar ::
+           a
+        -> Int
+    bar = const 0
+
+-- | Baz
+class Baz a where
+    foobar :: a -> a
+    foobar a =
+        barbaz (bazbar a)
+    -- | Bar baz
+    barbaz ::
+        a -> a
+    -- | Baz bar
+    bazbar ::
+        a ->
+        a
+    -- First comment
+    barbaz a
+        = bazbar -- Middle comment
+            a
+    -- Last comment
+    bazbar a
+        = barbaz
+            a

--- a/data/examples/declaration/class/default-signatures-out.hs
+++ b/data/examples/declaration/class/default-signatures-out.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DefaultSignatures #-}
+
+-- | Something.
+class Foo a where
+  -- | Foo
+  foo :: a -> String
+  default foo :: Show a => a -> String
+  foo = show
+
+-- | Something else.
+class Bar a where
+  -- | Bar
+  bar
+    :: String
+    -> String
+    -> a
+  -- Pointless comment
+  default bar
+    :: ( Read a
+       , Semigroup a
+       )
+    => a
+    -> a
+    -> a
+  -- Even more pointless comment
+  bar
+    a
+    b = read a <> read b

--- a/data/examples/declaration/class/default-signatures.hs
+++ b/data/examples/declaration/class/default-signatures.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DefaultSignatures #-}
+
+-- | Something.
+class Foo a where
+    -- | Foo
+    foo :: a -> String
+    default foo :: Show a => a -> String
+    foo = show
+
+-- | Something else.
+class Bar a
+  where
+    -- | Bar
+    bar ::
+           String
+        -> String
+        -> a
+
+    -- Pointless comment
+    default bar :: (
+        Read a,
+        Semigroup a
+      ) =>
+      a -> a -> a
+
+    -- Even more pointless comment
+    bar
+      a
+      b
+      =
+      read a <> read b

--- a/data/examples/declaration/class/dependency-super-classes-out.hs
+++ b/data/examples/declaration/class/dependency-super-classes-out.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+-- | Something.
+class (MonadReader r s, MonadWriter w m) => MonadState s m | m -> s where
+  get :: m s
+  put :: s -> m ()
+
+-- | 'MonadParsec'
+class ( Stream s -- Token streams
+      , MonadPlus m -- Potential for failure
+      )
+      => MonadParsec e s m
+      | m -> e s where
+  -- | 'getState' returns state
+  getState
+    :: m s
+  -- | 'putState' sets state
+  putState
+    :: s
+    -> m ()

--- a/data/examples/declaration/class/dependency-super-classes.hs
+++ b/data/examples/declaration/class/dependency-super-classes.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+-- | Something.
+class ( MonadReader r s,MonadWriter w m ) => MonadState s m| m -> s where
+    get :: m s
+    put :: s -> m ()
+
+-- | 'MonadParsec'
+
+class (
+        Stream s, -- Token streams
+        MonadPlus m -- Potential for failure
+    ) => MonadParsec e s m | m -> e s
+  where
+    -- | 'getState' returns state
+    getState
+        ::
+            m s
+    -- | 'putState' sets state
+    putState ::
+            s
+         -> m ()

--- a/data/examples/declaration/class/empty-classes-out.hs
+++ b/data/examples/declaration/class/empty-classes-out.hs
@@ -1,0 +1,5 @@
+-- | Foo!
+class Foo a
+
+-- | Bar!
+class Bar a

--- a/data/examples/declaration/class/empty-classes.hs
+++ b/data/examples/declaration/class/empty-classes.hs
@@ -1,0 +1,4 @@
+-- | Foo!
+class Foo a where
+-- | Bar!
+class Bar a

--- a/data/examples/declaration/class/functional-dependencies-out.hs
+++ b/data/examples/declaration/class/functional-dependencies-out.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+-- | Something.
+class Foo a b | a -> b
+
+class Bar a b | a -> b, b -> a where
+  bar :: a
+
+-- | Something else.
+class Baz a b c d
+      | a b -> c d -- Foo
+      , b c -> a d -- Bar
+      , a c -> b d -- Baz
+      , a c d -> b
+      , a b d -> a b c d where
+  baz :: a -> b

--- a/data/examples/declaration/class/functional-dependencies.hs
+++ b/data/examples/declaration/class/functional-dependencies.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+-- | Something.
+class Foo a b | a -> b
+
+class Bar a b | a -> b, b -> a where bar :: a
+
+-- | Something else.
+class Baz a b c d
+    | a b -> c d -- Foo
+    , b c -> a d  -- Bar
+    , a c -> b d-- Baz
+    , a c d -> b
+    , a b d -> a b c d
+  where
+    baz :: a -> b

--- a/data/examples/declaration/class/multi-parameters-out.hs
+++ b/data/examples/declaration/class/multi-parameters-out.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+class Foo a b where
+  foo :: a -> b
+
+-- | Something.
+class Bar a b c d where
+  bar
+    :: a
+    -> b
+    -> c
+    -> d
+
+class Baz where
+  baz :: Int
+
+-- | Something else.
+class BarBaz a b c d e f where
+  barbaz
+    :: a -> f
+  bazbar
+    :: e
+    -> f

--- a/data/examples/declaration/class/multi-parameters.hs
+++ b/data/examples/declaration/class/multi-parameters.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+class Foo a b where foo :: a -> b
+
+-- | Something.
+class Bar
+        a b c d
+  where
+    bar ::
+           a
+        -> b
+        -> c
+        -> d
+
+class Baz
+  where
+    baz :: Int
+
+-- | Something else.
+class
+      BarBaz
+        a
+        b
+        c
+        d
+        e
+        f where
+    barbaz ::
+        a -> f
+    bazbar ::
+        e ->
+        f

--- a/data/examples/declaration/class/poly-kinded-classes-out.hs
+++ b/data/examples/declaration/class/poly-kinded-classes-out.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE PolyKinds #-}
+class Foo (a :: k)
+
+class Bar ( a
+            :: *
+          )

--- a/data/examples/declaration/class/poly-kinded-classes.hs
+++ b/data/examples/declaration/class/poly-kinded-classes.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE PolyKinds #-}
+
+class Foo (a::k)
+
+class Bar
+    (a
+       :: *)

--- a/data/examples/declaration/class/single-parameters-out.hs
+++ b/data/examples/declaration/class/single-parameters-out.hs
@@ -1,0 +1,22 @@
+-- | Something.
+class Foo a where
+  foo :: a
+
+-- | Something more.
+class Bar a where
+  -- | Bar
+  bar :: a -> a -> a
+
+class Baz a where
+  -- | Baz
+  baz
+    :: ( a
+       , a -- ^ First argument
+       )
+    -> a -- ^ Second argument
+    -> a -- ^ Return value
+
+class BarBaz a where
+  barbaz
+    :: a -> b
+  bazbar :: b -> a

--- a/data/examples/declaration/class/single-parameters.hs
+++ b/data/examples/declaration/class/single-parameters.hs
@@ -1,0 +1,20 @@
+-- | Something.
+class Foo a where foo :: a
+
+-- | Something more.
+class Bar a where
+    -- | Bar
+    bar :: a -> a -> a
+
+class Baz a where
+    -- | Baz
+    baz ::
+        (a,
+         a) -- ^ First argument
+        -> a -- ^ Second argument
+        -> a -- ^ Return value
+
+class BarBaz a where
+    barbaz ::
+        a -> b
+    bazbar :: b -> a

--- a/data/examples/declaration/class/super-classes-out.hs
+++ b/data/examples/declaration/class/super-classes-out.hs
@@ -1,0 +1,12 @@
+class Foo a
+
+class Foo a => Bar a
+
+class (Foo a, Bar a)
+      => Baz a
+
+class ( Foo a -- Foo?
+      , Bar a -- Bar?
+      , Baz a -- Baz
+      )
+      => BarBar a

--- a/data/examples/declaration/class/super-classes.hs
+++ b/data/examples/declaration/class/super-classes.hs
@@ -1,0 +1,9 @@
+class () => Foo a
+class Foo a  => Bar a
+class (Foo a,Bar a) =>
+      Baz a
+class (
+    Foo a, -- Foo?
+    Bar a, -- Bar?
+    Baz a  -- Baz
+  ) => BarBar a

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -60,6 +60,7 @@ library
                     , Ormolu.Printer.Internal
                     , Ormolu.Printer.Meat.Common
                     , Ormolu.Printer.Meat.Declaration
+                    , Ormolu.Printer.Meat.Declaration.Class
                     , Ormolu.Printer.Meat.Declaration.Instance
                     , Ormolu.Printer.Meat.Declaration.Data
                     , Ormolu.Printer.Meat.Declaration.Signature

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+-- | Rendering of type class declarations.
+
+module Ormolu.Printer.Meat.Declaration.Class
+  ( p_classDecl
+  )
+where
+
+import Class
+import Control.Arrow
+import Control.Monad
+import Data.Foldable
+import Data.Function
+import Data.List (sortBy)
+import Ormolu.Printer.Combinators
+import Ormolu.Printer.Meat.Declaration.Signature
+import Ormolu.Printer.Meat.Declaration.Value
+import Ormolu.Printer.Meat.Declaration.TypeFamily
+import Ormolu.Printer.Meat.Common
+import Ormolu.Printer.Meat.Type
+import Ormolu.Utils
+import GHC
+import RdrName (RdrName (..))
+import SrcLoc (Located, combineSrcSpans)
+
+p_classDecl
+  :: LHsContext GhcPs
+  -> Located RdrName
+  -> LHsQTyVars GhcPs
+  -> [Located (FunDep (Located RdrName))]
+  -> [LSig GhcPs]
+  -> LHsBinds GhcPs
+  -> [LFamilyDecl GhcPs]
+  -> [LTyFamDefltEqn GhcPs]
+  -> R ()
+p_classDecl ctx name tvars fdeps csigs cdefs cats catdefs = do
+  let HsQTvs {..} = tvars
+      combinedSpans =
+        getLoc ctx `combineSrcSpans`
+        getLoc name `combineSrcSpans`
+        foldr (combineSrcSpans . getLoc) noSrcSpan hsq_explicit `combineSrcSpans`
+        foldr (combineSrcSpans . getLoc) noSrcSpan fdeps
+  txt "class "
+  sitcc $ do
+    switchLayout combinedSpans $ do
+      unless (null (unLoc ctx)) $ do
+        located ctx p_hsContext
+        breakpoint
+        txt "=> "
+      p_rdrName name
+      unless (null hsq_explicit) space
+      spaceSep (located' p_hsTyVarBndr) hsq_explicit
+      unless (null fdeps) $ do
+        breakpoint
+        txt "| "
+        velt (withSep comma (located' p_funDep) fdeps)
+  -- GHC's AST does not necessarily store each kind of element in source
+  -- location order. This happens because different declarations are stored in
+  -- different lists. Consequently, to get all the declarations in proper order,
+  -- they need to be manually sorted.
+  let sigs = (getLoc &&& located' p_sigDecl) <$> csigs
+      defs = (getLoc &&& located' p_valDecl) <$> cdefs
+      tyfam_decls = (getLoc &&& located' (p_famDecl Associated)) <$> cats
+      tyfam_defs = (getLoc &&& located' p_famDefDecl) <$> catdefs
+      decls =
+        snd <$>
+        sortBy
+          (compare `on` fst)
+          (sigs <> toList defs <> tyfam_decls <> tyfam_defs)
+  if not (null decls)
+    then do
+      txt " where"
+      newline
+      inci (sequence_ decls)
+    else newline
+
+p_famDefDecl :: TyFamDefltEqn GhcPs -> R ()
+p_famDefDecl FamEqn {..} = do
+  txt "type"
+  breakpoint
+  let eqn = FamEqn { feqn_pats = tyVarsToTypes feqn_pats, .. }
+      hsib = HsIB { hsib_ext = NoExt, hsib_body = eqn }
+  inci (p_tyFamInstEqn hsib)
+  newline
+p_famDefDecl XFamEqn {} = notImplemented "XFamEqn"
+
+p_funDep :: FunDep (Located RdrName) -> R ()
+p_funDep (before, after) = do
+  spaceSep p_rdrName before
+  txt " -> "
+  spaceSep p_rdrName after

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -9,6 +9,7 @@ module Ormolu.Printer.Meat.Type
   , p_hsContext
   , p_hsTyVarBndr
   , p_conDeclFields
+  , tyVarsToTypes
   )
 where
 
@@ -136,3 +137,19 @@ p_conDeclField ConDeclField {..} = do
     txt ":: "
     locatedVia Nothing cd_fld_type p_hsType
 p_conDeclField (XConDeclField NoExt) = notImplemented "XConDeclField"
+
+----------------------------------------------------------------------------
+-- Convertion functions
+
+tyVarsToTypes :: LHsQTyVars GhcPs -> [LHsType GhcPs]
+tyVarsToTypes = \case
+  HsQTvs {..} -> fmap tyVarToType <$> hsq_explicit
+  XLHsQTyVars {} -> notImplemented "XLHsQTyVars"
+
+tyVarToType :: HsTyVarBndr GhcPs -> HsType GhcPs
+tyVarToType = \case
+  UserTyVar NoExt tvar -> HsTyVar NoExt NotPromoted tvar
+  KindedTyVar NoExt tvar kind ->
+    HsParTy NoExt $ noLoc $
+    HsKindSig NoExt (noLoc (HsTyVar NoExt NotPromoted tvar)) kind
+  XTyVarBndr {} -> notImplemented "XTyVarBndr"


### PR DESCRIPTION
This pull request implements the latter half of #49. Specifically, it deals with pretty printing type class declarations. This includes pretty printing the associated type and data families.

Like #72, type class declarations are formatted such that indentation hangs after the `class`:

```haskell
class ( Ord a
      , Show a
      )
      => Foo a where
```

Functional dependencies over multiple lines use a style that is debatable. Specifically,

```haskell
class Bar a b
      | a -> b
      , b -> a where
```

Obviously feel free to request a change of style if desired.

The only other thing of note aside from that is this: I ended up duplicating the the `tyVarsToTypes` helper function. Alternatively, I could move it and export it from either the `Ormolu.Printer.Meat.Common` or `Ormolu.Printer.Meat.Type` modules.