### PR TITLE
Abolish ‘yaml’ configuration

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,21 +15,15 @@ import Paths_ormolu (version)
 import System.Exit (ExitCode (..), exitWith)
 import System.IO (hPutStrLn, stderr)
 import qualified Data.Text.IO as TIO
-import qualified Data.Yaml as Yaml
 
 -- | Entry point of the program.
 
 main :: IO ()
 main = withPrettyOrmoluExceptions $ do
   Opts {..} <- execParser optsParserInfo
-  config <- case optConfigFile of
-    Nothing -> return optConfig
-    Just path -> do
-      config <- Yaml.decodeFileThrow path
-      return (config <> optConfig)
   r <- case optInputFile of
-    "-" -> ormoluStdin config
-    inputFile -> ormoluFile config inputFile
+    "-" -> ormoluStdin optConfig
+    inputFile -> ormoluFile optConfig inputFile
   let notForStdin = do
         when (optInputFile == "-") $ do
           hPutStrLn
@@ -58,8 +52,6 @@ main = withPrettyOrmoluExceptions $ do
 data Opts = Opts
   { optMode :: !Mode
     -- ^ Mode of operation
-  , optConfigFile :: !(Maybe FilePath)
-    -- ^ Location of configuration file (optional)
   , optConfig :: !Config
     -- ^ Ormolu 'Config'
   , optInputFile :: !FilePath
@@ -106,12 +98,6 @@ optsParser = Opts
     , metavar "MODE"
     , value Stdout
     , help "Mode of operation: 'stdout', 'inplace', or 'check'"
-    ]
-  <*> (optional . strOption . mconcat)
-    [ long "config"
-    , short 'c'
-    , metavar "CONFIG"
-    , help "Location of configuration file"
     ]
   <*> configParser
   <*> (strArgument . mconcat)

--- a/data/examples/declaration/value/function/list-comprehensions.hs
+++ b/data/examples/declaration/value/function/list-comprehensions.hs
@@ -1,4 +1,4 @@
-foo x =  [a|a<-x]
+foo x =  [a |a<-x]
 
 bar x y = [  (a, b)  |  a<-x, even a  , b<-y, a != b  ]
 

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -47,7 +47,6 @@ library
                     , mtl            >= 2.0 && < 3.0
                     , syb            >= 0.7 && < 0.8
                     , text           >= 0.2 && < 1.3
-                    , yaml           >= 0.8 && < 0.12
   exposed-modules:    Ormolu
                     , Ormolu.Config
                     , Ormolu.Diff
@@ -126,7 +125,6 @@ executable ormolu
                     , optparse-applicative >= 0.14 && < 0.15
                     , ormolu
                     , text           >= 0.2 && < 1.3
-                    , yaml           >= 0.8 && < 0.12
   other-modules:      Paths_ormolu
   if flag(dev)
     ghc-options:      -Wall -Werror -Wcompat

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -12,7 +12,6 @@ module Ormolu.Config
   )
 where
 
-import Data.Yaml
 import qualified SrcLoc as GHC
 
 -- | Ormolu configuration.
@@ -25,24 +24,6 @@ data Config = Config
   , cfgDebug :: !Bool
     -- ^ Output information useful for debugging
   } deriving (Eq, Show)
-
-instance Semigroup Config where
-  a <> b = Config
-    { cfgDynOptions = cfgDynOptions a <> cfgDynOptions b
-    , cfgUnsafe = cfgUnsafe a || cfgUnsafe b
-    , cfgDebug = cfgDebug a || cfgDebug b
-    }
-
-instance Monoid Config where
-  mempty = defaultConfig
-  mappend = (<>)
-
-instance FromJSON Config where
-  parseJSON = withObject "config" $ \o -> do
-    cfgDynOptions <- o .: "ghc-opts"
-    cfgUnsafe <- o .: "unsafe"
-    cfgDebug <- o .: "debug"
-    return Config {..}
 
 -- | Default 'Config'.
 
