### PR TITLE
[#94] Improve handling of newline before match group bodies

### DIFF
--- a/data/examples/declaration/class/default-implementations-out.hs
+++ b/data/examples/declaration/class/default-implementations-out.hs
@@ -13,7 +13,8 @@ class Bar a where
 -- | Baz
 class Baz a where
   foobar :: a -> a
-  foobar a = barbaz (bazbar a)
+  foobar a =
+    barbaz (bazbar a)
   -- | Bar baz
   barbaz
     :: a -> a

--- a/data/examples/declaration/class/default-signatures-out.hs
+++ b/data/examples/declaration/class/default-signatures-out.hs
@@ -25,4 +25,5 @@ class Bar a where
   -- Even more pointless comment
   bar
     a
-    b = read a <> read b
+    b =
+      read a <> read b

--- a/data/examples/declaration/instance/instance-sigs-out.hs
+++ b/data/examples/declaration/instance/instance-sigs-out.hs
@@ -10,7 +10,8 @@ instance Ord Int where
     -> Ordering
   compare
     _
-    _ = GT
+    _ =
+      GT
 
 instance Applicative [] where
   pure

--- a/data/examples/declaration/value/function/if-single-line-out.hs
+++ b/data/examples/declaration/value/function/if-single-line-out.hs
@@ -2,4 +2,5 @@ foo :: Int -> Int
 foo x = if x > 5 then 10 else 12
 
 bar :: Int -> Int
-bar x = if x > 5 then 10 else 12
+bar x =
+  if x > 5 then 10 else 12

--- a/data/examples/declaration/value/function/newline-single-line-body-out.hs
+++ b/data/examples/declaration/value/function/newline-single-line-body-out.hs
@@ -1,0 +1,10 @@
+function :: Int -> Int
+function a =
+  aReallyLongFunctionNameThatShouldStayOnThisLineToAvoidOverflowing 10000 a
+
+function' :: String -> String
+function' s = case s of
+  "ThisString" ->
+    -- And a comment here is okay
+    "Yay"
+  _ -> "Boo"

--- a/data/examples/declaration/value/function/newline-single-line-body.hs
+++ b/data/examples/declaration/value/function/newline-single-line-body.hs
@@ -1,0 +1,10 @@
+function :: Int -> Int
+function a =
+  aReallyLongFunctionNameThatShouldStayOnThisLineToAvoidOverflowing 10000 a
+
+function' :: String     -> String
+function' s  =    case s  of
+  "ThisString" -> -- And a comment here is okay
+    "Yay"
+
+  _ -> "Boo"

--- a/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
@@ -1,5 +1,6 @@
 pattern Arrow t1 t2 = App "->" [t1, t2]
-pattern Int = App "Int" []
+pattern Int =
+  App "Int" []
 pattern Maybe t =
   App
     "Maybe"


### PR DESCRIPTION
The PR changes the body layouting to use a span that includes the last point in
the name/pattern part of a match. This forces the layout to be multiline iff the
body starts on a newline.

Closes #94 