### PR TITLE
Handle multi-line case patterns

### DIFF
--- a/data/examples/declaration/value/function/pattern/multiline-case-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/multiline-case-pattern-out.hs
@@ -1,0 +1,12 @@
+readerBench doc name =
+  runPure $ case (getReader name, getWriter name) of
+    ( Right (TextReader r, rexts),
+      Right (TextWriter w, wexts)) -> undefined
+
+f xs = case xs of
+  [ a,
+    b] -> a + b
+
+g xs = case xs of
+  ( a :
+      bs) -> a + b

--- a/data/examples/declaration/value/function/pattern/multiline-case-pattern.hs
+++ b/data/examples/declaration/value/function/pattern/multiline-case-pattern.hs
@@ -1,0 +1,12 @@
+readerBench doc name =
+  runPure $ case (getReader name, getWriter name) of
+    (Right (TextReader r, rexts),
+     Right (TextWriter w, wexts)) -> undefined
+
+f xs = case xs of
+  [    a,
+   b       ] -> a + b
+
+g xs = case xs of
+  (a:
+    bs) -> a + b

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -27,6 +27,7 @@ module Ormolu.Printer.Combinators
   , velt
   , velt'
   , withSep
+  , withSep'
   , spaceSep
   , newlineSep
     -- ** Wrapping
@@ -174,7 +175,8 @@ velt xs = sequence_ (intersperse breakpoint' (sitcc <$> xs))
 velt' :: [R ()] -> R ()
 velt' xs = sitcc $ sequence_ (intersperse breakpoint (sitcc <$> xs))
 
--- | Put separator between renderings of items of a list.
+-- | Put separator between renderings of items of a list. (the separator is
+-- prepended to the elements)
 
 withSep
   :: R ()                       -- ^ Separator
@@ -186,6 +188,19 @@ withSep sep f = \case
   (x:xs) ->
     let g a = sep >> f a
     in f x : fmap g xs
+
+-- | Put separator between renderings of items of a list. (the separator is
+-- appended to the elements)
+
+withSep'
+  :: R ()                       -- ^ Separator
+  -> (a -> R ())                -- ^ How to render list items
+  -> [a]                        -- ^ List to render
+  -> [R ()]                     -- ^ List of printing actions
+withSep' sep f = \case
+  [] -> []
+  [x] -> [f x]
+  (x:xs) -> (f x >> sep) : withSep' sep f xs
 
 -- | Render space-separated elements.
 --


### PR DESCRIPTION
This PR closes #198

It turns out there are some weird parsing rules for patterns in `case` statements specifically.
From what I could figure out, tuples, lists and even infix constructors like `:` needs to have a symbol/operator on each line of the multi-line pattern match (but this is only necessary at the top level pattern, nested patterns can do the same as anywhere else).
I am not too what what the rationals for GHC is to have a special case here. Maybe something to make patterns unambiguous? I'll have to ask around.
In the meantime, I believe this PR fixes all these case pattern issues while keeping a style more or less consistent with what we already have.