### PR TITLE
Add newlines between most declarations in a type class

### DIFF
--- a/data/examples/declaration/class/associated-data-out.hs
+++ b/data/examples/declaration/class/associated-data-out.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE TypeFamilies #-}
 class Foo a where
+
   data FooBar a
 
 -- | Something.
 class Bar a where
+
   -- | Bar bar
   data BarBar a
+
   -- | Bar baz
   data
     BarBaz
@@ -13,12 +16,14 @@ class Bar a where
 
 -- | Something more.
 class Baz a where
+
   -- | Baz bar
   data
     BazBar
       a
       b
       c
+
   -- | Baz baz
   data
     BazBaz

--- a/data/examples/declaration/class/associated-type-defaults-out.hs
+++ b/data/examples/declaration/class/associated-type-defaults-out.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE TypeFamilies #-}
 class Foo a where
+
   type FooBar a = Int
 
 -- | Something.
 class Bar a where
+
   -- Define bar
   type
     BarBar a =
       BarBaz a
+
   -- Define baz
   type
     BarBaz
@@ -16,9 +19,11 @@ class Bar a where
         a
 
 class Baz a where
+
   type
     BazBar
       a
+
   type
     BazBar a =
       Bar a

--- a/data/examples/declaration/class/associated-types-out.hs
+++ b/data/examples/declaration/class/associated-types-out.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE TypeFamilies #-}
 class Foo a where
+
   type FooBar a
 
 -- | Something.
 class Bar a where
+
   -- | Bar bar
   type BarBar a
+
   -- | Bar baz
   type
     BarBaz
@@ -13,12 +16,14 @@ class Bar a where
 
 -- | Something more.
 class Baz a where
+
   -- | Baz bar
   type
     BazBar
       a -- Foo
       b -- Bar
       c
+
   -- | Baz baz
   type
     -- After type

--- a/data/examples/declaration/class/default-implementations-out.hs
+++ b/data/examples/declaration/class/default-implementations-out.hs
@@ -1,10 +1,12 @@
 -- | Foo
 class Foo a where
+
   foo :: a -> a
   foo a = a
 
 -- | Bar
 class Bar a where
+
   bar
     :: a
     -> Int
@@ -12,20 +14,25 @@ class Bar a where
 
 -- | Baz
 class Baz a where
+
   foobar :: a -> a
   foobar a =
     barbaz (bazbar a)
+
   -- | Bar baz
   barbaz
     :: a -> a
+
   -- | Baz bar
   bazbar
     :: a
     -> a
+
   -- First comment
   barbaz a =
     bazbar -- Middle comment
       a
+
   -- Last comment
   bazbar a =
     barbaz

--- a/data/examples/declaration/class/default-signatures-out.hs
+++ b/data/examples/declaration/class/default-signatures-out.hs
@@ -2,18 +2,22 @@
 
 -- | Something.
 class Foo a where
+
   -- | Foo
   foo :: a -> String
+
   default foo :: Show a => a -> String
   foo = show
 
 -- | Something else.
 class Bar a where
+
   -- | Bar
   bar
     :: String
     -> String
     -> a
