### PR TITLE
Fix Record Pattern Synonyms

### DIFF
--- a/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
@@ -1,9 +1,23 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 
 pattern Arrow t1 t2 = App "->" [t1, t2]
 
+pattern Arrow {t1, t2} = App "->" [t1, t2]
+
+pattern Arrow
+  { t1,
+    t2
+    } =
+  App "->" [t1, t2]
+
 pattern Int =
   App "Int" []
+
+pattern Maybe {t} =
+  App
+    "Maybe"
+    [t]
 
 pattern Maybe t =
   App

--- a/data/examples/declaration/value/pattern-synonyms/bidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional.hs
@@ -1,8 +1,16 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 pattern Arrow t1 t2 = App "->"    [t1, t2]
+pattern Arrow{t1,t2} = App "->"    [t1,t2]
+pattern Arrow{t1
+             , t2} = App "->" [t1, t2]
 pattern Int         =
   App "Int"   []
+pattern Maybe{t}    =
+  App
+    "Maybe"
+    [t]
 pattern Maybe t     =
   App
     "Maybe"

--- a/data/examples/declaration/value/pattern-synonyms/unidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/unidirectional-out.hs
@@ -5,6 +5,18 @@ pattern Head x <- x : xs
 pattern Head' x <-
   x : xs
 
+pattern Head'' {x} <-
+  x : xs
+
+pattern FirstTwo {x, y} <-
+  x : (y : xs)
+
+pattern FirstTwo'
+  { x,
+    y
+    } <-
+  x : (y : xs)
+
 pattern Simple <- "Simple"
 
 pattern WithTypeSig :: String

--- a/data/examples/declaration/value/pattern-synonyms/unidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/unidirectional.hs
@@ -5,6 +5,15 @@ pattern Head x <- x:xs
 pattern Head' x
   <- x:xs
 
+pattern Head''{x}
+  <- x:xs
+
+pattern FirstTwo{x,y}
+  <- x : (y : xs)
+
+pattern FirstTwo'{x
+                 , y} <- x : (y:xs)
+
 pattern Simple <- "Simple"
 
 pattern WithTypeSig :: String


### PR DESCRIPTION
This fixes #191 about curly braces being removed when using record pattern synonyms.