### PR TITLE
Support data types with infix & multi-line declarations

### DIFF
--- a/data/examples/declaration/data/multiline-names-out.hs
+++ b/data/examples/declaration/data/multiline-names-out.hs
@@ -1,0 +1,29 @@
+data
+  Foo
+    a
+    b
+  = Foo a b
+
+data a :-> b = Arrow (a -> b)
+
+data (f :* g) a = f a :* g a
+
+data
+  ( f :+
+    g
+  )
+    a
+  = L (f a)
+  | R (g a)
+
+data a `Arrow` b = Arrow' (a -> b)
+
+data (f `Product` g) a = f a `Product` g a
+
+data
+  ( f `Sum`
+    g
+  )
+    a
+  = L' (f a)
+  | R' (g a)

--- a/data/examples/declaration/data/multiline-names.hs
+++ b/data/examples/declaration/data/multiline-names.hs
@@ -1,0 +1,23 @@
+data Foo a
+         b
+  = Foo a b
+
+data a :-> b = Arrow (a -> b)
+
+data (f :* g) a = f a :* g a
+
+data (f
+      :+
+      g)
+  a = L (f a)
+    | R (g a)
+
+data a `Arrow` b = Arrow' (a -> b)
+
+data (f `Product` g) a = f a `Product` g a
+
+data (f
+      `Sum`
+      g)
+  a = L' (f a)
+    | R' (g a)

--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -6,7 +6,9 @@ instance Foo Int where
 
 instance Foo Double where
 
-  newtype Bar Double
+  newtype
+    Bar
+      Double
     = DoubleBar
         Double
         Double

--- a/data/examples/declaration/instance/data-family-instances-out.hs
+++ b/data/examples/declaration/instance/data-family-instances-out.hs
@@ -3,7 +3,9 @@
 
 data instance Foo Int = FooInt Int
 
-data instance Foo [Int]
+data instance
+  Foo
+    [Int]
   = IntListFoo
       ( Int
       , Int

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -66,7 +66,12 @@ p_tyClDecl style = \case
   FamDecl NoExt x -> p_famDecl style x
   SynDecl {..} -> p_synDecl tcdLName tcdTyVars tcdRhs
   DataDecl {..} ->
-    p_dataDecl Associated tcdLName (tyVarsToTypes tcdTyVars) tcdDataDefn
+    p_dataDecl
+      Associated
+      tcdLName
+      (tyVarsToTypes tcdTyVars)
+      tcdFixity
+      tcdDataDefn
   ClassDecl {..} ->
     p_classDecl
       tcdCtxt

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -112,7 +112,7 @@ p_dataFamInstDecl style = \case
   DataFamInstDecl {..} -> do
     let HsIB {..} = dfid_eqn
         FamEqn {..} = hsib_body
-    p_dataDecl style feqn_tycon feqn_pats feqn_rhs
+    p_dataDecl style feqn_tycon feqn_pats feqn_fixity feqn_rhs
 
 match_overlap_mode :: Maybe (Located OverlapMode) -> R () -> R ()
 match_overlap_mode overlap_mode layoutStrategy =


### PR DESCRIPTION
Close #151.

This pull request fixes the bug in #151 where data types with infix names & names layed out over multiple lines get incorrectly formatted. Specifically, this pull request reuses `p_infixDefHelper` to easily take care of this behavior.

No other changes to formatting (such as e.g. indentation) are applied. Consequently, certain cases (such as `GADTs`) may at times look awkward:

```haskell
data
  Foo
    (a :: Type)
    (b :: Type) where
  Foo :: a -> b -> Foo a b
  Bar :: b -> a -> Foo a b
```