### PR TITLE
[#98] Fix where blocks with do notation

### DIFF
--- a/data/examples/declaration/value/function/do-where-out.hs
+++ b/data/examples/declaration/value/function/do-where-out.hs
@@ -1,0 +1,5 @@
+f :: Maybe Int
+f = do
+  return c
+  where
+    c = 0

--- a/data/examples/declaration/value/function/do-where.hs
+++ b/data/examples/declaration/value/function/do-where.hs
@@ -1,0 +1,5 @@
+f :: Maybe Int
+f = do
+  return c
+  where
+    c = 0


### PR DESCRIPTION
The issue here was that `placeHanging` removed the `inci` that would normally be applied to the whole function body and the local bindings. This PR adds an `inci` around the local bindings, conditional on being in `Hanging` mode.

Closes #98 