### PR TITLE
Implement all facets of arrow notation

### DIFF
--- a/data/examples/declaration/value/function/arrow/expression-applications-out.hs
+++ b/data/examples/declaration/value/function/arrow/expression-applications-out.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE Arrows #-}
+foo x y = x -< y
+
+bar f x =
+  f x -< -- Hello
+    x -- World
+
+baz x y = x -<< y

--- a/data/examples/declaration/value/function/arrow/expression-applications.hs
+++ b/data/examples/declaration/value/function/arrow/expression-applications.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE Arrows #-}
+
+foo x y = x -< y
+
+bar f x
+    =  f x  -- Hello
+    -< x    -- World
+
+baz x y = x -<< y

--- a/data/examples/declaration/value/function/arrow/expression-forms-out.hs
+++ b/data/examples/declaration/value/function/arrow/expression-forms-out.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE Arrows #-}
+foo f g x y = (|test (f -< x) (g -< y)|)
+
+bar f g x y =
+  (| test
+       ( f -<
+         x
+       )
+       ( g -<
+         y
+       )
+  |)

--- a/data/examples/declaration/value/function/arrow/expression-forms.hs
+++ b/data/examples/declaration/value/function/arrow/expression-forms.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE Arrows #-}
+
+foo f g x y = (| test (f -< x) (g -< y) |)
+
+bar f g x y = (|
+    test
+      (f
+       -< x)
+      (g
+       -< y)
+  |)

--- a/data/examples/declaration/value/function/arrow/proc-applications-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications-out.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Arrows #-}
+foo x = proc a -> a -< x
+
+bar f x =
+  proc
+    ( y
+    , z
+    , w
+    )
+  ->
+    f -< -- The value
+      ( x -- Foo
+      , w -- Bar
+      , z -- Baz
+      )
+
+baz x = proc a -> a -<< x

--- a/data/examples/declaration/value/function/arrow/proc-applications.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Arrows #-}
+
+foo x = proc a -> a -< x
+
+bar f x =
+    proc (
+        y,
+        z,
+        w
+    ) -> f -- The value
+    -< (
+        x, -- Foo
+        w, -- Bar
+        z  -- Baz
+    )
+
+baz x = proc a -> a -<< x

--- a/data/examples/declaration/value/function/arrow/proc-cases-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-cases-out.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Arrows #-}
+foo f = proc a -> case a of Left b -> f -< b
+
+bar f g h j = proc a -> case a of
+  Left
+    ( (a, b)
+    , (c, d)
+    ) -> f (a <> c) -< b <> d
+  Right
+    (Left a) ->
+      h -< a
+  Right
+    (Right b) ->
+      j -< b

--- a/data/examples/declaration/value/function/arrow/proc-cases.hs
+++ b/data/examples/declaration/value/function/arrow/proc-cases.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Arrows #-}
+foo f =proc a -> case  a  of Left b -> f -<b
+
+bar f g h j
+  = proc a ->
+    case a of
+        Left (
+            (a, b),
+            (c, d)
+         ) -> f (a <> c) -< b <> d
+
+        Right
+          (Left a) ->
+            h -< a
+        Right
+          (Right b) ->
+            j -< b

--- a/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE Arrows #-}
+foo
+  f
+  g
+  h
+  ma =
+    proc
+      ( (a, b)
+      , (c, d)
+      , (e, f)
+      )
+    -> do
+      -- Begin do
+      (x, y) <- -- GHC parser fails if layed out over multiple lines
+        f -- Call into f
+          ( a
+          , c -- Tuple together arguments
+          )
+          ( b
+          , d
+          ) -<
+          ( b + 1 -- Funnel into arrow
+          , d * b
+          )
+      if x `mod` y == 0 -- Basic condition
+      then
+        case e of -- Only left case is relevant
+          Left
+            ( z
+            , w
+            ) -> \u -> -- Procs can have lambdas
+              let v =
+                    u ^ -- Actually never used
+                      2
+              in ( returnA -<
+                   -- Just do the calculation
+                   (x + y * z)
+                 )
+      else
+        do
+          let u = x -- Let bindings bind expressions, not commands
+            -- Could pattern match directly on x
+          i <-
+            case u of
+              0 -> (g . h -< u)
+              n ->
+                ( ( h . g -<
+                    y -- First actual use of y
+                  )
+                )
+          returnA -< ()
+          -- Sometimes execute effects
+          if i > 0
+          then ma -< ()
+          else returnA -< ()
+          returnA -<
+            ( i +
+              x *
+              y -- Just do the calculation
+            )

