### PR TITLE
Adjust rendering of kind signatures and implicit parameters

### DIFF
--- a/data/examples/declaration/data/kind-annotations-out.hs
+++ b/data/examples/declaration/data/kind-annotations-out.hs
@@ -1,0 +1,1 @@
+data Something (n :: Nat) = Something

--- a/data/examples/declaration/data/kind-annotations.hs
+++ b/data/examples/declaration/data/kind-annotations.hs
@@ -1,0 +1,1 @@
+data Something (n :: Nat) = Something

--- a/data/examples/declaration/value/function/implicit-params-out.hs
+++ b/data/examples/declaration/value/function/implicit-params-out.hs
@@ -4,3 +4,12 @@ sortBy :: (a -> a -> Bool) -> [a] -> [a]
 
 sort :: (?cmp :: a -> a -> Bool) => [a] -> [a]
 sort = sortBy ?cmp
+
+sort'
+  :: ( ?cmp
+         :: a -> a -> Bool
+     , ?foo :: Int
+     )
+  => [a]
+  -> [a]
+sort' = sort

--- a/data/examples/declaration/value/function/implicit-params.hs
+++ b/data/examples/declaration/value/function/implicit-params.hs
@@ -3,3 +3,8 @@ sortBy :: (a -> a -> Bool) -> [a] -> [a]
 
 sort   :: (?cmp :: a -> a -> Bool) => [a] -> [a]
 sort    = sortBy ?cmp
+
+sort' ::  (?cmp
+             :: a -> a -> Bool
+          ,?foo :: Int) => [a] -> [a]
+sort' = sort

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -69,15 +69,16 @@ p_hsType = \case
       located y p_hsType
   HsParTy NoExt t ->
     parens (located t p_hsType)
-  HsIParamTy NoExt n t -> do
+  HsIParamTy NoExt n t -> sitcc $ do
     located n atom
     breakpoint
     inci $ do
       txt ":: "
       located t p_hsType
   HsStarTy NoExt _ -> txt "*"
-  HsKindSig NoExt t k -> do
+  HsKindSig NoExt t k -> sitcc $ do
     located t p_hsType
+    space -- FIXME
     inci $ do
       txt ":: "
       located k p_hsType


### PR DESCRIPTION
Previously there was no space between type variable and `::`, which is why I started digging this in the first place.