### PR TITLE
[#70] Format Pattern Synonym Signatures

### DIFF
--- a/data/examples/declaration/signature/pattern/multiline-out.hs
+++ b/data/examples/declaration/signature/pattern/multiline-out.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+pattern Arrow
+  :: Type
+  -> Type
+  -> Type

--- a/data/examples/declaration/signature/pattern/multiline.hs
+++ b/data/examples/declaration/signature/pattern/multiline.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE PatternSynonyms #-}
+pattern Arrow :: Type
+  -> Type -> Type

--- a/data/examples/declaration/signature/pattern/single-line-out.hs
+++ b/data/examples/declaration/signature/pattern/single-line-out.hs
@@ -1,0 +1,2 @@
+{-# LANGUAGE PatternSynonyms #-}
+pattern Arrow :: Type -> Type -> Type

--- a/data/examples/declaration/signature/pattern/single-line.hs
+++ b/data/examples/declaration/signature/pattern/single-line.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+pattern Arrow :: Type -> Type -> Type

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -25,6 +25,7 @@ p_sigDecl = line . p_sigDecl'
 p_sigDecl' :: Sig GhcPs -> R ()
 p_sigDecl' = \case
   TypeSig NoExt names hswc -> p_typeSig names hswc
+  PatSynSig NoExt names hsib -> p_patSynSig names hsib
   ClassOpSig NoExt def names hsib -> p_classOpSig def names hsib
   FixSig NoExt sig -> p_fixSig sig
   InlineSig NoExt name inlinePragma -> p_inlineSig name inlinePragma
@@ -55,6 +56,14 @@ p_typeAscription HsWC {..} = do
     txt ":: "
     located (hsib_body hswc_body) p_hsType
 p_typeAscription (XHsWildCardBndrs NoExt) = notImplemented "XHsWildCardBndrs"
+
+p_patSynSig
+  :: [Located RdrName]
+  -> HsImplicitBndrs GhcPs (LHsType GhcPs)
+  -> R ()
+p_patSynSig names hsib = do
+  txt "pattern "
+  p_typeSig names HsWC {hswc_ext = NoExt, hswc_body = hsib}
 
 p_classOpSig
   :: Bool                       -- ^ Whether this is a \"default\" signature


### PR DESCRIPTION
This is a simple addition, adding `pattern ` in front of normal type signature
formatting