### PR TITLE
Shift ‘in’ in ‘let’ to the right to allow placing it in do blocks

### DIFF
--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -47,3 +47,8 @@ foo = do
         print x
         y <- c
         print y
+
+trickyLet = do
+  foo
+  let x = 5
+   in bar x

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -46,3 +46,8 @@ foo = do
 
           y <- c
           print y
+
+trickyLet = do
+  foo
+  let x = 5
+   in bar x

--- a/data/examples/declaration/value/function/let-multi-line-out.hs
+++ b/data/examples/declaration/value/function/let-multi-line-out.hs
@@ -2,11 +2,11 @@ foo :: Int -> Int
 foo x =
   let z = y
       y = x
-  in z + 100
+   in z + 100
 
 bar :: Int -> Int
 bar x =
   let z = y
       y = x
-  in z +
-       100
+   in z +
+        100

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -459,7 +459,7 @@ p_hsExpr = \case
   HsLet NoExt localBinds e -> do
     txt "let "
     sitcc (located localBinds p_hsLocalBinds)
-    breakpoint
+    vlayout space (newline >> space)
     txt "in "
     sitcc (located e p_hsExpr)
   HsDo NoExt ctx es -> do


### PR DESCRIPTION
Close #145.

It is a bit uncommon to format it like this, but this way it can be placed without changes in do blocks as well. I think it's the right way go about that bug.