--- a/data/examples/declaration/value/function/arrow/proc-do-complex.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE Arrows #-}
+foo
+  f
+  g
+  h
+  ma = proc (
+        (a, b),
+        (c, d),
+        (e, f)
+      ) ->
+    do -- Begin do
+        (x,y) -- GHC parser fails if layed out over multiple lines
+         <- f -- Call into f
+              (a,
+               c) -- Tuple together arguments
+              (b,
+               d)
+         -< (b + 1, -- Funnel into arrow
+             d * b)
+        if
+          x `mod` y == 0 -- Basic condition
+        then case e -- Only left case is relevant
+            of Left (z,
+                     w) -> \u -> -- Procs can have lambdas
+                let
+                    v
+                      = u -- Actually never used
+                        ^ 2
+                in
+                    (returnA
+                      -< -- Just do the calculation
+                     (x + y * z))
+        else do
+          let u = x -- Let bindings bind expressions, not commands
+          -- Could pattern match directly on x
+          i <- case u of
+            0 -> (g . h -< u)
+            n -> (
+                  (h . g
+                   -< y) -- First actual use of y
+                  )
+          returnA -< ()
+          -- Sometimes execute effects
+          if i > 0
+            then ma -< ()
+            else returnA -< ()
+          returnA -< (i +
+                      x *
+                      y) -- Just do the calculation

--- a/data/examples/declaration/value/function/arrow/proc-do-simple-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-simple-out.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE Arrows #-}
+foo f = proc a -> do
+  f -< a
+
+bar f = proc a -> do
+  b <- f -< a
+
+barbar f g = proc a -> do
+  b <- f -< a
+  returnA -< b
+
+barbaz f g = proc (a, b) -> do
+  c <- f -< a
+  d <- g -< b
+
+bazbar f = proc a -> do
+  a <-
+    f -<
+      a
+
+bazbaz f g h = proc (a, b, c) -> do
+  x <-
+    f b -< a
+  y <-
+    g b -< b
+  z <-
+    h
+      x
+      y -<
+      ( a
+      , b
+      , c
+      )
+  returnA -<
+    (x, y, z)

--- a/data/examples/declaration/value/function/arrow/proc-do-simple.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-simple.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE Arrows #-}
+
+foo f = proc a ->
+  do f -< a
+
+bar f = proc a ->
+  do b <- f -< a
+
+barbar f g = proc a ->
+  do b <- f -< a
+     returnA -< b
+
+barbaz f g = proc (a, b) ->
+  do c <- f -< a
+     d <- g -< b
+
+bazbar f = proc a ->
+  do a
+       <-
+       f
+       -<
+       a
+
+bazbaz f g h = proc (a, b, c) ->
+  do x
+       <- f b -< a
+     y <-
+       g b -< b
+     z <-
+       h
+         x
+         y
+       -< (
+           a,
+           b,
+           c
+       )
+     returnA -<
+       (x, y, z)

--- a/data/examples/declaration/value/function/arrow/proc-forms-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-forms-out.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE Arrows #-}
+foo0 f g x y = proc _ -> (|f (g -< (x, y))|)
+
+foo1 f g h x = proc (y, z) ->
+  (|test (h f . (h g) -< (y x) . y z) ((h g) . h f -< y z . (y x))|)
+
+foo2 f g h x = proc (y, z) ->
+  (| test
+       ( h f .
+         h g -<
+         y x .
+           y z
+       )
+       ( h g .
+         h f -<
+         y z .
+           y x
+       )
+  |)
+
+bar0 f g x y = proc _ -> f -< x &&& g -< y
+
+bar1 f g h x = proc (y, z) ->
+  h f . (h g) -< (y x) . y z ||| (h g) . h f -< y z . (y x)
+
+bar2 f g h x = proc (y, z) ->
+  (h f . h g) -<
+    (y x) . y z |||
+      (h g . h f) -<
+      y z . (y x)

--- a/data/examples/declaration/value/function/arrow/proc-forms.hs
+++ b/data/examples/declaration/value/function/arrow/proc-forms.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE Arrows #-}
+
+foo0 f g x y = proc _ -> (| f (g -< (x, y)) |)
+
+foo1 f g h x =
+  proc (y, z) ->
+    (|   test (h f.(h g)  -<  (y x).y z)((h g)  .  h f-<y z  .  (y x))   |)
+
+foo2 f g h x =
+  proc (y, z) -> (|
+    test ( h f
+             . h g
+             -<
+           y x
+             . y z
+         )
+         ( h g
+             . h f
+             -<
+           y z
+             . y x)
+  |)
+
+bar0 f g x y = proc _ -> f -< x&&&g -< y
+
+bar1 f g h x =
+  proc (y, z) ->
+    h f.(h g)  -<  (y x).y z ||| (h g)  .  h f-<y z  .  (y x)
+
+bar2 f g h x =
+  proc (y, z) ->
+    (h f.h g)
+      -<  (y x).y z
+  |||
+    (h g  .  h f)
+      -<y z  .  (y x)

--- a/data/examples/declaration/value/function/arrow/proc-ifs-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-ifs-out.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE Arrows #-}
+foo f = proc a -> if a then f -< 0 else f -< 1
+
+bar f g = proc a ->
+  if f a
+  then
+    f .
+      g -<
+      a
+  else
+    g -<
+      b

--- a/data/examples/declaration/value/function/arrow/proc-ifs.hs
+++ b/data/examples/declaration/value/function/arrow/proc-ifs.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Arrows #-}
+
+foo f = proc a -> if a  then  f-<0  else  f-<1
+
+bar f g = proc a ->
+    if
+        f a
+    then
+          f
+        . g -< a
+    else
+        g
+        -<
+        b

