### PR TITLE
Implement pretty printing of basic & parallel list comprehensions

### DIFF
--- a/data/examples/declaration/value/function/list-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/list-comprehensions-out.hs
@@ -1,0 +1,25 @@
+foo x = [a | a <- x]
+
+bar x y = [(a, b) | a <- x, even a, b <- y, a != b]
+
+barbaz x y z w =
+  [ (a, b, c, d) -- Foo
+  | a <-
+      x -- Bar
+  , b <- y -- Baz
+  , any even [a, b]
+  , c <-
+      z *
+        z ^
+        2 -- Bar baz
+  , d <-
+      w +
+        w -- Baz bar
+  , all
+      even
+      [ a
+      , b
+      , c
+      , d
+      ]
+  ]

--- a/data/examples/declaration/value/function/list-comprehensions.hs
+++ b/data/examples/declaration/value/function/list-comprehensions.hs
@@ -1,0 +1,22 @@
+foo x =  [a|a<-x]
+
+bar x y = [  (a, b)  |  a<-x, even a  , b<-y, a != b  ]
+
+barbaz x y z w = [
+    (a, b, c, d) | -- Foo
+    a <-
+      x, -- Bar
+    b<-y,  -- Baz
+    any even [a, b],
+    c <- z *
+         z ^ 2,     -- Bar baz
+    d <-
+    w
+    +
+    w, -- Baz bar
+     all
+      even [
+        a, b,
+        c, d
+      ]
+  ]

--- a/data/examples/declaration/value/function/parallel-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/parallel-comprehensions-out.hs
@@ -1,0 +1,37 @@
+foo x y = [(a, b) | a <- x | b <- y]
+
+bar x y z w = [(a, b, c, d) | a <- x, b <- y, a `mod` b == 0 | c <- z | d <- w]
+
+baz x y z w =
+  [ ( a
+    , b
+    , c
+    , d
+    , e
+    , f
+    , g
+    , h
+    , i
+    , j
+    )
+  | a <- -- Foo 1
+      x -- Foo 2
+  , b <- -- Bar 1
+      y -- Bar 2
+  , a `mod`
+      b == -- Value
+      0
+  | c <- -- Baz 1
+      z * -- Baz 2
+        z -- Baz 3
+  | d <- w -- Other
+  | e <- x * x -- Foo bar
+  | f <- -- Foo baz 1
+      y + y -- Foo baz 2
+  | h <- z + z * w ^ 2 -- Bar foo
+  | i <- -- Bar bar 1
+      a + -- Bar bar 2
+        b -- Bar bar 3
+  , j <- -- Bar baz 1
+      a + b -- Bar baz 2
+  ]

--- a/data/examples/declaration/value/function/parallel-comprehensions.hs
+++ b/data/examples/declaration/value/function/parallel-comprehensions.hs
@@ -1,0 +1,28 @@
+foo x y = [(a,b) | a<-x | b<-y]
+
+bar x y z w = [(a,b,c,d)  |  a<-x,  b<-y, a`mod`b == 0|c<-z|d<-w ]
+
+baz x y z w = [
+    (a,b,c,d,e,
+     f,g,h,i,j) |
+    a<-                         -- Foo 1
+      x,                        -- Foo 2
+    b<-                         -- Bar 1
+        y,                      -- Bar 2
+    a
+      `mod` b                   -- Value
+      == 0|
+    c<-                         -- Baz 1
+    z *                         -- Baz 2
+    z|                          -- Baz 3
+    d<- w |                     -- Other
+    e <- x * x |                -- Foo bar
+    f                           -- Foo baz 1
+      <- y + y |                -- Foo baz 2
+     h <- z + z * w ^ 2 |       -- Bar foo
+    i <-                        -- Bar bar 1
+      a +                       -- Bar bar 2
+      b,                        -- Bar bar 3
+    j <-                        -- Bar baz 1
+      a + b                     -- Bar baz 2
+  ]


### PR DESCRIPTION
This pull requests implements some parts of list comprehensions as specified in #47. Specifically, it implements normal & parallel list comprehensions. However, it does not implement transform list comprehensions.

There are no real problems to speak of, as the formatting is obvious and consistent with what the Haskell community already does. See the tests for an example.

The reason transform list comprehensions are not implemented yet is because the GHC AST for representing list comprehensions is a horrible mess, where slightly different list comprehensions end up causing massively different syntax trees. The simplest way of solving this would likely be a preprocessing step that reads the syntax trees and produces a simple, linear list of bindings. I decided not to implement this yet to avoid delaying this commit further.