### PR TITLE
Fix let/where single line

### DIFF
--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -52,3 +52,9 @@ trickyLet = do
   foo
   let x = 5
    in bar x
+
+-- single line let-where
+samples n f = do
+  gen <- newQCGen
+  let rands g = g1 : rands g2 where (g1, g2) = split g
+  return $ rands gen

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -51,3 +51,9 @@ trickyLet = do
   foo
   let x = 5
    in bar x
+
+-- single line let-where
+samples n f = do
+    gen <- newQCGen
+    let rands g = g1 : rands g2 where (g1, g2) = split g
+    return $ rands gen

--- a/data/examples/declaration/value/function/let-single-line-out.hs
+++ b/data/examples/declaration/value/function/let-single-line-out.hs
@@ -1,2 +1,3 @@
 foo :: a -> a
 foo x = let x = x in x
+foo x = let x = z where z = 2 in x

--- a/data/examples/declaration/value/function/let-single-line.hs
+++ b/data/examples/declaration/value/function/let-single-line.hs
@@ -1,2 +1,3 @@
 foo :: a -> a
 foo x = let x = x in x
+foo x = let x = z where z = 2 in x

--- a/data/examples/declaration/value/function/where-out.hs
+++ b/data/examples/declaration/value/function/where-out.hs
@@ -1,7 +1,5 @@
 foo :: Int -> Int
-foo x = f x
-  where
-    f z = z
+foo x = f x where f z = z
 
 bar :: Int -> Int
 bar x = f x

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -188,11 +188,13 @@ p_match' placer pretty style isInfix m_pats m_grhss = do
                 then RightArrow
                 else EqualSign
           newlineSep (located' (p_grhs' pretty groupStyle)) grhssGRHSs
+          let whereLocation = combineSrcSpans patGrhssSpan $ getLoc grhssLocalBinds
           unless
             (GHC.isEmptyLocalBindsPR (unLoc grhssLocalBinds))
-            (inciLocalBinds $ do
-              newline
-              line (txt "where")
+            (inciLocalBinds . switchLayout whereLocation $ do
+              breakpoint
+              txt "where"
+              breakpoint
               inci (located grhssLocalBinds p_hsLocalBinds)
             )
     case style of


### PR DESCRIPTION
Closes #177

This PR implements the first fix suggested in #177

It adds support for single line `where` clauses which has the effect of fixing the issue with the interaction between `let` and `where` clauses in the single line case.