--- a/data/examples/declaration/value/function/arrow/proc-lambdas-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-lambdas-out.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE Arrows #-}
+foo = proc a -> \f b -> a -< f b -- Foo
+
+bar = proc x -> \f g h -> \() -> \(Left (x, y)) -> -- Tuple value
+  f (g (h x)) -< y

--- a/data/examples/declaration/value/function/arrow/proc-lambdas.hs
+++ b/data/examples/declaration/value/function/arrow/proc-lambdas.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE Arrows #-}
+
+foo = proc a->  \f b->a-<f b -- Foo
+
+bar =
+    proc x ->
+       \f g h ->
+       \() ->
+       \( Left (x,y )) -> -- Tuple value
+        f (g (h x)) -< y

--- a/data/examples/declaration/value/function/arrow/proc-lets-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-lets-out.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE Arrows #-}
+foo f = proc a -> let b = a in f -< b
+
+bar f g = proc a ->
+  let h =
+        f .
+          g a
+      j =
+        g .
+          h
+  in id -< (h, j)

--- a/data/examples/declaration/value/function/arrow/proc-lets.hs
+++ b/data/examples/declaration/value/function/arrow/proc-lets.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE Arrows #-}
+
+foo f = proc a -> let b = a in f -< b
+
+bar f g = proc a ->
+    let
+      h
+        = f
+        . g a
+      j = g
+          .
+          h
+    in
+      id -< (h, j)

--- a/data/examples/declaration/value/function/arrow/proc-parentheses-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-parentheses-out.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE Arrows #-}
+foo f = proc a -> (f -< a)
+
+bar f g = proc a ->
+  ( ( (f)
+      ( g
+      )
+    ) -<
+    ( ( ( ( ( ( g
+                a
+              )
+            )
+          )
+        )
+      )
+    )
+  )

--- a/data/examples/declaration/value/function/arrow/proc-parentheses.hs
+++ b/data/examples/declaration/value/function/arrow/proc-parentheses.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE Arrows #-}
+foo f = proc a -> ( f -< a )
+
+bar f g = proc a ->
+    ( ((f) (
+        g
+      ))
+    -< (((((
+        (g
+         a)
+        )))))
+    )

--- a/data/examples/declaration/value/function/arrow/recursive-procs-out.hs
+++ b/data/examples/declaration/value/function/arrow/recursive-procs-out.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE Arrows #-}
+foo f g = proc (x, y) -> do
+  rec a <- f y -< x
+      b <-
+        g x -<
+          y
+  bar -<
+    ( a
+    , b
+    )
+  rec p <-
+        f
+          p -<
+          a
+  rec q <-
+        g
+          q -<
+          b

--- a/data/examples/declaration/value/function/arrow/recursive-procs.hs
+++ b/data/examples/declaration/value/function/arrow/recursive-procs.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE Arrows #-}
+
+foo f g = proc (x, y) -> do
+  rec
+    a <- f y -< x
+    b
+        <-
+      g x
+        -<
+      y
+  bar -< (
+    a,
+    b
+   )
+  rec p <- f
+             p -< a
+  rec q <- g
+             q-< b

--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -32,3 +32,16 @@ quux =
     then x
     else y
     baz
+
+foo = do
+  rec a <- b + 5
+      let d = c
+      b <- a * 5
+      something
+      c <- a + b
+  print c
+  rec something $ do
+        x <- a
+        print x
+        y <- c
+        print y

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -27,3 +27,22 @@ quux = something $ do
   then x
   else y
   baz
+
+foo = do
+  rec
+    a <- b + 5
+
+    let d = c
+
+    b <- a * 5
+
+    something
+
+    c <- a + b
+  print c
+  rec something $ do
+          x <- a
+          print x
+
+          y <- c
+          print y

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -33,6 +33,7 @@ module Ormolu.Printer.Combinators
   , sitcc
   , line
   , backticks
+  , banana
   , braces
   , brackets
   , bracketsPar
@@ -227,6 +228,14 @@ backticks m = do
   txt "`"
   m
   txt "`"
+
+-- | Surround given entity by banana brackets (i.e., from arrow notation.)
+
+banana :: R () -> R ()
+banana m = sitcc $ do
+  txt "(|"
+  ospaces m
+  txt "|)"
 
 -- | Surround given entity by curly braces @{@ and  @}@.
 


### PR DESCRIPTION
This pull request implements all facets of arrow notation (as far as I know), as specified in #47. Most syntactic constructs reuse pretty printing specified previously, such as arrow cases, if-expressions and lambdas. Relevant operators (such as arrow argument passing) and brackets are also formatted as operators and brackets typically are.

Note that supporting arrow notation necessitates a need to generalise `p_stmt` and `p_matchGroup`, since arrow notation *literally* reuses these syntactic constructs, except so-called "arrow commands" are used instead of expressions. In theory, all these functions could be duplicated and specialised for arrows, though that seems undesirable.

Relevant expressions (e.g. proc notation) will hang properly, in a similar way to case expressions and do notation, using the same logic.