### PR TITLE
Avoid failing when comments get before an operator

### DIFF
--- a/data/examples/declaration/value/other/comments-get-before-op-out.hs
+++ b/data/examples/declaration/value/other/comments-get-before-op-out.hs
@@ -1,0 +1,10 @@
+main :: IO ()
+main = do
+  migrateSchema
+    [ migration1,
+      migration1,
+      migration3
+      ] -- When adding migrations here, don't forget to update
+    -- 'schemaVersion' in Galley.Data
+    `finally`
+    Log.close

--- a/data/examples/declaration/value/other/comments-get-before-op.hs
+++ b/data/examples/declaration/value/other/comments-get-before-op.hs
@@ -1,0 +1,11 @@
+main :: IO ()
+main = do
+    migrateSchema
+        [ migration1
+        , migration1
+        , migration3
+        -- When adding migrations here, don't forget to update
+        -- 'schemaVersion' in Galley.Data
+        ]
+      `finally`
+        Log.close

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -453,7 +453,9 @@ p_hsExpr = \case
     let opWrapper = case unLoc op of
           EWildPat NoExt -> backticks
           _ -> id
-    located op (opWrapper . p_hsExpr)
+    -- NOTE Sometimes operator may be displaced from the line by comments,
+    -- it still should be more indented to remain valid code.
+    inci $ located op (opWrapper . p_hsExpr)
     let placement =
           -- NOTE If end of operator and start of second argument are on
           -- different lines, always use normal placement.


### PR DESCRIPTION
Close #174.

This puts out the fire, but I'm not fully content with the solution. I also do not understand why it fails in the original issue but succeeds for e.g.:

```haskell
foo = do
  1
  +
  2
```