### PR TITLE
Implement properly indented constraint contexts

### DIFF
--- a/data/examples/declaration/class/dependency-super-classes-out.hs
+++ b/data/examples/declaration/class/dependency-super-classes-out.hs
@@ -8,11 +8,12 @@ class (MonadReader r s, MonadWriter w m) => MonadState s m | m -> s where
   put :: s -> m ()
 
 -- | 'MonadParsec'
-class ( Stream s -- Token streams
-      , MonadPlus m -- Potential for failure
-      )
-      => MonadParsec e s m
-      | m -> e s where
+class
+  ( Stream s -- Token streams
+  , MonadPlus m -- Potential for failure
+  )
+  => MonadParsec e s m
+    | m -> e s where
 
   -- | 'getState' returns state
   getState

--- a/data/examples/declaration/class/functional-dependencies-out.hs
+++ b/data/examples/declaration/class/functional-dependencies-out.hs
@@ -8,11 +8,12 @@ class Bar a b | a -> b, b -> a where
   bar :: a
 
 -- | Something else.
-class Baz a b c d
-      | a b -> c d -- Foo
-      , b c -> a d -- Bar
-      , a c -> b d -- Baz
-      , a c d -> b
-      , a b d -> a b c d where
+class
+  Baz a b c d
+    | a b -> c d -- Foo
+    , b c -> a d -- Bar
+    , a c -> b d -- Baz
+    , a c d -> b
+    , a b d -> a b c d where
 
   baz :: a -> b

--- a/data/examples/declaration/class/multi-parameters-out.hs
+++ b/data/examples/declaration/class/multi-parameters-out.hs
@@ -13,18 +13,19 @@ class Bar a b c d where
     -> d
 
 class -- Before name
-      Baz where
+  Baz where
 
   baz :: Int
 
 -- | Something else.
-class BarBaz
-        a -- Foo
-        b -- Bar
-        c -- Baz bar
-        d -- Baz baz
-        e -- Rest
-        f where
+class
+  BarBaz
+    a -- Foo
+    b -- Bar
+    c -- Baz bar
+    d -- Baz baz
+    e -- Rest
+    f where
 
   barbaz
     :: a -> f

--- a/data/examples/declaration/class/poly-kinded-classes-out.hs
+++ b/data/examples/declaration/class/poly-kinded-classes-out.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE PolyKinds #-}
 class Foo (a :: k)
 
-class Bar
-        ( a -- Variable
-          :: * -- Star
-        )
+class
+  Bar
+    ( a -- Variable
+      :: * -- Star
+    )

--- a/data/examples/declaration/class/super-classes-out.hs
+++ b/data/examples/declaration/class/super-classes-out.hs
@@ -2,11 +2,13 @@ class Foo a
 
 class Foo a => Bar a
 
-class (Foo a, Bar a)
-      => Baz a
+class
+  (Foo a, Bar a)
+  => Baz a
 
-class ( Foo a -- Foo?
-      , Bar a -- Bar?
-      , Baz a -- Baz
-      )
-      => BarBar a
+class
+  ( Foo a -- Foo?
+  , Bar a -- Bar?
+  , Baz a -- Baz
+  )
+  => BarBar a

