### PR TITLE
Cleanup nix config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: nix-build
       - run:
           name: Generate Haddocks
-          command: nix-build --attr doc
+          command: nix-build --attr ormolu.doc
       - store_artifacts:
           path: result-doc/share/doc
           destination: haddock

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ cabal.sandbox.config
 dist-*/
 dist/
 stack.yaml
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,24 +1,19 @@
-let pkgs = import ./nix/nixpkgs;
-    compiler = "ghc864";
-    sourceRegex = [
-      "^app.*$"
-      "^data.*$"
-      "^ormolu.cabal$"
-      "^src.*$"
-      "^tests.*$"
-      "^.*\.md$"
-    ];
-    haskellPackages = pkgs.haskell.packages.${compiler}.override
-      { overrides = (self: super:
-          super //
-          { "ormolu" = super.callCabal2nix "ormolu" (pkgs.lib.sourceByRegex ./. sourceRegex) {};
-          });
-      };
-in if pkgs.lib.inNixShell
-     then haskellPackages.shellFor
-       { packages = (ps: [ ps.ormolu ]);
-         buildInputs = [
-           pkgs.cabal-install
-         ];
-       }
-     else haskellPackages.ormolu
+let
+  pkgs = import ./nix/nixpkgs;
+  gitignoreSource = import ./nix/gitignore { inherit (pkgs) lib; };
+  compiler = "ghc864";
+  source = gitignoreSource ./.;
+  haskellPackages = pkgs.haskell.packages.${compiler}.override {
+    overrides = (self: super:
+    super // {
+      "ormolu" = super.callCabal2nix "ormolu" source { };
+    });
+  };
+in {
+  ormolu = haskellPackages.ormolu;
+  ormolu-shell = haskellPackages.shellFor {
+    packages = ps: [ ps.ormolu ];
+    buildInputs = [ pkgs.cabal-install ];
+  };
+}
+

--- a/nix/gitignore/default.nix
+++ b/nix/gitignore/default.nix
@@ -1,0 +1,8 @@
+{ lib }:
+
+let
+  rev = "ec5dd0536a5e4c3a99c797b86180f7261197c124";
+  sha256 = "0k2r8y21rn4kr5dmddd3906x0733fs3bb8hzfpabkdav3wcy3klv";
+  url = "https://github.com/hercules-ci/gitignore/archive/${rev}.tar.gz";
+  nixGitIgnore = builtins.fetchTarball { inherit url sha256; };
+in (import nixGitIgnore { inherit lib; }).gitignoreSource

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,8 +1,10 @@
 let
-  rev = "f52505fac8c82716872a616c501ad9eff188f97f";
-  sha256 = "0q2m2qhyga9yq29yz90ywgjbn9hdahs7i8wwlq7b55rdbyiwa5dy";
-  pkgs = import (builtins.fetchTarball {
+  rev = "454eea84a757ca5f733c4ec0f234eba2281c74eb";
+  sha256 = "1k9jbix4w43brqlfmvwy218pf5fbmzsnc08shaww9qfdl1rdlaxy";
+  nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;
-  }) { config.allowUnfree = true; };
+  };
+  pkgs = import nixpkgs { config.allowUnfree = true; };
 in pkgs
+

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix).ormolu-shell


### PR DESCRIPTION
Fixes #64 (tested on my macbook).

- Fixed it by pointing to a newer nixpkgs commit (the commit you pointed to previously is broken on darwin).
- Restructured default.nix and added a shell.nix (now people can use `lorri watch` too if they wish to do so).
- Ran `nixfmt` to give it consistent formatting

All nix commands should stay the same.