### PR TITLE
Support infix operator & multi-line class names

### DIFF
--- a/data/examples/declaration/class/associated-data-out.hs
+++ b/data/examples/declaration/class/associated-data-out.hs
@@ -14,7 +14,11 @@ class Bar a where
 -- | Something more.
 class Baz a where
   -- | Baz bar
-  data BazBar a b c
+  data
+    BazBar
+      a
+      b
+      c
   -- | Baz baz
   data
     BazBaz

--- a/data/examples/declaration/class/associated-data.hs
+++ b/data/examples/declaration/class/associated-data.hs
@@ -14,7 +14,10 @@ class Bar a
 -- | Something more.
 class Baz a where
     -- | Baz bar
-    data BazBar a b c
+    data BazBar
+        a
+        b
+        c
 
     -- | Baz baz
     data family BazBaz

--- a/data/examples/declaration/class/associated-types-out.hs
+++ b/data/examples/declaration/class/associated-types-out.hs
@@ -14,9 +14,14 @@ class Bar a where
 -- | Something more.
 class Baz a where
   -- | Baz bar
-  type BazBar a b c
+  type
+    BazBar
+      a -- Foo
+      b -- Bar
+      c
   -- | Baz baz
   type
+    -- After type
     BazBaz
       b
       a

--- a/data/examples/declaration/class/associated-types.hs
+++ b/data/examples/declaration/class/associated-types.hs
@@ -14,10 +14,14 @@ class Bar a
 -- | Something more.
 class Baz a where
     -- | Baz bar
-    type BazBar a b c
+    type BazBar
+        a      -- Foo
+        b      -- Bar
+        c
 
     -- | Baz baz
-    type BazBaz
+    type -- After type
+         BazBaz
         b
         a
         c

--- a/data/examples/declaration/class/multi-parameters-out.hs
+++ b/data/examples/declaration/class/multi-parameters-out.hs
@@ -10,11 +10,18 @@ class Bar a b c d where
     -> c
     -> d
 
-class Baz where
+class -- Before name
+      Baz where
   baz :: Int
 
 -- | Something else.
-class BarBaz a b c d e f where
+class BarBaz
+        a -- Foo
+        b -- Bar
+        c -- Baz bar
+        d -- Baz baz
+        e -- Rest
+        f where
   barbaz
     :: a -> f
   bazbar

--- a/data/examples/declaration/class/multi-parameters.hs
+++ b/data/examples/declaration/class/multi-parameters.hs
@@ -3,8 +3,7 @@
 class Foo a b where foo :: a -> b
 
 -- | Something.
-class Bar
-        a b c d
+class Bar a b c d
   where
     bar ::
            a
@@ -12,18 +11,19 @@ class Bar
         -> c
         -> d
 
-class Baz
+class -- Before name
+    Baz
   where
     baz :: Int
 
 -- | Something else.
 class
       BarBaz
-        a
-        b
-        c
-        d
-        e
+        a              -- Foo
+        b              -- Bar
+        c              -- Baz bar
+        d              -- Baz baz
+        e              -- Rest
         f where
     barbaz ::
         a -> f

--- a/data/examples/declaration/class/poly-kinded-classes-out.hs
+++ b/data/examples/declaration/class/poly-kinded-classes-out.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE PolyKinds #-}
 class Foo (a :: k)
 
-class Bar ( a
-            :: *
-          )
+class Bar
+        ( a -- Variable
+          :: * -- Star
+        )

--- a/data/examples/declaration/class/poly-kinded-classes.hs
+++ b/data/examples/declaration/class/poly-kinded-classes.hs
@@ -3,5 +3,6 @@
 class Foo (a::k)
 
 class Bar
-    (a
-       :: *)
+    (a -- Variable
+       :: * -- Star
+    )

--- a/data/examples/declaration/class/type-operators-out.hs
+++ b/data/examples/declaration/class/type-operators-out.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+class (:$) a b
+
+class (:&)
+        a
+        b
+
+class a :* b
+
+class a :+ -- Before operator
+        b -- After operator
+
+class ( f :.
+        g
+      )
+        a
+
+class a `Pair` b
+
+class a `Sum`
+        b
+
+class (f `Product` g) a
+
+class ( f `Sum`
+        g
+      )
+        a

--- a/data/examples/declaration/class/type-operators.hs
+++ b/data/examples/declaration/class/type-operators.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+
+class (:$) a b
+
+class (:&)
+    a
+        b
+
+class    a:*b
+
+class
+    a -- Before operator
+    :+
+    b -- After operator
+
+class (
+    f :. g
+  ) a
+
+class
+    a`Pair`b
+
+class
+          a
+    `Sum` b
+
+class (f`Product`g)a
+
+class (
+    f `Sum` g
+  ) a

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -51,6 +51,7 @@ p_tyClDecl = \case
       tcdCtxt
       tcdLName
       tcdTyVars
+      tcdFixity
       tcdFDs
       tcdSigs
       tcdMeths
@@ -69,6 +70,3 @@ p_derivDecl :: DerivDecl GhcPs -> R ()
 p_derivDecl = \case
   d@DerivDecl {..} -> p_standaloneDerivDecl d
   XDerivDecl _ -> notImplemented "XDerivDecl standalone deriving"
-
-----------------------------------------------------------------------------
--- Helpers


### PR DESCRIPTION
This pull request implements certain changes that were accidentally left out of #79. Specifically, it makes the handling of type variables & names for type class pretty printing reuse `p_infixDefHelper` to support infix operator names & parameters over multiple lines. In addition, minor cleanups and refactorings were left out of #79.