### PR TITLE
Add Splice printer

### DIFF
--- a/data/examples/declaration/splice/bracket-out.hs
+++ b/data/examples/declaration/splice/bracket-out.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE TemplateHaskell #-}
+foo =
+  [e|
+  foo bar
+  |]
+
+foo =
+  [e|
+  foo bar
+  |]
+
+foo = [t|Char|]
+
+foo =
+  [d|
+  foo :: Int -> Char
+
+  bar = 42
+
+  |]
+
+foo =
+  [||
+  foo bar
+  ||]

--- a/data/examples/declaration/splice/bracket.hs
+++ b/data/examples/declaration/splice/bracket.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+foo   = [|      foo bar
+  |]
+
+foo = [e| foo bar
+  |]
+
+foo = [t|       Char |]
+
+foo = [d|
+           foo:: Int       -> Char
+           bar = 42
+  |]
+
+foo = [|| foo bar
+  ||]

--- a/data/examples/declaration/splice/quasiquote-out.hs
+++ b/data/examples/declaration/splice/quasiquote-out.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE QuasiQuotes #-}
+x = [foo|    foo bar   |]
+
+x =
+  [e|    foo
+ bar  {- -}
+  |]
+
+[d|    foo bar
+
+|]

--- a/data/examples/declaration/splice/quasiquote.hs
+++ b/data/examples/declaration/splice/quasiquote.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+x = [foo|    foo bar   |]
+
+x = [e|    foo
+ bar  {- -}
+  |]
+
+[d|    foo bar
+
+|]

--- a/data/examples/declaration/splice/splice-decl-out.hs
+++ b/data/examples/declaration/splice/splice-decl-out.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE TemplateHaskell #-}
+$(foo bar)
+
+$foo
+
+$$(foo bar)
+
+$$foo
+
+foo bar
+
+[e|booya|]
+
+-- TemplateHaskell allows Q () at the top level
+do
+  pure []

--- a/data/examples/declaration/splice/splice-decl.hs
+++ b/data/examples/declaration/splice/splice-decl.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+$(  foo       bar)
+
+$foo
+
+$$(  foo       bar)
+
+$$foo
+
+foo bar
+
+[|booya|]
+
+-- TemplateHaskell allows Q () at the top level
+do
+  pure []

--- a/data/examples/declaration/splice/typed-splice-out.hs
+++ b/data/examples/declaration/splice/typed-splice-out.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TemplateHaskell #-}
+x =
+  $$( foo bar
+    )
+
+x = $$foo

--- a/data/examples/declaration/splice/typed-splice.hs
+++ b/data/examples/declaration/splice/typed-splice.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+x      =    $$(   foo  bar 
+  )
+
+x     =     $$foo

--- a/data/examples/declaration/splice/untyped-splice-out.hs
+++ b/data/examples/declaration/splice/untyped-splice-out.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE TemplateHaskell #-}
+x = $(foo bar)
+
+x =
+  $( foo
+       bar
+   )
+
+x = $foo

--- a/data/examples/declaration/splice/untyped-splice.hs
+++ b/data/examples/declaration/splice/untyped-splice.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+x      =    $(      foo bar     )
+
+x = $(   
+  foo  
+      bar      )
+
+x = $foo

--- a/data/examples/declaration/value/function/pattern/quasi-quotes-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/quasi-quotes-pattern-out.hs
@@ -4,7 +4,6 @@ singleline [yamlQQ|something|] = ()
 
 multiline :: ()
 multiline = case y of
-  [yamlQQ|
-    name: John Doe
-    age: 23
-  |] -> ()
+  [yamlQQ| name: John Doe
+age: 23
+|] -> ()

--- a/data/examples/declaration/value/function/pattern/splice-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/splice-pattern-out.hs
@@ -5,8 +5,8 @@ singleLine = case () of
 
 multiline = case () of
   $( x +
-     y
+       y
    ) -> ()
   $( y
-     "something"
+       "something"
    ) -> ()

--- a/data/examples/declaration/value/function/quasi-quotes-out.hs
+++ b/data/examples/declaration/value/function/quasi-quotes-out.hs
@@ -4,9 +4,8 @@ singleline = [yamlQQ|something|]
 
 multiline :: Value
 multiline =
