### PR TITLE
Fix printing of TH brackets

### DIFF
--- a/data/examples/declaration/data/gadt-syntax-out.hs
+++ b/data/examples/declaration/data/gadt-syntax-out.hs
@@ -1,3 +1,2 @@
 {-# LANUGAGE GADTSyntax #-}
-data Foo where
-  MKFoo :: a -> (a -> Bool) -> Foo
+data Foo where MKFoo :: a -> (a -> Bool) -> Foo

--- a/data/examples/declaration/splice/bracket-out.hs
+++ b/data/examples/declaration/splice/bracket-out.hs
@@ -2,23 +2,22 @@
 
 foo =
   [e|
-  foo bar
-  |]
+    foo bar
+    |]
 
 foo =
   [e|
-  foo bar
-  |]
+    foo bar
+    |]
 
 foo = [t|Char|]
 
 foo =
   [d|
-  foo :: Int -> Char
+    foo :: Int -> Char
 
-  bar = 42
-
-  |]
+    bar = 42
+    |]
 
 foo =
   [||

--- a/data/examples/declaration/splice/splice-decl-out.hs
+++ b/data/examples/declaration/splice/splice-decl-out.hs
@@ -15,3 +15,21 @@ foo bar
 -- TemplateHaskell allows Q () at the top level
 do
   pure []
+
+$(do [d|baz = baz|])
+
+[d|data T a where Foo :: T ()|]
+
+[d|
+  data T = T
+    deriving (Eq, Ord, Enum, Bounded, Show)
+  |]
+
+$(singletons [d|data T = T deriving (Eq, Ord, Enum, Bounded, Show)|])
+
+$( singletons
+     [d|
+       data T = T
+         deriving (Eq, Ord, Enum, Bounded, Show)
+       |]
+   )

--- a/data/examples/declaration/splice/splice-decl.hs
+++ b/data/examples/declaration/splice/splice-decl.hs
@@ -15,3 +15,20 @@ foo bar
 -- TemplateHaskell allows Q () at the top level
 do
   pure []
+
+$( do [d| baz = baz |] )
+
+[d| data T a where Foo :: T () |]
+
+[d|
+    data T = T
+      deriving (Eq, Ord, Enum, Bounded, Show)
+  |]
+
+$(singletons [d| data T = T deriving (Eq, Ord, Enum, Bounded, Show) |])
+
+$(singletons [d|
+  data T = T
+    deriving (Eq, Ord, Enum, Bounded, Show)
+ |])
+

--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -65,8 +65,7 @@ g = unFoo
   ret
 
 main =
-  do
-    stuff
+  do stuff
     `finally` do
       recover
 

--- a/data/examples/declaration/value/function/operators-out.hs
+++ b/data/examples/declaration/value/function/operators-out.hs
@@ -24,8 +24,7 @@ foo =
     + 2
 
 main =
-  do
-    stuff
+  do stuff
     `finally` do
       recover
 

--- a/data/examples/declaration/warning/warning-multiline-out.hs
+++ b/data/examples/declaration/warning/warning-multiline-out.hs
@@ -5,5 +5,6 @@
     "Really bad!"
     ]
   #-}
+
 test :: IO ()
 test = pure ()

