### PR TITLE
Correctly print \case's with guards

### DIFF
--- a/data/examples/declaration/value/function/lambda-case-out.hs
+++ b/data/examples/declaration/value/function/lambda-case-out.hs
@@ -2,4 +2,5 @@
 foo :: Int -> Int
 foo = \case
   5 -> 10
+  i | i > 5 -> 11
   _ -> 12

--- a/data/examples/declaration/value/function/lambda-case.hs
+++ b/data/examples/declaration/value/function/lambda-case.hs
@@ -3,4 +3,5 @@
 foo :: Int -> Int
 foo = \case
   5 -> 10
+  i  | i > 5 -> 11
   _ -> 12


### PR DESCRIPTION
It was producing invalid output when supplied with a
LambdaCase with a guard.

For example, given input:

```
{-# LANGUAGE LambdaCase #-}
foo = \case
  i  | i > 5 -> 11
```

It used to produce (with `--unsafe` flag):

```
{-# LANGUAGE LambdaCase #-}
foo = \case
  i -> | i > 5 = 11
```

After this patch:

```
{-# LANGUAGE LambdaCase #-}
foo = \case
  i | i > 5 -> 11
```

I couldn't comprehend the entirety of p_match function, 
so it is possible that I am missing something. However
the tests still pass.