### PR TITLE
[#52] Implement WARNING/DEPRECATED in module header

### DIFF
--- a/data/examples/module-header/warning-pragma-list-multiline-out.hs
+++ b/data/examples/module-header/warning-pragma-list-multiline-out.hs
@@ -1,0 +1,11 @@
+module Test
+  {-# DEPRECATED
+    [ "This module is deprecated."
+    , "Please use OtherModule instead."
+    ]
+    #-}
+  ( foo
+  , bar
+  , baz
+  )
+where

--- a/data/examples/module-header/warning-pragma-list-multiline.hs
+++ b/data/examples/module-header/warning-pragma-list-multiline.hs
@@ -1,0 +1,8 @@
+module Test {-# DEPRECATED ["This module is deprecated.",
+  "Please use OtherModule instead."
+ ]#-}
+  ( foo
+  , bar
+  , baz
+  )
+where

--- a/data/examples/module-header/warning-pragma-multiline-out.hs
+++ b/data/examples/module-header/warning-pragma-multiline-out.hs
@@ -1,0 +1,8 @@
+module Test {-# DEPRECATED "This module is unstable" #-}
+  ( foo
+  , bar
+  , baz
+  )
+where
+
+import Blah

--- a/data/examples/module-header/warning-pragma-multiline.hs
+++ b/data/examples/module-header/warning-pragma-multiline.hs
@@ -1,0 +1,4 @@
+module Test {-# DEPRECATED "This module is unstable" #-}
+  (foo, bar, baz) where
+
+import Blah

--- a/data/examples/module-header/warning-pragma-out.hs
+++ b/data/examples/module-header/warning-pragma-out.hs
@@ -1,0 +1,1 @@
+module Test {-# WARNING "This module is very internal" #-} where

--- a/data/examples/module-header/warning-pragma-singleton-list-out.hs
+++ b/data/examples/module-header/warning-pragma-singleton-list-out.hs
@@ -1,0 +1,1 @@
+module Test {-# WARNING "There's only one line here." #-} where

--- a/data/examples/module-header/warning-pragma-singleton-list.hs
+++ b/data/examples/module-header/warning-pragma-singleton-list.hs
@@ -1,0 +1,1 @@
+module Test {-# WArnING ["There's only one line here."]     #-} where

--- a/data/examples/module-header/warning-pragma.hs
+++ b/data/examples/module-header/warning-pragma.hs
@@ -1,0 +1,2 @@
+module Test {-# WARNING "This module is very internal"
+  #-} where

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -38,6 +38,7 @@ module Ormolu.Printer.Combinators
   , parens
   , parensHash
   , pragmaBraces
+  , pragma
     -- ** Literals
   , comma
   , space
@@ -269,6 +270,19 @@ pragmaBraces m = sitcc $ do
   m
   vlayout space (newline >> txt "  ")
   txt "#-}"
+
+-- | This surrounds the body in a pragma, which includes the 'pragmaBraces' and
+---  the keyword for the pragma. It also takes a 'SrcSpan', which should be the
+---  combined span of the body. This means multiline layouts are only triggered
+---  when the body spans multiple lines, not just when the braces or pragma
+---  keyword do.
+
+pragma :: SrcSpan -> Text -> R () -> R ()
+pragma srcSpan pragmaText body = switchLayout srcSpan . pragmaBraces $ do
+  txt pragmaText
+  breakpoint
+  inci body
+
 
 -- | Surround given entity by optional space before and a newline after, iff
 -- current layout is multiline.


### PR DESCRIPTION
This adds `WARNING` and `DEPRECATED` pragmas to the module header.

It will normalise singleton lists to just a string, and it will normalise to a single line layout unless there's explicit multi-lining in the body of the pragma (i.e. not just from hanging brackets.

The `pragma` combinator can be used for other pragmas later on.