### PR TITLE
Output multiple specialize pragmas in a row nicer

### DIFF
--- a/data/examples/declaration/signature/specialize/specialize-out.hs
+++ b/data/examples/declaration/signature/specialize/specialize-out.hs
@@ -1,6 +1,7 @@
 foo :: Num a => a -> a
 foo = id
 {-# SPECIALIZE foo :: Int -> Int #-}
+{-# SPECIALIZE foo :: Float -> Float #-}
 
 {-# SPECIALIZE [2] bar :: Int -> Int #-}
 bar :: Num a => a -> a

--- a/data/examples/declaration/signature/specialize/specialize.hs
+++ b/data/examples/declaration/signature/specialize/specialize.hs
@@ -2,6 +2,7 @@ foo :: Num a => a -> a
 foo = id
 
 {-# SPECIALIZE foo :: Int -> Int #-}
+{-# SPECIALIZE foo :: Float -> Float #-}
 
 {-# SPECIALIZE [2] bar :: Int -> Int #-}
 

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -70,6 +70,7 @@ separatedDecls (FunctionBody n) (InlinePragma n') = n /= n'
 separatedDecls (InlinePragma n) (TypeSignature n') = n /= n'
 separatedDecls (FunctionBody n) (SpecializePragma n') = n /= n'
 separatedDecls (SpecializePragma n) (TypeSignature n') = n /= n'
+separatedDecls (SpecializePragma n) (SpecializePragma n') = n /= n'
 separatedDecls _ _ = True
 
 pattern TypeSignature


### PR DESCRIPTION
We should not insert newlines between them.