### PR TITLE
Support transform list comprehensions

### DIFF
--- a/data/examples/declaration/value/function/transform-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/transform-comprehensions-out.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE TransformListComp #-}
+
+foo xs ys = [(x, y) | x <- xs, y <- ys, then reverse]
+
+foo' xs ys =
+  [ ( x
+    , y
+    )
+  | x <- xs
+  , y <- ys
+  , -- First comment
+    then reverse -- Second comment
+  ]
+
+bar xs ys = [(x, y) | x <- xs, y <- ys, then sortWith by (x + y)]
+
+bar' xs ys =
+  [ ( x
+    , y
+    )
+  | x <- xs
+  , y <- ys
+  , -- First comment
+    then sortWith
+    by
+      ( x +
+        y -- Second comment
+      )
+  ]
+
+baz xs ys = [(x, y) | x <- xs, y <- ys, then group using permutations]
+
+baz' xs ys =
+  [ ( x
+    , y
+    )
+  | x <- xs
+  , y <- ys
+  , -- First comment
+    then group using permutations -- Second comment
+  ]
+
+quux xs ys = [(x, y) | x <- xs, y <- ys, then group by (x + y) using groupWith]
+
+quux' xs ys =
+  [ ( x
+    , y
+    )
+  | x <- xs
+  , y <- ys
+  , -- First comment
+    then group by
+      ( x +
+        y
+      )
+    -- Second comment
+    using groupWith -- Third comment
+  ]

--- a/data/examples/declaration/value/function/transform-comprehensions.hs
+++ b/data/examples/declaration/value/function/transform-comprehensions.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE TransformListComp #-}
+
+foo xs ys = [(x, y) | x <- xs, y <- ys, then reverse]
+
+foo' xs ys = [
+  (x,
+   y) |
+  x <- xs,
+  y <- ys,
+  then -- First comment
+    reverse -- Second comment
+  ]
+
+bar xs ys = [(x, y) | x <- xs, y <- ys, then sortWith by (x + y)]
+
+bar' xs ys = [
+  (x,
+    y) |
+  x <- xs,
+  y <- ys,
+  then -- First comment
+    sortWith
+  by
+    (x
+      + y) -- Second comment
+  ]
+
+baz xs ys = [(x, y) | x <- xs, y <- ys, then group using permutations]
+
+baz' xs ys = [
+  (x,
+    y) |
+  x <- xs,
+  y <- ys,
+  then
+  group
+  using -- First comment
+    permutations -- Second comment
+  ]
+
+quux xs ys = [(x, y) | x <- xs, y <- ys, then group by (x + y) using groupWith]
+
+quux' xs ys = [
+  (x,
+    y) |
+  x <- xs,
+  y <- ys,
+  then
+  group
+  by -- First comment
+    (x
+      + y)
+  using -- Second comment
+    groupWith -- Third comment
+  ]


### PR DESCRIPTION
This pull request implements pretty printing of transform list comprehensions, as specified in the `TransStmt` part of #47.

Supporting such comprehensions while also keeping the codebase readable was surprisingly difficult, largely since the GHC AST for list comprehensions is notoriously difficult to work with. The simplest approach to solving the problem was to preprocess all list comprehensions and generate nested lists of statements, where the first layer correspond to parallel statements, and the second layer correspond to sequenced statements. Consequently, pretty printing of list comprehensions becomes a mere nested traversal.

All list comprehension preprocessing happens in `gatherStmt`, `gatherStmtBlock`, and `liftAppend`, which simply extracts the relevant statements into the relevant nested list. These could, in principle, be moved to another module to shrinken the size of the expression pretty printing module.