### PR TITLE
Add an option to display default extensions.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,6 +11,8 @@ import Data.Version (showVersion)
 import Development.GitRev
 import Options.Applicative
 import Ormolu
+import Ormolu.Parser (manualExts)
+import Ormolu.Utils (showOutputable)
 import Paths_ormolu (version)
 import System.Exit (ExitCode (..), exitWith)
 import System.IO (hPutStrLn, stderr)
@@ -68,7 +70,7 @@ data Mode
   deriving (Eq, Show)
 
 optsParserInfo :: ParserInfo Opts
-optsParserInfo = info (helper <*> ver <*> optsParser) . mconcat $
+optsParserInfo = info (helper <*> ver <*> exts <*> optsParser) . mconcat $
   [ fullDesc
   , progDesc ""
   , header ""
@@ -89,6 +91,12 @@ optsParserInfo = info (helper <*> ver <*> optsParser) . mconcat $
         ]
       , "using ghc " ++ VERSION_ghc
       ]
+    exts :: Parser (a -> a)
+    exts = infoOption displayExts . mconcat $
+      [ long "manual-exts"
+      , help "Display extensions that need to be enabled manually"
+      ]
+    displayExts = unlines (showOutputable <$> manualExts)
 
 optsParser :: Parser Opts
 optsParser = Opts

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -6,6 +6,7 @@
 
 module Ormolu.Parser
   ( parseModule
+  , manualExts
   )
 where
 
@@ -66,6 +67,28 @@ parseModule dynOpts path input' = liftIO $ do
             , prExtensions = exts
             }
   return (ws, r)
+
+-- | Extensions that are not enabled automatically and should be activated
+-- by user.
+
+manualExts :: [Extension]
+manualExts =
+  [ Arrows -- steals proc
+  , Cpp -- forbidden
+  , PatternSynonyms -- steals the pattern keyword
+  , RecursiveDo -- steals the rec keyword
+  , StaticPointers -- steals static keyword
+  , TransformListComp -- steals the group keyword
+  , UnboxedTuples -- breaks (#) lens operator
+  , MagicHash -- screws {-# these things #-}
+  , AlternativeLayoutRule
+  , AlternativeLayoutRuleTransitional
+  , MonadComprehensions
+  , UnboxedSums
+  , TemplateHaskellQuotes -- enables TH subset of quasi-quotes, this
+                          -- apparently interferes with QuasiQuotes in
+                          -- weird ways
+  ]
 
 ----------------------------------------------------------------------------
 -- Helpers (taken from ghc-exactprint)
@@ -161,26 +184,9 @@ getPragma s@(x:xs)
 -- default for ease of use.
 
 setDefaultExts :: DynFlags -> DynFlags
-setDefaultExts flags = foldl' GHC.xopt_set flags whitelist
+setDefaultExts flags = foldl' GHC.xopt_set flags autoExts
   where
-    whitelist = allExts \\ blacklist
+    autoExts = allExts \\ manualExts
     allExts = [minBound..maxBound]
-    blacklist =
-      [ Arrows -- steals proc
-      , Cpp -- forbidden
-      , PatternSynonyms -- steals the pattern keyword
-      , RecursiveDo -- steals the rec keyword
-      , StaticPointers -- steals static keyword
-      , TransformListComp -- steals the group keyword
-      , UnboxedTuples -- breaks (#) lens operator
-      , MagicHash -- screws {-# these things #-}
-      , AlternativeLayoutRule
-      , AlternativeLayoutRuleTransitional
-      , MonadComprehensions
-      , UnboxedSums
-      , TemplateHaskellQuotes -- enables TH subset of quasi-quotes, this
-                              -- apparently interferes with QuasiQuotes in
-                              -- weird ways
-      ]
 
 deriving instance Bounded Extension


### PR DESCRIPTION
See #163

```
$ ormolu -l
BangPatterns
BinaryLiterals
ConstraintKinds
DataKinds
DefaultSignatures
DeriveAnyClass
DerivingStrategies
DerivingVia
EmptyCase
EmptyDataDecls
ExistentialQuantification
ExplicitForAll
ExplicitNamespaces
ExtendedDefaultRules
FlexibleContexts
FlexibleInstances
ForeignFunctionInterface
FunctionalDependencies
GADTs
GADTSyntax
GeneralizedNewtypeDeriving
HexFloatLiterals
ImplicitParams
IncoherentInstances
InstanceSigs
KindSignatures
LambdaCase
MultiParamTypeClasses
MultiWayIf
NPlusKPatterns
NamedWildCards
NegativeLiterals
NumericUnderscores
OverlappingInstances
OverloadedLabels
OverloadedLists
OverloadedStrings
PackageImports
PatternGuards
PolyKinds
QuantifiedConstraints
QuasiQuotes
RankNTypes
RecordPuns
RecordWildCards
RecursiveDo
RoleAnnotations
ScopedTypeVariables
StandaloneDeriving
StarIsType
StaticPointers
TemplateHaskell
TupleSections
TypeApplications
TypeFamilies
TypeFamilyDependencies
TypeInType
TypeOperators
UndecidableInstances
UndecidableSuperClasses
```