-  [yamlQQ|
-    name: John Doe
-    age: 23
+  [yamlQQ| name: John Doe
+age: 23
 
-    something: foo
-  |]
+something: foo
+|]

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -68,6 +68,7 @@ library
                     , Ormolu.Printer.Meat.Declaration.Instance
                     , Ormolu.Printer.Meat.Declaration.RoleAnnotation
                     , Ormolu.Printer.Meat.Declaration.Signature
+                    , Ormolu.Printer.Meat.Declaration.Splice
                     , Ormolu.Printer.Meat.Declaration.Type
                     , Ormolu.Printer.Meat.Declaration.TypeFamily
                     , Ormolu.Printer.Meat.Declaration.Value

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -22,6 +22,7 @@ module Ormolu.Printer.Combinators
   , switchLayout
   , vlayout
   , breakpoint
+  , breakpoint'
     -- ** Formatting lists
   , velt
   , velt'
@@ -143,6 +144,14 @@ switchLayout spn = enterLayout
 breakpoint :: R ()
 breakpoint = vlayout space newline
 
+-- | Similar to 'breakpoint' but outputs nothing in case of single-line
+-- layout.
+--
+-- > breakpoint' = vlayout (return ()) newline
+
+breakpoint' :: R ()
+breakpoint' = vlayout (return ()) newline
+
 ----------------------------------------------------------------------------
 -- Formatting lists
 
@@ -155,9 +164,7 @@ breakpoint = vlayout space newline
 -- when layout is single line.
 
 velt :: [R ()] -> R ()
-velt xs = sequence_ (intersperse sep (sitcc <$> xs))
-  where
-    sep = vlayout (pure ()) newline
+velt xs = sequence_ (intersperse breakpoint' (sitcc <$> xs))
 
 -- | Like 'velt', but all sub-elements start at the same indentation level
 -- as first element, additionally spaces are inserted when layout is single

--- a/src/Ormolu/Printer/Meat/Declaration.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration.hs-boot
@@ -1,0 +1,12 @@
+module Ormolu.Printer.Meat.Declaration
+  ( p_hsDecls
+  , p_hsDecl
+  )
+where
+
+import GHC
+import Ormolu.Printer.Combinators
+
+p_hsDecls :: [LHsDecl GhcPs] -> R ()
+
+p_hsDecl :: HsDecl GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Splice.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Splice.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Ormolu.Printer.Meat.Declaration.Splice
+  ( p_spliceDecl
+  )
+where
+
+import GHC
+import Ormolu.Printer.Combinators
+import Ormolu.Printer.Meat.Declaration.Value (p_hsSplice)
+import Ormolu.Utils
+
+p_spliceDecl :: SpliceDecl GhcPs -> R ()
+p_spliceDecl = \case
+  SpliceDecl NoExt splice _explicit -> line $ located splice p_hsSplice
+  XSpliceDecl {} -> notImplemented "XSpliceDecl"


### PR DESCRIPTION
This PR does the following:

- [x] Format typed and untyped splices as expression
- [x] Format TH quotes
- [x] Fix QuasiQuote (by not formatting the inner string at all)

I haven't been able to format the declaration TH quotes:

```
foo = [d|
  bar :: Char
  bar = 'c'
  |]
```

In order to format the inner `HsDecl`, we need access to `p_hsDecl` from `Declaration.Value`.
I have 2 potential solutions to fix this but I'd like @mrkkrp's point of view before I go ahead and implement one of the two solutions.

1. We inline the `Declaration.Value` module in `Declaration`. I've quickly tried this and it looks like it would basically force us to move all the modules `Declaration.*` into `Declaration` since they basically all use `Declaration.Value` one way or another.
2. We could try to do some _dependency injection_ of the `p_hsDecl` function and pass it as an argument to the functions that need it. I assume this would end up being needed in most places the `R` monad goes so it might be interesting to put the `p_hsDecl` into the `Reader` monad that `R` is.

This second option is probably the crazier (most unusual) one, but I expect it will be a smaller difference to the codebase.
Maybe you have some other ideas to solve this?