### PR TITLE
Mention name of file even when rendered version fails to parse

### DIFF
--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -60,7 +60,11 @@ ormolu cfg path str = do
   -- same as AST of original snippet module span positions.
   unless (cfgUnsafe cfg) $ do
     (_, result1) <-
-      parseModule' cfg OrmoluOutputParsingFailed "<rendered>" (T.unpack txt)
+      parseModule'
+        cfg
+        OrmoluOutputParsingFailed
+        (path ++ "<rendered>")
+        (T.unpack txt)
     when (diff result0 result1) $
       liftIO $ throwIO (OrmoluASTDiffers str txt)
   return txt


### PR DESCRIPTION
Without this info it's hard to know which file from a bulk is problematic.