### PR TITLE
Change formatting of the operators

### DIFF
--- a/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
@@ -31,8 +31,8 @@ foo
               w
               ) -> \u -> -- Procs can have lambdas
               let v =
-                    u ^ -- Actually never used
-                      2
+                    u -- Actually never used
+                      ^ 2
               in ( returnA -<
                      -- Just do the calculation
                      (x + y * z)
@@ -55,7 +55,7 @@ foo
           then ma -< ()
           else returnA -< ()
           returnA -<
-            ( i +
-                x *
-                y -- Just do the calculation
+            ( i
+                + x
+                * y -- Just do the calculation
               )

--- a/data/examples/declaration/value/function/arrow/proc-forms-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-forms-out.hs
@@ -9,15 +9,15 @@ foo1 f g h x =
 foo2 f g h x =
   proc (y, z) ->
     (| test
-         ( h f .
-             h g -<
-             y x .
-               y z
+         ( h f
+             . h g -<
+             y x
+               . y z
            )
-         ( h g .
-             h f -<
-             y z .
-               y x
+         ( h g
+             . h f -<
+             y z
+               . y x
            )
       |)
 
@@ -30,6 +30,6 @@ bar1 f g h x =
 bar2 f g h x =
   proc (y, z) ->
     (h f . h g) -<
-      (y x) . y z |||
-        (h g . h f) -<
+      (y x) . y z
+        ||| (h g . h f) -<
         y z . (y x)

--- a/data/examples/declaration/value/function/arrow/proc-ifs-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-ifs-out.hs
@@ -5,8 +5,8 @@ foo f = proc a -> if a then f -< 0 else f -< 1
 bar f g = proc a ->
   if f a
   then
-    f .
-      g -<
+    f
+      . g -<
       a
   else
     g -<

--- a/data/examples/declaration/value/function/arrow/proc-lets-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-lets-out.hs
@@ -4,9 +4,9 @@ foo f = proc a -> let b = a in f -< b
 
 bar f g = proc a ->
   let h =
-        f .
-          g a
+        f
+          . g a
       j =
-        g .
-          h
+        g
+          . h
   in id -< (h, j)

--- a/data/examples/declaration/value/function/case-multi-line-out.hs
+++ b/data/examples/declaration/value/function/case-multi-line-out.hs
@@ -26,8 +26,8 @@ withGuards x =
   case x of
     x
       | x > 10 ->
-        foo +
-          bar
+        foo
+          + bar
     x | x > 5 -> 10
     _ -> 20
 

--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -23,17 +23,16 @@ baz = do
   let d = c + 2
   return d
 
-quux =
-  something $ do
-    foo
-    case x of
-      1 -> 10
-      2 -> 20
-    bar
-    if something
-    then x
-    else y
-    baz
+quux = something $ do
+  foo
+  case x of
+    1 -> 10
+    2 -> 20
+  bar
+  if something
+  then x
+  else y
+  baz
 
 foo = do
   rec a <- b + 5
@@ -52,6 +51,29 @@ trickyLet = do
   foo
   let x = 5
    in bar x
+
+f = unFoo . foo bar baz 3 $ do
+  act
+  ret
+
+g = unFoo
+  . foo
+      bar
+      baz
+      3 $ do
+  act
+  ret
+
+main =
+  do
+    stuff
+    `finally` do
+      recover
+
+foo =
+  do
+    1
+    + 2
 
 -- single line let-where
 samples n f = do

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -52,6 +52,26 @@ trickyLet = do
   let x = 5
    in bar x
 
+f = unFoo . foo bar baz 3 $  do
+  act
+  ret
+
+g = unFoo . foo
+      bar
+      baz 3 $  do
+  act
+  ret
+
+main =
+  do stuff
+   `finally` do
+     recover
+
+foo = do
+    1
+    +
+    2
+
 -- single line let-where
 samples n f = do
     gen <- newQCGen

--- a/data/examples/declaration/value/function/guards-out.hs
+++ b/data/examples/declaration/value/function/guards-out.hs
@@ -6,11 +6,11 @@ foo x
 bar :: Int -> Int
 bar x
   | x == 5 =
-    foo x +
-      foo 10
+    foo x
+      + foo 10
   | x == 6 =
-    foo x +
-      foo 20
+    foo x
+      + foo 20
   | otherwise = foo 100
 
 baz :: Int -> Int

--- a/data/examples/declaration/value/function/if-multi-line-out.hs
+++ b/data/examples/declaration/value/function/if-multi-line-out.hs
@@ -8,8 +8,8 @@ bar :: Int -> Int
 bar x =
   if x > 5
   then
-    foo x +
-      100
+    foo x
+      + 100
   else
     case x of
       1 -> 10

--- a/data/examples/declaration/value/function/lambda-multi-line-out.hs
+++ b/data/examples/declaration/value/function/lambda-multi-line-out.hs
@@ -13,10 +13,10 @@ tricky0 =
     canUnify poly_given_ok wt gt || go False wt gt
 
 tricky1 =
-  flip all (zip ws gs) $
-    \(wt, gt) -> canUnify poly_given_ok wt gt || go False wt gt
+  flip all (zip ws gs)
+    $ \(wt, gt) -> canUnify poly_given_ok wt gt || go False wt gt
 
 tricky2 =
-  flip all (zip ws gs) $
-    \(wt, gt) ->
+  flip all (zip ws gs)
+    $ \(wt, gt) ->
       canUnify poly_given_ok wt gt || go False wt gt

--- a/data/examples/declaration/value/function/let-multi-line-out.hs
+++ b/data/examples/declaration/value/function/let-multi-line-out.hs
@@ -8,8 +8,8 @@ bar :: Int -> Int
 bar x =
   let z = y
       y = x
-   in z +
-        100
+   in z
+        + 100
 
 inlineComment :: Int -> Int
 inlineComment =

--- a/data/examples/declaration/value/function/list-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/list-comprehensions-out.hs
@@ -9,12 +9,12 @@ barbaz x y z w =
       b <- y, -- Baz
       any even [a, b],
       c <-
-        z *
-          z ^
-          2, -- Bar baz
+        z
+          * z
+          ^ 2, -- Bar baz
       d <-
-        w +
-          w, -- Baz bar
+        w
+          + w, -- Baz bar
       all
         even
         [ a,

--- a/data/examples/declaration/value/function/operators-out.hs
+++ b/data/examples/declaration/value/function/operators-out.hs
@@ -1,0 +1,41 @@
+foo = bar
+  ++ {- some comment -}
+  case foo of
+    a -> a
+
+main =
+  bar
+    $ baz -- bar
+    -- baz
+
+f =
+  Foo <$> bar
+    <*> baz
+
+update =
+  do
+    foobar
+    `catch` \case
+      a -> a
+
+foo =
+  do
+    1
+    + 2
+
+main =
+  do
+    stuff
+    `finally` do
+      recover
+
+lenses =
+  Just $ M.fromList
+    $ "type"
+    .= ("user.connection" :: Text)
+    # "connection"
+    .= uc
+    # "user" .= case name of
+    Just n -> Just $ object ["name" .= n]
+    Nothing -> Nothing
+    # []

--- a/data/examples/declaration/value/function/operators.hs
+++ b/data/examples/declaration/value/function/operators.hs
@@ -1,0 +1,36 @@
+foo = bar ++
+    {- some comment -}
+    case foo of
+      a -> a
+
+main =
+  bar $ -- bar
+    baz -- baz
+
+f =
+  Foo <$> bar
+      <*> baz
+
+update =
+    do
+      foobar
+    `catch` \case
+      a -> a
+
+foo = do
+    1
+    +
+    2
+
+main =
+  do stuff
+   `finally` do
+     recover
+
+lenses = Just $ M.fromList
+  $ "type"       .= ("user.connection" :: Text)
+  # "connection" .= uc
+  # "user"       .= case name of
+      Just  n -> Just $ object ["name" .= n]
+      Nothing -> Nothing
+  # []

--- a/data/examples/declaration/value/function/parallel-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/parallel-comprehensions-out.hs
@@ -18,20 +18,22 @@ baz x y z w =
         x, -- Foo 2
       b <- -- Bar 1
         y, -- Bar 2
-      a `mod`
-        b == -- Value
-        0
+      a
+        `mod` b -- Value
+        == 0
       | c <- -- Baz 1
-          z * -- Baz 2
-            z -- Baz 3
+          z
+            * z -- Baz 2
+            -- Baz 3
       | d <- w -- Other
       | e <- x * x -- Foo bar
       | f <- -- Foo baz 1
           y + y -- Foo baz 2
       | h <- z + z * w ^ 2 -- Bar foo
       | i <- -- Bar bar 1
-          a + -- Bar bar 2
-            b, -- Bar bar 3
+          a
+            + b, -- Bar bar 2
+            -- Bar bar 3
         j <- -- Bar baz 1
           a + b -- Bar baz 2
     ]

--- a/data/examples/declaration/value/function/pattern/splice-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/splice-pattern-out.hs
@@ -5,8 +5,8 @@ singleLine = case () of
   $(y "something") -> ()
 
 multiline = case () of
-  $( x +
-       y
+  $( x
+       + y
      ) -> ()
   $( y
        "something"

--- a/data/examples/declaration/value/function/transform-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/transform-comprehensions-out.hs
@@ -23,8 +23,8 @@ bar' xs ys =
       -- First comment
       then sortWith
       by
-        ( x +
-            y -- Second comment
+        ( x
+            + y -- Second comment
           )
     ]
 
@@ -50,8 +50,8 @@ quux' xs ys =
       y <- ys,
       -- First comment
       then group by
-        ( x +
-            y
+        ( x
+            + y
           )
       -- Second comment
       using groupWith -- Third comment

--- a/data/examples/declaration/value/other/comments-get-before-op-out.hs
+++ b/data/examples/declaration/value/other/comments-get-before-op-out.hs
@@ -4,7 +4,7 @@ main = do
     [ migration1,
       migration1,
       migration3
-      ] -- When adding migrations here, don't forget to update
+      ]
+    -- When adding migrations here, don't forget to update
     -- 'schemaVersion' in Galley.Data
-    `finally`
-    Log.close
+    `finally` Log.close

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ in {
   ormolu = haskellPackages.ormolu;
   ormolu-shell = haskellPackages.shellFor {
     packages = ps: [ ps.ormolu ];
-    buildInputs = [ pkgs.cabal-install ];
+    buildInputs = [ haskellPackages.cabal-install haskellPackages.ghcid ];
   };
   hackage = pkgs.lib.mapAttrs ormolize haskellPackages;
 }

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -78,13 +78,22 @@ spitFollowingComment
 spitFollowingComment (L ref a) mlastSpn = do
   mnSpn <- nextEltSpan
   meSpn <- getEnclosingSpan ref
+  newlineModified <- isNewlineModified
   i <- getIndent
   withPoppedComment (commentFollowsElt ref mnSpn meSpn mlastSpn) $ \l comment ->
     if theSameLine l ref && not (isModule a)
       then modNewline $ \m -> setIndent i $ do
-        spit " "
-        spitComment comment
-        m
+        if newlineModified
+          then do
+            -- This happens when we have several lines each with its own
+            -- comment and they get merged by the formatter.
+            m
+            spitComment comment
+            newline
+          else do
+            spit " "
+            spitComment comment
+            m
       else modNewline $ \m -> setIndent i $ do
         m
         when (needsNewlineBefore l mlastSpn) newline


### PR DESCRIPTION
Close #95, close #176, close #179 and close #207, close #220.

Currently, all tests are pasing except `declaration/value/function/parallel-comprehensions.hs`, where there is an issue about comment placement which makes the AST differ. The comment issue can be summarized as:

```haskell
-- before
main =
  bar $ -- bar
    baz -- baz

-- after
main =
  bar
    $ baz -- baz -- bar
```

Besides the comment issue, I also did not implement the special treatment of `do` notation yet, so currently the common idiom:

```haskell
foo $ do
  bar
  baz
```

now becomes:

```haskell
foo
  $ do
    bar
    baz
```

Which looks a bit unusual, but syntactically valid. Otherwise all looks reasonable to me. I tested a few major Hackage packages and couldn't find any introduced regressions and on the plus side now we can format `pandoc`.

I will work on fixing the `do` notation tomorrow, and take a look at the comment placement issue later on.