### PR TITLE
Recognize gaps between comment blocks

### DIFF
--- a/data/examples/other/comment-alignment-out.hs
+++ b/data/examples/other/comment-alignment-out.hs
@@ -1,0 +1,9 @@
+class Foo a where
+
+  -- | Foo.
+  foo
+    :: Int
+    -> a -- ^ Something
+
+  -- | Bar.
+  bar :: a

--- a/data/examples/other/comment-alignment.hs
+++ b/data/examples/other/comment-alignment.hs
@@ -1,0 +1,11 @@
+class Foo a where
+
+  -- | Foo.
+
+  foo
+    :: Int
+    -> a -- ^ Something
+
+  -- | Bar.
+
+  bar :: a

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -15,7 +15,6 @@ where
 import Control.Monad
 import Data.Coerce (coerce)
 import Data.Data (Data)
-import Data.Maybe (isJust)
 import Ormolu.CommentStream
 import Ormolu.Printer.Internal
 import Ormolu.Utils (isModule)
@@ -202,7 +201,10 @@ commentFollowsElt ref mnSpn meSpn mlastSpn (L l comment) =
           let startColumn = srcLocCol . realSrcSpanStart
           in abs (startColumn espn - startColumn l)
                >= abs (startColumn ref - startColumn l)
-    continuation = isJust mlastSpn
+    continuation =
+      case mlastSpn of
+        Nothing -> False
+        Just spn -> srcSpanEndLine spn + 1 == srcSpanStartLine l
 
 -- | Output a 'Comment'. This is a low-level printing function.
 


### PR DESCRIPTION
Fixes #138

This PR adds a check for Haddock comments `-- |` so that they don't count as logically following.

Do you think I should add some checks for multiline comments starting with `{- |` as well?