--- a/data/examples/declaration/class/type-operators-out.hs
+++ b/data/examples/declaration/class/type-operators-out.hs
@@ -2,28 +2,33 @@
 {-# LANGUAGE TypeOperators #-}
 class (:$) a b
 
-class (:&)
-        a
-        b
+class
+  (:&)
+    a
+    b
 
 class a :* b
 
-class a :+ -- Before operator
-        b -- After operator
+class
+  a :+ -- Before operator
+    b -- After operator
 
-class ( f :.
-        g
-      )
-        a
+class
+  ( f :.
+    g
+  )
+    a
 
 class a `Pair` b
 
-class a `Sum`
-        b
+class
+  a `Sum`
+    b
 
 class (f `Product` g) a
 
-class ( f `Sum`
-        g
-      )
-        a
+class
+  ( f `Sum`
+    g
+  )
+    a

--- a/data/examples/declaration/instance/contexts-out.hs
+++ b/data/examples/declaration/instance/contexts-out.hs
@@ -2,10 +2,39 @@ instance Eq a => Eq [a] where
 
   (==) _ _ = False
 
-instance ( Ord a
-         , Ord b
-         )
-         => Ord
-              (a, b) where
+instance
+  ( Ord a
+  , Ord b
+  )
+  => Ord (a, b) where
 
   compare _ _ = GT
+
+instance
+  (Show a, Show b)
+  => Show
+       ( a
+       , b
+       ) where
+
+  showsPrec _ _ = showString ""
+
+instance
+  ( Read a -- Foo
+  , Read b
+  , Read
+      ( c
+      , -- Bar
+      d
+      )
+  )
+  => Read
+       ( a
+       , -- Baz
+       b
+       , ( c -- Quux
+         , d
+         )
+       ) where
+
+  readsPrec = undefined

--- a/data/examples/declaration/instance/contexts.hs
+++ b/data/examples/declaration/instance/contexts.hs
@@ -5,3 +5,29 @@ instance (
     Ord b
   ) => Ord (a,b) where
   compare _ _ = GT
+
+instance (Show a, Show b) =>
+  Show (
+    a,
+    b
+  ) where
+  showsPrec _ _ = showString ""
+
+instance (
+  Read a, -- Foo
+  Read b
+  , Read (
+    c, -- Bar
+    d
+    )
+  )
+  =>
+  Read (
+    a, -- Baz
+    b
+    ,(
+      c, -- Quux
+      d
+    )
+  ) where
+  readsPrec = undefined

--- a/data/examples/declaration/instance/overlappable-instances-out.hs
+++ b/data/examples/declaration/instance/overlappable-instances-out.hs
@@ -10,6 +10,9 @@ instance {-# OVERLAPS #-} Eq Double where
 
   (==) _ _ = False
 
-instance {-# INCOHERENT #-} Ord Double where
+instance
+  {-# INCOHERENT #-}
+  Ord
+    Double where
 
   compare _ _ = GT

--- a/data/examples/declaration/instance/overlappable-instances.hs
+++ b/data/examples/declaration/instance/overlappable-instances.hs
@@ -7,5 +7,7 @@ instance {-#  OVERLAPS  #-} Eq Double where
     (==) _ _ = False
 
 instance
-    {-# INCOHERENT  #-} Ord Double where
+    {-# INCOHERENT  #-}
+    Ord
+    Double where
     compare _ _ = GT

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -44,16 +44,18 @@ p_classDecl ctx name tvars fixity fdeps csigs cdefs cats catdefs = do
         getLoc ctx `combineSrcSpans`
         signatureSpans `combineSrcSpans`
         dependencySpans
-  txt "class "
-  sitcc $ do
-    switchLayout combinedSpans $ p_classContext ctx
-    switchLayout signatureSpans $ do
-      p_infixDefHelper
-        (isInfix fixity)
-        inci
-        (p_rdrName name)
-        (located' p_hsTyVarBndr <$> hsq_explicit)
-    switchLayout combinedSpans $ p_classFundeps fdeps
+  txt "class"
+  switchLayout combinedSpans $ do
+    breakpoint
+    inci $ do
+      p_classContext ctx
+      switchLayout signatureSpans $ do
+        p_infixDefHelper
+          (isInfix fixity)
+          inci
+          (p_rdrName name)
+          (located' p_hsTyVarBndr <$> hsq_explicit)
+      inci (p_classFundeps fdeps)
   -- GHC's AST does not necessarily store each kind of element in source
   -- location order. This happens because different declarations are stored in
   -- different lists. Consequently, to get all the declarations in proper order,

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -65,10 +65,13 @@ p_standaloneDerivDecl (XDerivDecl _) = notImplemented "XDerivDecl"
 p_clsInstDecl :: ClsInstDecl GhcPs -> R ()
 p_clsInstDecl = \case
   ClsInstDecl {..} -> do
-    txt "instance "
-    match_overlap_mode cid_overlap_mode space
+    txt "instance"
     case cid_poly_ty of
-      HsIB {..} -> sitcc (located hsib_body p_hsType)
+      HsIB {..} -> located hsib_body $ \x -> do
+        breakpoint
+        inci $ do
+          match_overlap_mode cid_overlap_mode breakpoint
+          p_hsType x
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
     -- GHC's AST does not necessarily store each kind of element in source
     -- location order. This happens because different declarations are stored in

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -29,7 +29,10 @@ p_hsType = \case
     located qs p_hsContext
     breakpoint
     txt "=> "
-    locatedVia Nothing t p_hsType
+    case unLoc t of
+      HsQualTy {} -> locatedVia Nothing t p_hsType
+      HsFunTy {} -> locatedVia Nothing t p_hsType
+      _ -> located t p_hsType
   HsTyVar NoExt p n -> do
     case p of
       Promoted -> txt "'"


### PR DESCRIPTION
Close #113.

This pull request implements the constraint context formatting specified in #113 and approved by @mrkkrp. Essentially, it simply indents the constraints one layer, instead of hanging the constraints off of `class` or `instance`.

Also, this pull request inadvertently fixes a bug in type pretty printing, where constraint types that do not end in function types cause potentially redundant breakpoints.