+
   -- Pointless comment
   default bar
     :: ( Read a

--- a/data/examples/declaration/class/dependency-super-classes-out.hs
+++ b/data/examples/declaration/class/dependency-super-classes-out.hs
@@ -2,7 +2,9 @@
 
 -- | Something.
 class (MonadReader r s, MonadWriter w m) => MonadState s m | m -> s where
+
   get :: m s
+
   put :: s -> m ()
 
 -- | 'MonadParsec'
@@ -11,9 +13,11 @@ class ( Stream s -- Token streams
       )
       => MonadParsec e s m
       | m -> e s where
+
   -- | 'getState' returns state
   getState
     :: m s
+
   -- | 'putState' sets state
   putState
     :: s

--- a/data/examples/declaration/class/functional-dependencies-out.hs
+++ b/data/examples/declaration/class/functional-dependencies-out.hs
@@ -4,6 +4,7 @@
 class Foo a b | a -> b
 
 class Bar a b | a -> b, b -> a where
+
   bar :: a
 
 -- | Something else.
@@ -13,4 +14,5 @@ class Baz a b c d
       , a c -> b d -- Baz
       , a c d -> b
       , a b d -> a b c d where
+
   baz :: a -> b

--- a/data/examples/declaration/class/multi-parameters-out.hs
+++ b/data/examples/declaration/class/multi-parameters-out.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 class Foo a b where
+
   foo :: a -> b
 
 -- | Something.
 class Bar a b c d where
+
   bar
     :: a
     -> b
@@ -12,6 +14,7 @@ class Bar a b c d where
 
 class -- Before name
       Baz where
+
   baz :: Int
 
 -- | Something else.
@@ -22,8 +25,10 @@ class BarBaz
         d -- Baz baz
         e -- Rest
         f where
+
   barbaz
     :: a -> f
+
   bazbar
     :: e
     -> f

--- a/data/examples/declaration/class/single-parameters-out.hs
+++ b/data/examples/declaration/class/single-parameters-out.hs
@@ -1,13 +1,16 @@
 -- | Something.
 class Foo a where
+
   foo :: a
 
 -- | Something more.
 class Bar a where
+
   -- | Bar
   bar :: a -> a -> a
 
 class Baz a where
+
   -- | Baz
   baz
     :: ( a
@@ -17,6 +20,8 @@ class Baz a where
     -> a -- ^ Return value
 
 class BarBaz a where
+
   barbaz
     :: a -> b
+
   bazbar :: b -> a

--- a/data/examples/declaration/signature/minimal/minimal-out.hs
+++ b/data/examples/declaration/signature/minimal/minimal-out.hs
@@ -1,5 +1,7 @@
 class Foo a where
+
   {-# MINIMAL (==) | ((/=), foo) #-}
+
   {-# MINIMAL
     a
     | ( b, c, d
@@ -8,5 +10,7 @@ class Foo a where
       )
     | g
     #-}
+
   (==) :: a -> a -> Bool
+
   (/=) :: a -> a -> Bool

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -27,8 +27,8 @@ import RdrName (RdrName (..))
 -- | Data and type family style.
 
 data FamilyStyle
-  = Associated
-  | Free
+  = Associated                  -- ^ Declarations in type classes
+  | Free                        -- ^ Top-level declarations
 
 p_hsmodName :: ModuleName -> R ()
 p_hsmodName mname = do

--- a/src/Ormolu/Printer/Meat/Declaration.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration.hs-boot
@@ -6,7 +6,8 @@ where
 
 import GHC
 import Ormolu.Printer.Combinators
+import Ormolu.Printer.Meat.Common
 
-p_hsDecls :: [LHsDecl GhcPs] -> R ()
+p_hsDecls :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
 
-p_hsDecl :: HsDecl GhcPs -> R ()
+p_hsDecl :: FamilyStyle -> HsDecl GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -605,7 +605,7 @@ p_hsBracket :: HsBracket GhcPs -> R ()
 p_hsBracket = \case
   ExpBr NoExt expr -> quote "e" (located expr p_hsExpr)
   PatBr NoExt pat -> quote "p" (located pat p_pat)
-  DecBrL NoExt decls -> quote "d" (p_hsDecls decls)
+  DecBrL NoExt decls -> quote "d" (p_hsDecls Free decls)
   DecBrG NoExt _ -> notImplemented "DecBrG" -- result of renamer
   TypBr NoExt ty -> quote "t" (located ty p_hsType)
   VarBr NoExt _ _ -> notImplemented "VarBr"

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -49,7 +49,7 @@ p_hsModule loc@(L moduleSpan hsModule) = do
         when (not (null hsmodImports) || not (null hsmodDecls)) newline
     forM_ (sortImports hsmodImports) (located' p_hsmodImport)
     when (not (null hsmodImports) && not (null hsmodDecls)) newline
-    p_hsDecls hsmodDecls
+    p_hsDecls Free hsmodDecls
     trailingComments <- hasMoreComments
     when (trailingComments && isJust hsmodName) newline
     spitRemainingComments


### PR DESCRIPTION
This pull request adds newlines between most declarations in a type class, as specified in #110. Certain other kinds of declarations (such as associated type signatures and bindings) are grouped together without newlines. The process for determining which declarations are grouped reuses the same logic as for modules.

Sorting of type class declarations now wraps everything up in a `HsDecl` instead of pre-pretty-printing everything ahead of time. Since the way in which declarations inside of type classes are pretty printed may vary (e.g. type families), a specialized pretty printer called `p_associatedDecl` is partially copied from `p_hsDecl`. This is a minor bit of code duplication. However, since the behavior is relatively different and constrained, I believe this minor code duplication is appropriate. Alternatively, I could have passed a context/style parameter into `p_hsDecl`. Ping me if this seems preferable.

The `p_hsDecls` pretty printer is reused for handling newlines between declarations. In order to reuse `p_hsDecls` with `p_associatedDecl`, I generalised the pretty printer to accept any declaration pretty printer and called it `p_hsDecls'`. Alternatively, again, `p_hsDecls` could accept a context/style parameter.

Otherwise, all cases where `separatedDecls` matches `TypeSig` will now also match `ClassOpSig`, since that is how all type signatures are represented in type classes.