### PR TITLE
[#114] removes trailing whitespace from empty export list

### DIFF
--- a/data/examples/module-header/multiline-empty-out.hs
+++ b/data/examples/module-header/multiline-empty-out.hs
@@ -1,0 +1,4 @@
+module Foo
+  (
+  )
+where

--- a/data/examples/module-header/multiline-empty.hs
+++ b/data/examples/module-header/multiline-empty.hs
@@ -1,0 +1,2 @@
+module Foo (
+           ) where

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -18,7 +18,11 @@ import Ormolu.Printer.Meat.Common
 import Ormolu.Utils
 
 p_hsmodExports :: [LIE GhcPs] -> R ()
-p_hsmodExports xs = do
+p_hsmodExports [] = do
+  txt "("
+  breakpoint'
+  txt ")"
+p_hsmodExports xs =
   parens . velt $ withSep comma (sitcc . located' p_lie) xs
 
 p_hsmodImport :: ImportDecl GhcPs -> R ()


### PR DESCRIPTION
Fixes #114 

- added test case to reproduce the unwanted behavior
- fixed it with an ad-hoc pattern matching in `p_hsmodExports`