### PR TITLE
Fix type signature declarations for multiple values

### DIFF
--- a/data/examples/declaration/signature/type/multi-value-out.hs
+++ b/data/examples/declaration/signature/type/multi-value-out.hs
@@ -1,0 +1,6 @@
+foo, bar :: Int
+
+foo
+  , bar
+  , baz
+    :: Int

--- a/data/examples/declaration/signature/type/multi-value.hs
+++ b/data/examples/declaration/signature/type/multi-value.hs
@@ -1,0 +1,5 @@
+foo, bar :: Int
+
+foo,
+  bar,
+    baz :: Int

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -35,9 +35,16 @@ p_typeSig
   :: [Located RdrName]          -- ^ Names (before @::@)
   -> LHsSigWcType GhcPs         -- ^ Type
   -> R ()
-p_typeSig names hswc = do
-  spaceSep p_rdrName names
-  p_typeAscription hswc
+p_typeSig [] _ = return () -- should not happen though
+p_typeSig (n:ns) hswc = do
+  p_rdrName n
+  if null ns
+    then p_typeAscription hswc
+    else inci $ do
+      vlayout (return ()) newline
+      comma
+      velt (withSep comma p_rdrName ns)
+      p_typeAscription hswc
 
 p_typeAscription
   :: LHsSigWcType GhcPs


### PR DESCRIPTION
Close #87.

Maybe the style is debatable, but I don't know a better way to format it in multi-line.