--- a/data/examples/declaration/warning/warning-single-line-out.hs
+++ b/data/examples/declaration/warning/warning-single-line-out.hs
@@ -1,4 +1,5 @@
-{-# WARNING test "This is a warning" #-}
 {-# DEPRECATED test, foo "This is a deprecation" #-}
+
+{-# WARNING test "This is a warning" #-}
 test :: IO ()
 test = pure ()

--- a/data/examples/declaration/warning/warning-single-line.hs
+++ b/data/examples/declaration/warning/warning-single-line.hs
@@ -1,5 +1,5 @@
-{-# WARNING test    ["This is a warning" ] #-}
 {-# Deprecated test, foo "This is a deprecation"
   #-}
+{-# WARNING test    ["This is a warning" ] #-}
 test :: IO ()
 test = pure ()

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -37,9 +37,9 @@ p_hsDecls style decls =
     case md of
       Nothing -> located d pDecl
       Just d' ->
-        if separatedDecls (unLoc d) (unLoc d')
-          then line (located d pDecl)
-          else located d pDecl
+        line $ if separatedDecls (unLoc d) (unLoc d')
+               then line (located d pDecl)
+               else located d pDecl
   where
     pDecl = p_hsDecl style
 
@@ -118,6 +118,7 @@ isPragma = \case
   SCCPragma n -> Just n
   AnnTypePragma n -> Just n
   AnnValuePragma n -> Just n
+  WarningPragma n -> Just n
   _ -> Nothing
 
 pattern TypeSignature
@@ -128,7 +129,8 @@ pattern TypeSignature
       , AnnTypePragma
       , AnnValuePragma
       , PatternSignature
-      , Pattern :: RdrName -> HsDecl GhcPs
+      , Pattern
+      , WarningPragma  :: RdrName -> HsDecl GhcPs
 pattern TypeSignature n <- (sigRdrName -> Just n)
 pattern FunctionBody n <- ValD NoExt (FunBind NoExt (L _ n) _ _ _)
 pattern InlinePragma n <- SigD NoExt (InlineSig NoExt (L _ n) _)
@@ -138,6 +140,7 @@ pattern AnnTypePragma n <- AnnD NoExt (HsAnnotation NoExt _ (TypeAnnProvenance (
 pattern AnnValuePragma n <- AnnD NoExt (HsAnnotation NoExt _ (ValueAnnProvenance (L _ n)) _)
 pattern PatternSignature n <- SigD NoExt (PatSynSig NoExt ((L _ n):_) _)
 pattern Pattern n <- ValD NoExt (PatSynBind NoExt (PSB _ (L _ n) _ _ _))
+pattern WarningPragma n <- WarningD NoExt (Warnings NoExt _ [(L _ (Warning NoExt [(L _ n)] _))])
 
 sigRdrName :: HsDecl GhcPs -> Maybe RdrName
 sigRdrName (SigD NoExt (TypeSig NoExt ((L _ n):_) _)) = Just n

--- a/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
@@ -14,7 +14,7 @@ import Ormolu.Utils
 
 p_annDecl :: AnnDecl GhcPs -> R ()
 p_annDecl = \case
-  HsAnnotation NoExt _ annProv expr -> line . pragma "ANN" . inci $ do
+  HsAnnotation NoExt _ annProv expr -> pragma "ANN" . inci $ do
     p_annProv annProv
     breakpoint
     located expr p_hsExpr

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -64,13 +64,11 @@ p_classDecl ctx name tvars fixity fdeps csigs cdefs cats catdefs = do
         ) <$> catdefs
       allDecls =
         snd <$> sortBy (comparing fst) (sigs <> vals <> tyFams <> tyFamDefs)
-  if not (null allDecls)
-  then do
+  unless (null allDecls) $ do
     txt " where"
     newline -- Ensure line is added after where clause.
     newline -- Add newline before first declaration.
     inci (p_hsDecls Associated allDecls)
-  else newline
 
 p_classContext :: LHsContext GhcPs -> R ()
 p_classContext ctx = unless (null (unLoc ctx)) $ do

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -51,7 +51,7 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
     if gadt
       then do
         txt " where"
-        newline
+        breakpoint
         inci . sitcc $ sep newline (sitcc . located' p_conDecl) dd_cons
       else switchLayout (getLoc name : (getLoc <$> dd_cons)) $
         inci $ do
@@ -59,9 +59,10 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
           txt "= "
           let s = vlayout (txt " | ") (newline >> txt "| ")
           sep s (sitcc . located' p_conDecl) dd_cons
-  newline
-  inci . located dd_derivs $ \xs ->
-    forM_ xs (line . located' p_hsDerivingClause)
+
+  unless (null $ unLoc dd_derivs) breakpoint
+  inci . located dd_derivs $ \xs -> do
+    sep newline (located' p_hsDerivingClause) xs
 p_dataDecl _ _ _ _ (XHsDataDefn NoExt) = notImplemented "XHsDataDefn"
 
 p_conDecl :: ConDecl GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Default.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Default.hs
@@ -13,7 +13,7 @@ import Ormolu.Utils
 
 p_defaultDecl :: DefaultDecl GhcPs -> R ()
 p_defaultDecl = \case
-  DefaultDecl NoExt ts -> line $ do
+  DefaultDecl NoExt ts -> do
     txt "default"
     breakpoint
     inci . parens . sitcc $

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -19,10 +19,10 @@ import Ormolu.Utils
 
 p_foreignDecl :: ForeignDecl GhcPs -> R ()
 p_foreignDecl = \case
-  fd@ForeignImport {fd_fi} -> line $ do
+  fd@ForeignImport {fd_fi} -> do
     p_foreignImport fd_fi
     p_foreignTypeSig fd
-  fd@ForeignExport {fd_fe} -> line $ do
+  fd@ForeignExport {fd_fe} -> do
     p_foreignExport fd_fe
     p_foreignTypeSig fd
   XForeignDecl {} -> notImplemented "XForeignDecl"

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -14,6 +14,7 @@ where
 
 import BasicTypes
 import Control.Arrow
+import Control.Monad
 import Data.Foldable
 import Data.List (sortBy)
 import Data.Ord (comparing)
@@ -59,7 +60,6 @@ p_standaloneDerivDecl DerivDecl {..} = do
         instTypes True
       ViaStrategy (XHsImplicitBndrs NoExt) ->
         notImplemented "XHsImplicitBndrs"
-  newline
 p_standaloneDerivDecl (XDerivDecl _) = notImplemented "XDerivDecl"
 
 p_clsInstDecl :: ClsInstDecl GhcPs -> R ()
@@ -87,15 +87,13 @@ p_clsInstDecl = \case
             allDecls =
               snd <$>
                 sortBy (comparing fst) (sigs <> vals <> tyFamInsts <> dataFamInsts)
-        if null allDecls
-          then newline
-          else do
-            switchLayout [getLoc hsib_body] breakpoint
-            inci $ do
-              txt "where"
-              newline -- Ensure line is added after where clause.
-              newline -- Add newline before first declaration.
-              p_hsDecls Associated allDecls
+        unless (null allDecls) $ do
+          switchLayout [getLoc hsib_body] breakpoint
+          inci $ do
+            txt "where"
+            newline -- Ensure line is added after where clause.
+            newline -- Add newline before first declaration.
+            p_hsDecls Associated allDecls
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
   XClsInstDecl NoExt -> notImplemented "XClsInstDecl"
 
@@ -107,7 +105,6 @@ p_tyFamInstDecl style = \case
       Free -> "type instance"
     breakpoint
     inci (p_tyFamInstEqn tfid_eqn)
-    newline
 
 p_dataFamInstDecl :: FamilyStyle -> DataFamInstDecl GhcPs -> R ()
 p_dataFamInstDecl style = \case

--- a/src/Ormolu/Printer/Meat/Declaration/RoleAnnotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/RoleAnnotation.hs
@@ -24,7 +24,7 @@ p_roleAnnot = \case
   XRoleAnnotDecl _ -> notImplemented "XRoleAnnotDecl"
 
 p_roleAnnot' :: Located RdrName -> [Located (Maybe Role)] -> R ()
-p_roleAnnot' l_name anns = line $ do
+p_roleAnnot' l_name anns = do
   txt "type role"
   breakpoint
   inci $ do

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -20,7 +20,7 @@ import qualified Data.Text as T
 
 p_ruleDecls :: RuleDecls GhcPs -> R ()
 p_ruleDecls = \case
-  HsRules NoExt _ xs -> line . pragma "RULES" . sitcc $
+  HsRules NoExt _ xs -> pragma "RULES" . sitcc $
     sep breakpoint (sitcc . located' p_ruleDecl) xs
   XRuleDecls NoExt -> notImplemented "XRuleDecls"
 

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -6,7 +6,6 @@
 
 module Ormolu.Printer.Meat.Declaration.Signature
   ( p_sigDecl
-  , p_sigDecl'
   , p_typeAscription
   , p_activation
   , visibleActivation
@@ -23,10 +22,7 @@ import Ormolu.Printer.Meat.Type
 import Ormolu.Utils
 
 p_sigDecl :: Sig GhcPs -> R ()
-p_sigDecl = line . p_sigDecl'
-
-p_sigDecl' :: Sig GhcPs -> R ()
-p_sigDecl' = \case
+p_sigDecl = \case
   TypeSig NoExt names hswc -> p_typeSig names hswc
   PatSynSig NoExt names hsib -> p_patSynSig names hsib
   ClassOpSig NoExt def names hsib -> p_classOpSig def names hsib

--- a/src/Ormolu/Printer/Meat/Declaration/Splice.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Splice.hs
@@ -12,5 +12,5 @@ import Ormolu.Utils
 
 p_spliceDecl :: SpliceDecl GhcPs -> R ()
 p_spliceDecl = \case
-  SpliceDecl NoExt splice _explicit -> line $ located splice p_hsSplice
+  SpliceDecl NoExt splice _explicit -> located splice p_hsSplice
   XSpliceDecl {} -> notImplemented "XSpliceDecl"

--- a/src/Ormolu/Printer/Meat/Declaration/Type.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Type.hs
@@ -21,7 +21,7 @@ p_synDecl
   -> LHsQTyVars GhcPs           -- ^ Type variables
   -> LHsType GhcPs              -- ^ RHS of type declaration
   -> R ()
-p_synDecl name tvars t = line $ do
+p_synDecl name tvars t = do
   txt "type "
   p_rdrName name
   let HsQTvs {..} = tvars

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -46,14 +46,14 @@ p_famDecl style FamilyDecl {..} = do
       when (isJust rsig && isJust fdInjectivityAnn) breakpoint
       forM_ fdInjectivityAnn (located' p_injectivityAnn)
   case mmeqs of
-    Nothing -> newline
+    Nothing -> return ()
     Just meqs -> do
       txt " where"
       case meqs of
-        Nothing -> txt " .." >> newline
+        Nothing -> txt " .."
         Just eqs -> do
           newline
-          forM_ eqs (located' (line . inci . p_tyFamInstEqn))
+          sep newline (located' (inci . p_tyFamInstEqn)) eqs
 p_famDecl _ (XFamilyDecl NoExt) = notImplemented "XFamilyDecl"
 
 p_familyResultSigL

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -54,6 +54,7 @@ p_hsModule exts (L moduleSpan HsModule {..}) = do
     forM_ (sortImports hsmodImports) (located' p_hsmodImport)
     when (hasImports && hasDecls) newline
     p_hsDecls Free hsmodDecls
+    when hasDecls newline
     trailingComments <- hasMoreComments
     when (trailingComments && hasModuleHeader) newline
     spitRemainingComments


### PR DESCRIPTION
Close #196

The actual solution was simply indenting the closing `|]` one more level. However there were a few more issues around them, which led me to a slightly bigger refactor.

The main reason is that, all `p_*Decl` functions used to print a trailing newline. This makes sense for top-level constructs, however it was making printing something like `[d|data Foo = Foo|]` impossible.

In this PR, I removed trailing newlines from individual printers and gave that responsibility to `p_hsDecls`, and inserted an additional trailing newline when printing modules.

While doing that, I noticed a few bugs/inconsistencies, and I had to fix them in the process:

* Warning pragmas used to not print a trailing newline, so they were always attached to the next expression. I made it more like the other pragmas, where we attach it to a neighbour function if the name matches, otherwise we separate it with a newline.
* We used to print single line GADT's and single line `do` notations using multiple lines, which breaks idempotency on some cases (formatting an already formatted output can give a different result). I tweak them to prefer single line layout if possible (sometimes it is not possible because of the semicolon syntax).