### PR TITLE
Fix Haddock placement for function arguments

### DIFF
--- a/data/examples/other/argument-comment-out.hs
+++ b/data/examples/other/argument-comment-out.hs
@@ -1,0 +1,4 @@
+foo
+  :: Int -- ^ Documentation
+  -> Bool
+foo _ = True

--- a/data/examples/other/argument-comment.hs
+++ b/data/examples/other/argument-comment.hs
@@ -1,0 +1,4 @@
+foo
+  :: Int -- ^ Documentation
+  -> Bool
+foo _ = True

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -78,7 +78,7 @@ spitFollowingComment
   -> R (Maybe RealSrcSpan)      -- ^ Location of this comment
 spitFollowingComment (L ref a) mlastSpn = do
   mnSpn <- nextEltSpan
-  meSpn <- getEnclosingSpan
+  meSpn <- getEnclosingSpan ref
   i <- getIndent
   withPoppedComment (commentFollowsElt ref mnSpn meSpn mlastSpn) $ \l comment ->
     if theSameLine l ref && not (isModule a)
@@ -201,7 +201,7 @@ commentFollowsElt ref mnSpn meSpn mlastSpn (L l comment) =
         Just espn ->
           let startColumn = srcLocCol . realSrcSpanStart
           in abs (startColumn espn - startColumn l)
-               > abs (startColumn ref - startColumn l)
+               >= abs (startColumn ref - startColumn l)
     continuation = isJust mlastSpn
 
 -- | Output a 'Comment'. This is a low-level printing function.

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -72,7 +72,7 @@ data RC = RC
     -- ^ Whether to relax aligning rules for comments
   , rcDebug :: Bool
     -- ^ Whether to print debugging info as we go
-  , rcEnclosingSpan :: Maybe RealSrcSpan
+  , rcEnclosingSpans :: [RealSrcSpan]
     -- ^ Span of enclosing element of AST
   , rcAnns :: Anns
     -- ^ Collection of annotations
@@ -117,7 +117,7 @@ runR debug (R m) sstream cstream anns =
       , rcLayout = MultiLine
       , rcRelaxedComments = False
       , rcDebug = debug
-      , rcEnclosingSpan = Nothing
+      , rcEnclosingSpans = []
       , rcAnns = anns
       }
     sc = SC
@@ -316,17 +316,18 @@ setIndent i m' = do
   R (local modRC m)
   traceR "set_indent_after" Nothing
 
--- | Get 'RealSrcSpan' of enclosing span, if any.
+-- | Get 'RealSrcSpan' of enclosing span for given referencne span.
 
-getEnclosingSpan :: R (Maybe RealSrcSpan)
-getEnclosingSpan = R (asks rcEnclosingSpan)
+getEnclosingSpan :: RealSrcSpan -> R (Maybe RealSrcSpan)
+getEnclosingSpan r =
+  listToMaybe . dropWhile (== r) <$> R (asks rcEnclosingSpans)
 
 -- | Set 'RealSrcSpan' of enclosing span for the given computation.
 
 withEnclosingSpan :: RealSrcSpan -> R () -> R ()
 withEnclosingSpan spn (R m) = do
   let modRC rc = rc
-        { rcEnclosingSpan = Just spn
+        { rcEnclosingSpans = spn : rcEnclosingSpans rc
         }
   R (local modRC m)
 

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -38,14 +38,13 @@ p_hsType = \case
     located f p_hsType
     breakpoint
     inci (located x p_hsType)
-  HsFunTy NoExt f x@(L _ x') -> do
-    located f p_hsType
+  HsFunTy NoExt x y@(L _ y') -> do
+    located x p_hsType
     breakpoint
     txt "-> "
-    let located_ = case x' of
-          HsFunTy{} -> locatedVia Nothing
-          _ -> located
-    located_ x p_hsType
+    case y' of
+      HsFunTy{} -> p_hsType y'
+      _ -> located y p_hsType
   HsListTy NoExt t -> located t (brackets . p_hsType)
   HsTupleTy NoExt tsort xs ->
     let parens' =


### PR DESCRIPTION
Close #80.

I'm not sure it's perfect, but it fixes the original issue and all the tests pass.

The problem was in entering with locate (or some version of it) the same span twice. So the algorithm saw an element with identical enclosing element and the `commentFollowsElt` function got confused.

The solution is two first augment registration of enclosing spans to allow us to keep more than one item there. Then we can filter out spans which are just copies of current reference span to get to the “real” enclosing span.

It seems to make sense to attach comments to child element if it starts exactly at the same position of parent element, hence the distance between start of enclosing/reference span and start of comment is the same, thus changing `>` to `>=` in `commentFollowsElt`.