@@ -57,7 +38,7 @@ defaultConfig = Config
 
 newtype DynOption = DynOption
   { unDynOption :: String
-  } deriving (Eq, Ord, Show, FromJSON)
+  } deriving (Eq, Ord, Show)
 
 -- | Convert 'DynOption' to @'GHC.Located' 'String'@.
 

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -10,10 +10,10 @@ where
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.List (isPrefixOf)
+import Data.List (isPrefixOf, foldl')
 import Data.Maybe (catMaybes)
 import GHC hiding (IE, parseModule, parser)
-import GHC.LanguageExtensions.Type (Extension (Cpp))
+import GHC.LanguageExtensions.Type (Extension (..))
 import GHC.Paths (libdir)
 import Ormolu.Config
 import Ormolu.Exception
@@ -87,7 +87,7 @@ initDynFlagsPure fp input = do
   -- I was told we could get away with using the 'unsafeGlobalDynFlags'. as
   -- long as 'parseDynamicFilePragma' is impure there seems to be no reason
   -- to use it.
-  dflags0 <- GHC.getSessionDynFlags
+  dflags0 <- setDefaultExts <$> GHC.getSessionDynFlags
   let tokens = GHC.getOptions dflags0 (GHC.stringToStringBuffer input) fp
   (dflags1, _, _) <- GHC.parseDynamicFilePragma dflags0 tokens
   -- Turn this on last to avoid T10942
@@ -154,3 +154,70 @@ getPragma s@(x:xs)
   | otherwise =
       let (prag, remline) = getPragma xs
       in (x:prag, ' ':remline)
+
+-- | Enable all language extensions that we think should be enabled by
+-- default for ease of use.
+
+setDefaultExts :: DynFlags -> DynFlags
+setDefaultExts flags = foldl' GHC.xopt_set flags
+  [ OverlappingInstances
+  , UndecidableInstances
+  , IncoherentInstances
+  , UndecidableSuperClasses
+  , ExtendedDefaultRules
+  , ForeignFunctionInterface
+  , TemplateHaskell
+  , QuasiQuotes
+  , ImplicitParams
+  , ScopedTypeVariables
+  , BangPatterns
+  , TypeFamilies
+  , TypeFamilyDependencies
+  , TypeInType
+  , OverloadedStrings
+  , OverloadedLists
+  , RecordWildCards
+  , RecordPuns
+  , GADTs
+  , GADTSyntax
+  , NPlusKPatterns
+  , ConstraintKinds
+  , PolyKinds
+  , DataKinds
+  , InstanceSigs
+  , StandaloneDeriving
+  , DefaultSignatures
+  , DeriveAnyClass
+  , DerivingStrategies
+  , DerivingVia
+  , FlexibleContexts
+  , FlexibleInstances
+  , MultiParamTypeClasses
+  , FunctionalDependencies
+  , ExistentialQuantification
+  , EmptyDataDecls
+  , KindSignatures
+  , RoleAnnotations
+  , GeneralizedNewtypeDeriving
+  , RecursiveDo
+  , TupleSections
+  , PatternGuards
+  , RankNTypes
+  , TypeOperators
+  , ExplicitNamespaces
+  , PackageImports
+  , ExplicitForAll
+  , LambdaCase
+  , MultiWayIf
+  , BinaryLiterals
+  , NegativeLiterals
+  , HexFloatLiterals
+  , OverloadedLabels
+  , EmptyCase
+  , NamedWildCards
+  , StaticPointers
+  , TypeApplications
+  , NumericUnderscores
+  , QuantifiedConstraints
+  , StarIsType
+  ]


### PR DESCRIPTION
What could be better?

* Fixes #69 (because it drops `yaml` dependency).
* Fixes #62 (because it enabled all extensions).
* Fixes #56 (because messing with cabal files is no longer necessary).