### PR TITLE
Handle semicolons

### DIFF
--- a/data/examples/declaration/class/associated-data-out.hs
+++ b/data/examples/declaration/class/associated-data-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-class Foo a where
-
-  data FooBar a
+class Foo a where data FooBar a
 
 -- | Something.
 class Bar a where

--- a/data/examples/declaration/class/associated-type-defaults-out.hs
+++ b/data/examples/declaration/class/associated-type-defaults-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-class Foo a where
-
-  type FooBar a = Int
+class Foo a where type FooBar a = Int
 
 -- | Something.
 class Bar a where

--- a/data/examples/declaration/class/associated-types-out.hs
+++ b/data/examples/declaration/class/associated-types-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-class Foo a where
-
-  type FooBar a
+class Foo a where type FooBar a
 
 -- | Something.
 class Bar a where

--- a/data/examples/declaration/class/functional-dependencies-out.hs
+++ b/data/examples/declaration/class/functional-dependencies-out.hs
@@ -3,9 +3,7 @@
 -- | Something.
 class Foo a b | a -> b
 
-class Bar a b | a -> b, b -> a where
-
-  bar :: a
+class Bar a b | a -> b, b -> a where bar :: a
 
 -- | Something else.
 class

--- a/data/examples/declaration/class/multi-parameters-out.hs
+++ b/data/examples/declaration/class/multi-parameters-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-class Foo a b where
-
-  foo :: a -> b
+class Foo a b where foo :: a -> b
 
 -- | Something.
 class Bar a b c d where

--- a/data/examples/declaration/class/single-parameters-out.hs
+++ b/data/examples/declaration/class/single-parameters-out.hs
@@ -1,7 +1,5 @@
 -- | Something.
-class Foo a where
-
-  foo :: a
+class Foo a where foo :: a
 
 -- | Something more.
 class Bar a where

--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-instance Foo Int where
-
-  data Bar Int = IntBar Int Int
+instance Foo Int where data Bar Int = IntBar Int Int
 
 instance Foo Double where
 

--- a/data/examples/declaration/instance/associated-types-out.hs
+++ b/data/examples/declaration/instance/associated-types-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-instance Foo Int where
-
-  type Bar Int = Double
+instance Foo Int where type Bar Int = Double
 
 instance Foo Double where
 

