### PR TITLE
Tweak formatting of warning pragmas

### DIFF
--- a/data/examples/declaration/warning/warning-single-line-out.hs
+++ b/data/examples/declaration/warning/warning-single-line-out.hs
@@ -3,3 +3,9 @@
 {-# WARNING test "This is a warning" #-}
 test :: IO ()
 test = pure ()
+
+bar = 3
+{-# DEPRECATED bar "Bar is deprecated" #-}
+
+{-# DEPRECATED baz "Baz is also deprecated" #-}
+baz = 5

--- a/data/examples/declaration/warning/warning-single-line.hs
+++ b/data/examples/declaration/warning/warning-single-line.hs
@@ -3,3 +3,11 @@
 {-# WARNING test    ["This is a warning" ] #-}
 test :: IO ()
 test = pure ()
+
+bar = 3
+
+{-# Deprecated bar "Bar is deprecated" #-}
+
+{-# DEPRECATED baz "Baz is also deprecated" #-}
+baz = 5
+

--- a/data/examples/module-header/warning-pragma-multiline-out.hs
+++ b/data/examples/module-header/warning-pragma-multiline-out.hs
@@ -1,4 +1,5 @@
-module Test {-# DEPRECATED "This module is unstable" #-}
+module Test
+  {-# DEPRECATED "This module is unstable" #-}
   ( foo,
     bar,
     baz

--- a/data/examples/module-header/warning-pragma-out.hs
+++ b/data/examples/module-header/warning-pragma-out.hs
@@ -1,1 +1,3 @@
-module Test {-# WARNING "This module is very internal" #-} where
+module Test
+  {-# WARNING "This module is very internal" #-}
+where

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -103,6 +103,7 @@ separatedDecls
   -> HsDecl GhcPs
   -> Bool
 separatedDecls (TypeSignature n) (FunctionBody n') = n /= n'
+separatedDecls x (FunctionBody n) | Just n' <- isPragma x = n /= n'
 separatedDecls (FunctionBody n) x | Just n' <- isPragma x = n /= n'
 separatedDecls x y | Just n <- isPragma x, Just n' <- isPragma y = n /= n'
 separatedDecls x (TypeSignature n') | Just n <- isPragma x = n /= n'

--- a/src/Ormolu/Printer/Meat/Declaration/Warning.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Warning.hs
@@ -29,7 +29,6 @@ p_moduleWarning :: WarningTxt -> R ()
 p_moduleWarning wtxt = do
   let (pragmaText, lits) = warningText wtxt
   switchLayout (getLoc <$> lits) $ do
-    breakpoint
     inci $ pragma pragmaText (inci $ p_lits lits)
 
 p_topLevelWarning :: [Located RdrName] -> WarningTxt -> R ()


### PR DESCRIPTION
Closes #262 .

Just tweak the layout handling on module header a bit, and a minor fix on the part where we decide if we should separate two declarations.