### PR TITLE
Use error codes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,7 +12,7 @@ import Development.GitRev
 import Options.Applicative
 import Ormolu
 import Paths_ormolu (version)
-import System.Exit (exitFailure)
+import System.Exit (ExitCode (..), exitWith)
 import qualified Data.Text.IO as TIO
 import qualified Data.Yaml as Yaml
 
@@ -34,7 +34,10 @@ main = withPrettyOrmoluExceptions $ do
       TIO.writeFile optInputFile r
     Check -> do
       r' <- TIO.readFile optInputFile
-      when (r /= r') exitFailure
+      when (r /= r') . exitWith $
+        ExitFailure 100 -- 100 is different to all the other exit code that
+                        -- are emitted either from an 'OrmoluException' or
+                        -- from 'error' and 'notImplemented'.
 
 ----------------------------------------------------------------------------
 -- Command line options parsing.

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -10,7 +10,7 @@ where
 
 import Control.Exception
 import Data.Text (Text)
-import System.Exit (ExitCode (ExitFailure), exitWith)
+import System.Exit (ExitCode (..), exitWith)
 import System.IO
 import qualified GHC
 import qualified Outputable as GHC

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -10,7 +10,7 @@ where
 
 import Control.Exception
 import Data.Text (Text)
-import System.Exit (exitFailure)
+import System.Exit (ExitCode (ExitFailure), exitWith)
 import System.IO
 import qualified GHC
 import qualified Outputable as GHC
@@ -53,7 +53,13 @@ withPrettyOrmoluExceptions m = m `catch` h
     h :: OrmoluException -> IO a
     h e = do
       hPutStrLn stderr (displayException e)
-      exitFailure
+      exitWith . ExitFailure $
+        case e of
+          -- Error code 1 is for `error` or `notImplemented`
+          OrmoluCppEnabled -> 2
+          OrmoluParsingFailed _ _ -> 3
+          OrmoluOutputParsingFailed _ _ -> 4
+          OrmoluASTDiffers _ _ -> 5
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
This PR adds explicit error codes for different type of errors:

- `0`: Success (no error), as usual
- `1`: `error`/`notImplemented`
- `2`: `OrmoluCppEnabled`
- `3`: `OrmoluParsingFailed`
- `4`: `OrmoluOutputParsingFailed`
- `5`: `OrmoluASTDiffers`
- `100`: `--mode check` input different to output

The motivation for this is to be able to easily know more or less what went wrong from a shell script.

A use case where these error codes would be useful (I intend on making full use of this) would be to use `ormolu --mode check` in a linting suite but to disregard errors in case a given module uses CPP.