--- a/data/examples/declaration/instance/contexts-out.hs
+++ b/data/examples/declaration/instance/contexts-out.hs
@@ -1,6 +1,4 @@
-instance Eq a => Eq [a] where
-
-  (==) _ _ = False
+instance Eq a => Eq [a] where (==) _ _ = False
 
 instance
   ( Ord a,

--- a/data/examples/declaration/instance/multi-parameter-out.hs
+++ b/data/examples/declaration/instance/multi-parameter-out.hs
@@ -1,6 +1,4 @@
-instance MonadReader a ((->) a) where
-
-  ask = id
+instance MonadReader a ((->) a) where ask = id
 
 instance MonadState s (State s) where
 

--- a/data/examples/declaration/instance/overlappable-instances-out.hs
+++ b/data/examples/declaration/instance/overlappable-instances-out.hs
@@ -1,6 +1,4 @@
-instance {-# OVERLAPPABLE #-} Eq Int where
-
-  (==) _ _ = False
+instance {-# OVERLAPPABLE #-} Eq Int where (==) _ _ = False
 
 instance {-# OVERLAPPING #-} Ord Int where
 

--- a/data/examples/declaration/instance/single-parameter-out.hs
+++ b/data/examples/declaration/instance/single-parameter-out.hs
@@ -1,6 +1,4 @@
-instance Monoid Int where
-
-  (<>) x y = x + y
+instance Monoid Int where (<>) x y = x + y
 
 instance Enum Int where
 
@@ -9,3 +7,5 @@ instance Enum Int where
   toEnum =
     \x ->
       x
+
+instance Foo Int where foo x = x; bar y = y

--- a/data/examples/declaration/instance/single-parameter.hs
+++ b/data/examples/declaration/instance/single-parameter.hs
@@ -6,3 +6,5 @@ instance Enum Int
     toEnum
       = \x ->
         x
+
+instance Foo Int where { foo x = x; bar y = y }

--- a/data/examples/declaration/value/function/case-single-line-out.hs
+++ b/data/examples/declaration/value/function/case-single-line-out.hs
@@ -1,2 +1,7 @@
 foo :: Int -> Int
 foo x = case x of x -> x
+
+foo :: IO ()
+foo = case [1] of [_] -> "singleton"; _ -> "not singleton"
+
+foo = case [1] of { [] -> foo; _ -> bar } `finally` baz

--- a/data/examples/declaration/value/function/case-single-line.hs
+++ b/data/examples/declaration/value/function/case-single-line.hs
@@ -1,2 +1,6 @@
 foo :: Int -> Int
 foo x = case x of x -> x
+
+foo :: IO ()
+foo = case [1] of [_] -> "singleton"; _ -> "not singleton"
+foo = case [1] of { [] -> foo; _ -> bar } `finally` baz

--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE RecursiveDo #-}
 
-bar = do
-  foo
-  bar
+bar = do foo; bar
 
 baz =
   mdo
@@ -60,14 +58,21 @@ g = unFoo
   . foo
       bar
       baz
-      3 $ do
-  act
-  ret
+      3
+  $ do
+    act
+    ret
 
 main =
   do stuff
     `finally` do
       recover
+
+main = do stuff `finally` recover
+
+main = do { stuff } `finally` recover
+
+foo = do do { foo; bar }; baz
 
 foo =
   do
@@ -77,5 +82,30 @@ foo =
 -- single line let-where
 samples n f = do
   gen <- newQCGen
-  let rands g = g1 : rands g2 where (g1, g2) = split g
+  let rands g = g1 : rands g2 where { (g1, g2) = split g }
   return $ rands gen
+
+main = do bar
+
+main = do bar; baz
+
+main = do
+  bar
+  baz
+
+main = do
+  a <- bar
+  let a = b; c = d
+  baz d
+  let e = f
+      g = h
+  return c
+
+readInClause = do
+  do
+    lookAhead g_Do
+    parseNote ErrorC 1063 "You need a line feed or semicolon before the 'do'."
+    <|> do
+      optional g_Semi
+      void allspacing
+  return things

--- a/data/examples/declaration/value/function/do.hs
+++ b/data/examples/declaration/value/function/do.hs
@@ -67,6 +67,12 @@ main =
    `finally` do
      recover
 
+main = do stuff `finally` recover
+
+main = do { stuff  } `finally` recover
+
+foo = do { do {foo; bar}; baz }
+
 foo = do
     1
     +
@@ -77,3 +83,29 @@ samples n f = do
     gen <- newQCGen
     let rands g = g1 : rands g2 where (g1, g2) = split g
     return $ rands gen
+
+main = do bar
+main = do { bar; baz }
+main = do { bar
+          ; baz
+          }
+
+main = do
+  a <- bar
+  let a = b; c = d
+  baz d
+  let e = f
+      g = h
+  return c
+
+readInClause = do
+    do {
+        lookAhead g_Do;
+        parseNote ErrorC 1063 "You need a line feed or semicolon before the 'do'.";
+    } <|> do {
+        optional g_Semi;
+        void allspacing;
+    }
+
+    return things
+

--- a/data/examples/declaration/value/function/lambda-multi-line-out.hs
+++ b/data/examples/declaration/value/function/lambda-multi-line-out.hs
@@ -20,3 +20,8 @@ tricky2 =
   flip all (zip ws gs)
     $ \(wt, gt) ->
       canUnify poly_given_ok wt gt || go False wt gt
+
+foo =
+  prop "is inverse to closure" $ \(f :: StaticPtr (Int -> Int))
+  (x :: Int) ->
+      (unclosure . closure) f x == deRefStaticPtr f x

--- a/data/examples/declaration/value/function/lambda-multi-line.hs
+++ b/data/examples/declaration/value/function/lambda-multi-line.hs
@@ -20,3 +20,9 @@ tricky2 =
   flip all (zip ws gs) $
   \(wt, gt) ->
     canUnify poly_given_ok wt gt || go False wt gt
+
+foo =
+  prop "is inverse to closure" $ \(f :: StaticPtr (Int -> Int))
+                                  (x :: Int) ->
+    (unclosure . closure) f x == deRefStaticPtr f x
+

--- a/data/examples/declaration/value/function/let-single-line-out.hs
+++ b/data/examples/declaration/value/function/let-single-line-out.hs
@@ -1,3 +1,9 @@
 foo :: a -> a
 foo x = let x = x in x
-foo x = let x = z where z = 2 in x
+foo x = let x = z where { z = 2 } in x
+foo x = let x = z where { z = 2 }; a = 3 in x
+foo x = let g :: Int -> Int; g = id in ()
+
+let a = b; c = do { foo; bar }; d = baz in b
+
+let a = case True of { True -> foo; False -> bar }; b = foo a in b

--- a/data/examples/declaration/value/function/let-single-line.hs
+++ b/data/examples/declaration/value/function/let-single-line.hs
@@ -1,3 +1,8 @@
 foo :: a -> a
 foo x = let x = x in x
 foo x = let x = z where z = 2 in x
+foo x = let x = z where { z = 2; }; a = 3 in x
+foo x = let {g :: Int -> Int; g = id} in ()
+let a = b; c = do { foo; bar }; d = baz in b
+let a = case True of { True -> foo; False -> bar }; b = foo a in b
+

--- a/data/examples/declaration/value/function/operators-out.hs
+++ b/data/examples/declaration/value/function/operators-out.hs
@@ -33,7 +33,8 @@ lenses =
     .= ("user.connection" :: Text)
     # "connection"
     .= uc
-    # "user" .= case name of
-    Just n -> Just $ object ["name" .= n]
-    Nothing -> Nothing
+    # "user"
+    .= case name of
+      Just n -> Just $ object ["name" .= n]
+      Nothing -> Nothing
     # []

--- a/data/examples/declaration/value/function/pattern/pattern-bind-out.hs
+++ b/data/examples/declaration/value/function/pattern/pattern-bind-out.hs
@@ -1,6 +1,9 @@
-foo :: Int
 foo = bar
   where
     Foo bar baz = quux
     Baz
       quux = zoo
+
+foo = bar
+  where
+    Foo bar baz = quux

--- a/data/examples/declaration/value/function/pattern/pattern-bind.hs
+++ b/data/examples/declaration/value/function/pattern/pattern-bind.hs
@@ -1,6 +1,9 @@
-foo :: Int
 foo = bar
   where
     Foo bar baz = quux
     Baz
       quux = zoo
+
+foo = bar
+  where Foo bar baz = quux
+

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -66,8 +66,8 @@ p_classDecl ctx name tvars fixity fdeps csigs cdefs cats catdefs = do
         snd <$> sortBy (comparing fst) (sigs <> vals <> tyFams <> tyFamDefs)
   unless (null allDecls) $ do
     txt " where"
-    newline -- Ensure line is added after where clause.
-    newline -- Add newline before first declaration.
+    breakpoint -- Ensure whitespace is added after where clause.
+    breakpoint' -- Add newline before first declaration.
     inci (p_hsDecls Associated allDecls)
 
 p_classContext :: LHsContext GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -52,7 +52,7 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
       then do
         txt " where"
         breakpoint
-        inci . sitcc $ sep newline (sitcc . located' p_conDecl) dd_cons
+        inci $ sepSemi (located' p_conDecl) dd_cons
       else switchLayout (getLoc name : (getLoc <$> dd_cons)) $
         inci $ do
           breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -67,11 +67,7 @@ p_clsInstDecl = \case
   ClsInstDecl {..} -> do
     txt "instance"
     case cid_poly_ty of
-      HsIB {..} -> located hsib_body $ \x -> do
-        breakpoint
-        inci $ do
-          match_overlap_mode cid_overlap_mode breakpoint
-          p_hsType x
+      HsIB {..} -> do
         -- GHC's AST does not necessarily store each kind of element in source
         -- location order. This happens because different declarations are stored in
         -- different lists. Consequently, to get all the declarations in proper
@@ -87,13 +83,19 @@ p_clsInstDecl = \case
             allDecls =
               snd <$>
                 sortBy (comparing fst) (sigs <> vals <> tyFamInsts <> dataFamInsts)
-        unless (null allDecls) $ do
-          switchLayout [getLoc hsib_body] breakpoint
+        located hsib_body $ \x -> do
+          breakpoint
           inci $ do
-            txt "where"
-            newline -- Ensure line is added after where clause.
-            newline -- Add newline before first declaration.
-            p_hsDecls Associated allDecls
+            match_overlap_mode cid_overlap_mode breakpoint
+            p_hsType x
+            unless (null allDecls) $ do
+              breakpoint
+              txt "where"
+        unless (null allDecls) $ do
+          inci $ do
+            breakpoint -- Ensure whitespace is added after where clause.
+            breakpoint' -- Add newline before first declaration
+            dontUseBraces $ p_hsDecls Associated allDecls
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
   XClsInstDecl NoExt -> notImplemented "XClsInstDecl"
 

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -57,14 +57,15 @@ p_hsModule pragmas (L moduleSpan HsModule {..}) = do
         when (hasImports || hasDecls) newline
     forM_ (sortImports hsmodImports) (located' p_hsmodImport)
     when (hasImports && hasDecls) newline
-    p_hsDecls Free hsmodDecls
-    trailingComments <- hasMoreComments
-    when hasDecls $ do
-      newlineModified <- isNewlineModified
-      newline
-      -- In this case we need to insert a newline between the comments
-      -- output as a side effect of the previous newline and trailing
-      -- comments to prevent them from merging.
-      when (newlineModified && trailingComments) newline
-    when (trailingComments && hasModuleHeader) newline
-    spitRemainingComments
+    switchLayout (map getLoc hsmodDecls) $ do
+      p_hsDecls Free hsmodDecls
+      trailingComments <- hasMoreComments
+      when hasDecls $ do
+        newlineModified <- isNewlineModified
+        newline
+        -- In this case we need to insert a newline between the comments
+        -- output as a side effect of the previous newline and trailing
+        -- comments to prevent them from merging.
+        when (newlineModified && trailingComments) newline
+      when (trailingComments && hasModuleHeader) newline
+      spitRemainingComments


### PR DESCRIPTION
Close #152, #189, #258.

This PR adds a `p_layout` combinator which uses semicolon-separated layout on single line constructs, and indentation based layout on multi line constructs. I implemented some common constructs like `do` and `let` using the new combinator, and they can now properly handle semicolons; however there is still some more work remaining to use it on all. In the end, we should be able to remove the `newline` combinator (should be either replaced by `breakpoint`, or by `p_layout`).

Also, currently this PR uses an inherently incorrect approach when deciding when to omit braces. So, we sometimes use braces unnecessarily (`do { foo }`), and there are probably some edge cases we will format incorrectly (I couldn't figure out an example).

Current test-cases are passing alongside with the issues #152 and #189, and we can now format `aeson` and almost `lens` (there is another issue regarding exporting pattern synonyms).