### PR TITLE
Run on Hackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ $ nix-build -A hackage.<package>
 ```
 
 Then inspect `result/log.txt` for possible problems. The derivation will
-also contain formatted files for inspection.
+also contain formatted `.hs` files for inspection and original inputs with
+`.hs-original` extension (those are with CPP dropped, exactly what is fed
+into Ormolu).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ formatted output.
 $ ormolu --mode inplace Module.hs
 ```
 
+## Running on Hackage
+
+It's possible to try Ormolu on arbitrary packages from Hackage. For that
+execute:
+
+```console
+$ nix-build -A hackage.<package>
+```
+
+Then inspect `result/log.txt` for possible problems. The derivation will
+also contain formatted files for inspection.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -132,6 +132,11 @@ configParser = Config
     , short 'd'
     , help "Output information useful for debugging"
     ]
+  <*> (switch . mconcat)
+    [ long "tolerate-cpp"
+    , short 'p'
+    , help "Do not fail if CPP pragma is present"
+    ]
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/nix/gitignore/default.nix
+++ b/nix/gitignore/default.nix
@@ -1,8 +1,0 @@
-{ lib }:
-
-let
-  rev = "ec5dd0536a5e4c3a99c797b86180f7261197c124";
-  sha256 = "0k2r8y21rn4kr5dmddd3906x0733fs3bb8hzfpabkdav3wcy3klv";
-  url = "https://github.com/hercules-ci/gitignore/archive/${rev}.tar.gz";
-  nixGitIgnore = builtins.fetchTarball { inherit url sha256; };
-in (import nixGitIgnore { inherit lib; }).gitignoreSource

--- a/nix/ormolize/default.nix
+++ b/nix/ormolize/default.nix
@@ -13,6 +13,7 @@
     '';
     installPhase = ''
       mkdir "$out"
+      find . -name '*.hs-original' -exec cp --parents {} $out \;
       find . -name '*.hs' -exec cp --parents {} $out \;
       cp log.txt $out/log.txt
     '';

--- a/nix/ormolize/default.nix
+++ b/nix/ormolize/default.nix
@@ -1,0 +1,19 @@
+{ pkgs, haskellPackages }: _: p:
+  pkgs.stdenv.mkDerivation {
+    name = p.name + "-ormolized";
+    src = p.src;
+    buildInputs = [
+      haskellPackages.cpphs
+      haskellPackages.ormolu
+      pkgs.glibcLocales
+    ];
+    LANG = "en_US.UTF-8";
+    buildPhase = ''
+      find . -name '*.hs' -exec bash ${./ormolize.sh} {} \; 2> log.txt
+    '';
+    installPhase = ''
+      mkdir "$out"
+      find . -name '*.hs' -exec cp --parents {} $out \;
+      cp log.txt $out/log.txt
+    '';
+  }

--- a/nix/ormolize/ormolize.sh
+++ b/nix/ormolize/ormolize.sh
@@ -5,9 +5,6 @@ set -euo pipefail
 # drop includes
 sed -i '/^#include/d' "$1"
 
-# drop CPP
-sed -i '/^{-# LANGUAGE CPP/d' "$1"
-
 # deal with CPP in a fairly straightforward way
 cpphs "$1" --noline > "$1-nocpp" 2> /dev/null
 
@@ -18,4 +15,4 @@ mv "$1-nocpp" "$1"
 cp "$1" "$1-original"
 
 # run ormolu
-ormolu -m inplace "$1" || ormolu -u -m inplace "$1"
+ormolu --tolerate-cpp --mode inplace "$1" || ormolu --tolerate-cpp --unsafe --mode inplace "$1"

--- a/nix/ormolize/ormolize.sh
+++ b/nix/ormolize/ormolize.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# drop includes
+sed -i '/^#include/d' "$1"
+
+# drop CPP
+sed -i '/^{-# LANGUAGE CPP/d' "$1"
+
+# deal with CPP in a fairly straightforward way
+cpphs "$1" --noline > "$1-nocpp" 2> /dev/null
+
+# annoyingly, cpphs cannot modify files in place
+mv "$1-nocpp" "$1"
+
+# run ormolu
+ormolu -m inplace "$1"

--- a/nix/ormolize/ormolize.sh
+++ b/nix/ormolize/ormolize.sh
@@ -14,5 +14,8 @@ cpphs "$1" --noline > "$1-nocpp" 2> /dev/null
 # annoyingly, cpphs cannot modify files in place
 mv "$1-nocpp" "$1"
 
+# preserve the original
+cp "$1" "$1-original"
+
 # run ormolu
-ormolu -m inplace "$1"
+ormolu -m inplace "$1" || ormolu -u -m inplace "$1"

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -67,7 +67,7 @@ ormolu cfg path str = do
         (T.unpack txt)
     case diff result0 result1 of
       Same -> return ()
-      Different ss -> liftIO $ throwIO (OrmoluASTDiffers ss str txt)
+      Different ss -> liftIO $ throwIO (OrmoluASTDiffers path ss)
   return txt
 
 -- | Load a file and format it. The file stays intact and the rendered

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -109,8 +109,8 @@ parseModule'
   -> FilePath                   -- ^ File name to use in errors
   -> String                     -- ^ Actual input for the parser
   -> m ([GHC.Warn], ParseResult)
-parseModule' Config {..} mkException path str = do
-  (ws, r) <- parseModule cfgDynOptions path str
+parseModule' cfg mkException path str = do
+  (ws, r) <- parseModule cfg path str
   case r of
     Left (spn, err) -> liftIO $ throwIO (mkException spn err)
     Right x -> return (ws, x)

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -23,6 +23,10 @@ data Config = Config
     -- ^ Do formatting faster but without automatic detection of defects
   , cfgDebug :: !Bool
     -- ^ Output information useful for debugging
