### PR TITLE
Insert newlines after annotations in certain cases

### DIFF
--- a/data/examples/declaration/annotation/annotation-out.hs
+++ b/data/examples/declaration/annotation/annotation-out.hs
@@ -1,12 +1,20 @@
 {-# ANN module (5 :: Int) #-}
+
 {-# ANN
   module
   ( 5
       :: Int
   )
   #-}
+
 {-# ANN foo "hey" #-}
+foo :: Int
+foo = 5
+
 {-# ANN
   Char
   (Just 42)
-  #-}{- Comment -}
+  #-}
+
+data Foo = Foo Int
+{- Comment -}

--- a/data/examples/declaration/annotation/annotation.hs
+++ b/data/examples/declaration/annotation/annotation.hs
@@ -5,10 +5,14 @@
 
 {-#       ANN      foo        "hey" #-}
 
-{-#       ANN
-    Char 
+foo :: Int
+foo = 5
 
+{-#       ANN
+    Char
 
     (Just 42)#-}
+
+data Foo = Foo Int
 
 {- Comment -}

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -110,18 +110,24 @@ isPragma = \case
   InlinePragma n -> Just n
   SpecializePragma n -> Just n
   SCCPragma n -> Just n
+  AnnTypePragma n -> Just n
+  AnnValuePragma n -> Just n
   _ -> Nothing
 
 pattern TypeSignature
       , FunctionBody
       , InlinePragma
       , SpecializePragma
-      , SCCPragma :: RdrName -> HsDecl GhcPs
+      , SCCPragma
+      , AnnTypePragma
+      , AnnValuePragma :: RdrName -> HsDecl GhcPs
 pattern TypeSignature n <- (sigRdrName -> Just n)
 pattern FunctionBody n <- ValD NoExt (FunBind NoExt (L _ n) _ _ _)
 pattern InlinePragma n <- SigD NoExt (InlineSig NoExt (L _ n) _)
 pattern SpecializePragma n <- SigD NoExt (SpecSig NoExt (L _ n) _ _)
 pattern SCCPragma n <- SigD NoExt (SCCFunSig NoExt _ (L _ n) _)
+pattern AnnTypePragma n <- AnnD NoExt (HsAnnotation NoExt _ (TypeAnnProvenance (L _ n)) _)
+pattern AnnValuePragma n <- AnnD NoExt (HsAnnotation NoExt _ (ValueAnnProvenance (L _ n)) _)
 
 sigRdrName :: HsDecl GhcPs -> Maybe RdrName
 sigRdrName (SigD NoExt (TypeSig NoExt ((L _ n):_) _)) = Just n

--- a/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
@@ -14,7 +14,7 @@ import Ormolu.Utils
 
 p_annDecl :: AnnDecl GhcPs -> R ()
 p_annDecl = \case
-  HsAnnotation NoExt _ annProv expr -> pragma "ANN" $ do
+  HsAnnotation NoExt _ annProv expr -> line . pragma "ANN" $ do
     p_annProv annProv
     breakpoint
     located expr p_hsExpr


### PR DESCRIPTION
Just like other pragmas annotations will now “stick” to the definitions they pertain to. If it's not possible, there will be a newline separating them from other declarations in the module.