### PR TITLE
Fix rendering of implicit bidirectional pattern synonyms

### DIFF
--- a/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 pattern Arrow t1 t2 = App "->" [t1, t2]
+
 pattern Int =
   App "Int" []
+
 pattern Maybe t =
   App
     "Maybe"

--- a/data/examples/declaration/value/pattern-synonyms/bidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 pattern Arrow t1 t2 = App "->"    [t1, t2]
 pattern Int         =
   App "Int"   []

--- a/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional-out.hs
@@ -9,3 +9,9 @@ pattern HeadC' x <-
   x : xs
   where
     HeadC' x = [x]
+
+pattern Simple <-
+  "Simple"
+  where
+    Simple =
+      "Complicated"

--- a/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional.hs
@@ -7,3 +7,7 @@ pattern HeadC' x <-
   x:xs
   where
     HeadC' x = [x]
+
+pattern Simple <- "Simple"
+  where
+    Simple = "Complicated"

--- a/data/examples/declaration/value/pattern-synonyms/unidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/unidirectional-out.hs
@@ -4,3 +4,5 @@ pattern Head x <- x : xs
 
 pattern Head' x <-
   x : xs
+
+pattern Simple <- "Simple"

--- a/data/examples/declaration/value/pattern-synonyms/unidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/unidirectional.hs
@@ -4,3 +4,5 @@ pattern Head x <- x:xs
 
 pattern Head' x
   <- x:xs
+
+pattern Simple <- "Simple"

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -575,24 +575,28 @@ p_hsExpr = \case
 p_patSynBind :: PatSynBind GhcPs GhcPs -> R ()
 p_patSynBind PSB {..} = do
   txt "pattern "
+  let nonEmptySynDetails = \case
+        PrefixCon (_:_) -> True
+        RecCon (_:_) -> True
+        _ -> False
   case psb_dir of
     Unidirectional -> do
       p_rdrName psb_id
-      space
+      when (nonEmptySynDetails psb_args) space
       p_patSynDetails psb_args
       txt " <-"
       breakpoint
       inci (located psb_def p_pat)
     ImplicitBidirectional -> do
       p_rdrName psb_id
-      space
+      when (nonEmptySynDetails psb_args) space
       p_patSynDetails psb_args
       txt " ="
       breakpoint
-      located psb_def p_pat
+      inci (located psb_def p_pat)
     ExplicitBidirectional mgroup -> do
       p_rdrName psb_id
-      space
+      when (nonEmptySynDetails psb_args) space
       p_patSynDetails psb_args
       txt " <-"
       breakpoint


### PR DESCRIPTION
Previously we forgot to enable the extension, and apparently we were just defining a function called `pattern`.