+  , cfgTolerateCpp :: !Bool
+    -- ^ Do not fail if CPP pragma is present (still doesn't handle CPP but
+    -- useful for formatting of files that enable the extension without
+    -- actually containing CPP macros)
   } deriving (Eq, Show)
 
 -- | Default 'Config'.
@@ -32,6 +36,7 @@ defaultConfig = Config
   { cfgDynOptions = []
   , cfgUnsafe = False
   , cfgDebug = False
+  , cfgTolerateCpp = False
   }
 
 -- | A wrapper for dynamic options.

--- a/src/Ormolu/Diff.hs
+++ b/src/Ormolu/Diff.hs
@@ -84,6 +84,8 @@ matchIgnoringSrcSpans = genericQuery
       maybe id appendSpan (cast mspn) (genericQuery x y)
 
     appendSpan :: SrcSpan -> Diff -> Diff
-    appendSpan s (Different ss) | fresh = Different (s:ss)
-      where fresh = not $ any (flip isSubspanOf s) ss
+    appendSpan s (Different ss) | fresh && helpful = Different (s:ss)
+      where
+        fresh = not $ any (flip isSubspanOf s) ss
+        helpful = isGoodSrcSpan s
     appendSpan _ d = d

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -9,7 +9,6 @@ module Ormolu.Exception
 where
 
 import Control.Exception
-import Data.Text (Text)
 import Ormolu.Utils (showOutputable)
 import System.Exit (ExitCode (..), exitWith)
 import System.IO
@@ -18,29 +17,35 @@ import qualified GHC
 -- | Ormolu exception representing all cases when Ormolu can fail.
 
 data OrmoluException
-  = OrmoluCppEnabled
+  = OrmoluCppEnabled FilePath
     -- ^ Ormolu does not work with source files that use CPP
   | OrmoluParsingFailed GHC.SrcSpan String
     -- ^ Parsing of original source code failed
   | OrmoluOutputParsingFailed GHC.SrcSpan String
     -- ^ Parsing of formatted source code failed
-  | OrmoluASTDiffers [GHC.SrcSpan] String Text
-    -- ^ Original and resulting ASTs differ, first argument is the original
-    -- source code, second argument is rendered source code
+  | OrmoluASTDiffers FilePath [GHC.SrcSpan]
+    -- ^ Original and resulting ASTs differ
   deriving (Eq, Show)
 
 instance Exception OrmoluException where
   displayException = \case
-    OrmoluCppEnabled -> "CPP is not supported"
+    OrmoluCppEnabled path -> unlines
+      [ "CPP is not supported:"
+      , withIndent path
+      ]
     OrmoluParsingFailed s e ->
       showParsingErr "Parsing of source code failed:" s e
     OrmoluOutputParsingFailed s e ->
       showParsingErr "Parsing of formatted code failed:" s e ++
-        "Please, consider reporting the bug."
-    OrmoluASTDiffers ss _ _ -> unlines $
-      ["AST of input and AST of formatted code differ."]
-      ++ map (\s -> "  at " ++ showOutputable s) ss ++
-      ["Please, consider reporting the bug."]
+        "Please, consider reporting the bug.\n"
+    OrmoluASTDiffers path ss -> unlines $
+      [ "AST of input and AST of formatted code differ."
+      ]
+      ++ (fmap withIndent $ case fmap (\s -> "at " ++ showOutputable s) ss of
+           [] -> ["in " ++ path]
+           xs -> xs) ++
+      [ "Please, consider reporting the bug."
+      ]
 
 -- | Inside this wrapper 'OrmoluException' will be caught and displayed
 -- nicely using 'displayException'.
@@ -56,10 +61,10 @@ withPrettyOrmoluExceptions m = m `catch` h
       exitWith . ExitFailure $
         case e of
           -- Error code 1 is for `error` or `notImplemented`
-          OrmoluCppEnabled -> 2
+          OrmoluCppEnabled _ -> 2
           OrmoluParsingFailed _ _ -> 3
           OrmoluOutputParsingFailed _ _ -> 4
-          OrmoluASTDiffers _ _ _ -> 5
+          OrmoluASTDiffers _ _ -> 5
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -69,6 +74,11 @@ withPrettyOrmoluExceptions m = m `catch` h
 showParsingErr :: String -> GHC.SrcSpan -> String -> String
 showParsingErr msg spn err = unlines
   [ msg
-  , showOutputable spn
-  , err
+  , withIndent (showOutputable spn)
+  , withIndent err
   ]
+
+-- | Indent with 2 spaces for readability.
+
+withIndent :: String -> String
+withIndent txt = "  " ++ txt

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -54,7 +54,7 @@ parseModule dynOpts path input' = liftIO $ do
   -- otherwise the exception will be wrapped as a GHC panic, which we don't
   -- want.
   when (GHC.xopt Cpp dynFlags) $
-   throwIO OrmoluCppEnabled
+   throwIO (OrmoluCppEnabled path)
   let r = case runParser GHC.parseModule dynFlags path input of
         GHC.PFailed _ ss m ->
           Left (ss, GHC.showSDoc dynFlags m)


### PR DESCRIPTION
Close #160.

TODO:

- [x] Filter out the bash script and nix files from Ormoul sources because their editing causes re-compilation of Ormolu. That's annoying. Perhaps we should just use a plain regexp instead of that gitignore magic.
- [x] Better organize the new nix code.
- [x] Improve error reporting in Ormolu. Any error reported by Ormolu should at least say which file is problematic. Also, do not show unhelpful spans in diff reporting, that's of no use.
