### PR TITLE
Add newlines between most declarations in a type class instance

### DIFF
--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -1,15 +1,19 @@
 {-# LANGUAGE TypeFamilies #-}
 instance Foo Int where
+
   data Bar Int = IntBar Int Int
 
 instance Foo Double where
+
   newtype Bar Double
     = DoubleBar
         Double
         Double
 
 instance Foo [a] where
+
   data Bar [a]
     = ListBar [Bar a]
+
   data Baz [a]
     = ListBaz

--- a/data/examples/declaration/instance/associated-types-out.hs
+++ b/data/examples/declaration/instance/associated-types-out.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE TypeFamilies #-}
 instance Foo Int where
+
   type Bar Int = Double
 
 instance Foo Double where
+
   type
     Bar
       Double =
       [Double]
+
   type
     Baz Double =
       [Double]

--- a/data/examples/declaration/instance/contexts-out.hs
+++ b/data/examples/declaration/instance/contexts-out.hs
@@ -1,4 +1,5 @@
 instance Eq a => Eq [a] where
+
   (==) _ _ = False
 
 instance ( Ord a
@@ -6,4 +7,5 @@ instance ( Ord a
          )
          => Ord
               (a, b) where
+
   compare _ _ = GT

--- a/data/examples/declaration/instance/instance-sigs-out.hs
+++ b/data/examples/declaration/instance/instance-sigs-out.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE InstanceSigs #-}
 instance Eq Int where
+
   (==) :: Int -> Int -> Bool
   (==) _ _ = False
 
 instance Ord Int where
+
   compare
     :: Int
     -> Int
@@ -14,10 +16,12 @@ instance Ord Int where
       GT
 
 instance Applicative [] where
+
   pure
     :: a
     -> [a]
   pure a = [a]
+
   (<*>)
     :: [a] -> [a] -> [a]
   (<*>) _ _ = []

--- a/data/examples/declaration/instance/multi-parameter-out.hs
+++ b/data/examples/declaration/instance/multi-parameter-out.hs
@@ -1,6 +1,9 @@
 instance MonadReader a ((->) a) where
+
   ask = id
 
 instance MonadState s (State s) where
+
   get = State.get
+
   put = State.put

--- a/data/examples/declaration/instance/overlappable-instances-out.hs
+++ b/data/examples/declaration/instance/overlappable-instances-out.hs
@@ -1,11 +1,15 @@
 instance {-# OVERLAPPABLE #-} Eq Int where
+
   (==) _ _ = False
 
 instance {-# OVERLAPPING #-} Ord Int where
+
   compare _ _ = GT
 
 instance {-# OVERLAPS #-} Eq Double where
+
   (==) _ _ = False
 
 instance {-# INCOHERENT #-} Ord Double where
+
   compare _ _ = GT

--- a/data/examples/declaration/instance/single-parameter-out.hs
+++ b/data/examples/declaration/instance/single-parameter-out.hs
@@ -1,7 +1,10 @@
 instance Monoid Int where
+
   (<>) x y = x + y
 
 instance Enum Int where
+
   fromEnum x = x
+
   toEnum = \x ->
     x

--- a/data/examples/declaration/signature/specialize/specialize-instance-out.hs
+++ b/data/examples/declaration/signature/specialize/specialize-instance-out.hs
@@ -3,12 +3,16 @@ data Foo a = Foo a
 data VT v m r = VT v m r
 
 instance (Eq a) => Eq (Foo a) where
+
   {-# SPECIALIZE instance Eq (Foo [(Int, Bar)]) #-}
+
   (==) (Foo a) (Foo b) = (==) a b
 
 instance (Num r, V.Vector v r, Factored m r) => Num (VT v m r) where
+
   {-# SPECIALIZE instance
     ( Factored m Int => Num (VT U.Vector m Int)
     )
     #-}
+
   VT x + VT y = VT $ V.zipWith (+) x y


### PR DESCRIPTION
This pull request adds newlines between most declarations in a type class instance, completing the changes specified in #110 and #120. Certain other kinds of declarations, such as instance signatures (e.g., from `InstanceSigs`) and bindings, are grouped together without newlines. The process for determining which declarations are grouped reuses the same logic as for modules and type classes.

Sorting of type class instance declarations now wraps everything up in a `HsDecl` instead of pretty printing everything ahead of time. Once the declarations are wrapped up, the `p_hsDecls` pretty printer is reused for pretty printing and handling newlines between declarations.

Otherwise, a newline is also added before the first declaration, similarly to #120.