### PR TITLE
Include source locations in diff report

### DIFF
--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -65,8 +65,9 @@ ormolu cfg path str = do
         OrmoluOutputParsingFailed
         (path ++ "<rendered>")
         (T.unpack txt)
-    when (diff result0 result1) $
-      liftIO $ throwIO (OrmoluASTDiffers str txt)
+    case diff result0 result1 of
+      Same -> return ()
+      Different ss -> liftIO $ throwIO (OrmoluASTDiffers ss str txt)
   return txt
 
 -- | Load a file and format it. The file stays intact and the rendered

--- a/src/Ormolu/Diff.hs
+++ b/src/Ormolu/Diff.hs
@@ -6,6 +6,7 @@
 
 module Ormolu.Diff
   ( diff
+  , Diff(..)
   )
 where
 
@@ -15,43 +16,74 @@ import GHC
 import Ormolu.Imports (sortImports)
 import Ormolu.Parser.Result
 
+-- | Result of comparing two 'ParseResult's.
+
+data Diff
+  = Same                        -- ^ Two parse results are the same
+  | Different [SrcSpan]         -- ^ Two parse results differ
+
+instance Semigroup Diff where
+  Same <> a = a
+  a <> Same = a
+  Different xs <> Different ys = Different (xs ++ ys)
+
+instance Monoid Diff where
+  mempty = Same
+
 -- | Return 'False' if two annotated ASTs are the same modulo span
 -- positions.
 
-diff :: ParseResult -> ParseResult -> Bool
+diff :: ParseResult -> ParseResult -> Diff
 diff ParseResult { prCommentStream = cstream0
                  , prParsedSource = ps0
                  }
      ParseResult { prCommentStream = cstream1
                  , prParsedSource = ps1
                  } =
-  not (matchIgnoringSrcSpans cstream0 cstream1)
-  || not (matchIgnoringSrcSpans ps0 ps1)
+  matchIgnoringSrcSpans cstream0 cstream1 <>
+  matchIgnoringSrcSpans ps0 ps1
 
 -- | Compare two values for equality disregarding differences in 'SrcSpan's
 -- and the ordering of import lists.
 
-matchIgnoringSrcSpans :: Data a => a -> a -> Bool
+matchIgnoringSrcSpans :: Data a => a -> a -> Diff
 matchIgnoringSrcSpans = genericQuery
   where
-    genericQuery :: GenericQ (GenericQ Bool)
-    genericQuery x y = (toConstr x == toConstr y)
-      && and (gzipWithQ (genericQuery
-                           `extQ` srcSpanEq
-                           `extQ` hsModuleEq
-                           `extQ` sourceTextEq) x y)
+    genericQuery :: GenericQ (GenericQ Diff)
+    genericQuery x y
+      | typeOf x == typeOf y, toConstr x == toConstr y =
+          mconcat $ gzipWithQ
+            (genericQuery
+              `extQ` srcSpanEq
+              `extQ` hsModuleEq
+              `extQ` sourceTextEq
+              `ext2Q` forLocated)
+            x y
+      | otherwise = Different []
 
-    srcSpanEq :: SrcSpan -> GenericQ Bool
-    srcSpanEq _ _ = True
+    srcSpanEq :: SrcSpan -> GenericQ Diff
+    srcSpanEq _ _ = Same
 
-    hsModuleEq :: HsModule GhcPs -> GenericQ Bool
+    hsModuleEq :: HsModule GhcPs -> GenericQ Diff
     hsModuleEq hs0 hs1' =
       case cast hs1' :: Maybe (HsModule GhcPs) of
-        Nothing -> False
+        Nothing -> Different []
         Just hs1 ->
           matchIgnoringSrcSpans
             hs0 { hsmodImports = sortImports (hsmodImports hs0) }
             hs1 { hsmodImports = sortImports (hsmodImports hs1) }
 
-    sourceTextEq :: SourceText -> GenericQ Bool
-    sourceTextEq _ _ = True
+    sourceTextEq :: SourceText -> GenericQ Diff
+    sourceTextEq _ _ = Same
+
+    forLocated
+      :: (Data e0, Data e1)
+      => GenLocated e0 e1
+      -> GenericQ Diff
+    forLocated x@(L mspn _) y =
+      maybe id appendSpan (cast mspn) (genericQuery x y)
+
+    appendSpan :: SrcSpan -> Diff -> Diff
+    appendSpan s (Different ss) | fresh = Different (s:ss)
+      where fresh = not $ any (flip isSubspanOf s) ss
+    appendSpan _ d = d

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -24,7 +24,7 @@ data OrmoluException
     -- ^ Parsing of original source code failed
   | OrmoluOutputParsingFailed GHC.SrcSpan String
     -- ^ Parsing of formatted source code failed
-  | OrmoluASTDiffers String Text
+  | OrmoluASTDiffers [GHC.SrcSpan] String Text
     -- ^ Original and resulting ASTs differ, first argument is the original
     -- source code, second argument is rendered source code
   deriving (Eq, Show)
@@ -37,10 +37,10 @@ instance Exception OrmoluException where
     OrmoluOutputParsingFailed s e ->
       showParsingErr "Parsing of formatted code failed:" s e ++
         "Please, consider reporting the bug."
-    OrmoluASTDiffers _ _ -> unlines
-      [ "AST of input and AST of formatted code differ."
-      , "Please, consider reporting the bug."
-      ]
+    OrmoluASTDiffers ss _ _ -> unlines $
+      ["AST of input and AST of formatted code differ."]
+      ++ map (\s -> "  at " ++ showOutputable s) ss ++
+      ["Please, consider reporting the bug."]
 
 -- | Inside this wrapper 'OrmoluException' will be caught and displayed
 -- nicely using 'displayException'.
@@ -59,7 +59,7 @@ withPrettyOrmoluExceptions m = m `catch` h
           OrmoluCppEnabled -> 2
           OrmoluParsingFailed _ _ -> 3
           OrmoluOutputParsingFailed _ _ -> 4
-          OrmoluASTDiffers _ _ -> 5
+          OrmoluASTDiffers _ _ _ -> 5
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Close #202.

This should help with #200 

Before this patch:

```
$ ormolu -m inplace cmm/CmmBuildInfoTables.hs
AST of input and AST of formatted code differ.
Please, consider reporting the bug.
```

After this patch:
```
$ ormolu -m inplace cmm/CmmBuildInfoTables.hs
AST of input and AST of formatted code differ.
  at cmm/CmmBuildInfoTables.hs:1:1
  at cmm/CmmBuildInfoTables.hs:411:13-39
  at cmm/CmmBuildInfoTables.hs:419:9-57
Please, consider reporting the bug.
```