### PR TITLE
Fix TH quoting of operators

### DIFF
--- a/data/examples/declaration/splice/quotes-out.hs
+++ b/data/examples/declaration/splice/quotes-out.hs
@@ -2,9 +2,13 @@ foo = ''R
 
 bar = 'foo
 
+bar' = 'foo_bar
+
 baz = ''(:#)
 
 baz' = ''(Foo.Bar.:#)
+
+equals = ''(==)
 
 unit = ''()
 

--- a/data/examples/declaration/splice/quotes.hs
+++ b/data/examples/declaration/splice/quotes.hs
@@ -2,9 +2,13 @@ foo = ''R
 
 bar = 'foo
 
+bar' = 'foo_bar
+
 baz = ''(:#)
 
 baz' = ''(Foo.Bar.:#)
+
+equals = ''(==)
 
 unit = ''()
 

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -15,7 +15,7 @@ import Bag (bagToList)
 import BasicTypes
 import Control.Monad
 import Data.Bool (bool)
-import Data.Char (isPunctuation)
+import Data.Char (isPunctuation, isSymbol)
 import Data.Data hiding (Infix, Prefix)
 import Data.List (intersperse, sortOn)
 import Data.Text (Text)
@@ -843,8 +843,10 @@ p_hsBracket = \case
     -- turn makes it impossible to detect if there are parentheses around
     -- it, etc. So we have to add parentheses manually assuming they are
     -- necessary for all operators.
-    let isOperator = any isPunctuation (showOutputable (rdrNameOcc name))
-          && not (doesNotNeedExtraParens name)
+    let isOperator = all
+                        (\i -> isPunctuation i || isSymbol i)
+                        (showOutputable (rdrNameOcc name))
+                     && not (doesNotNeedExtraParens name)
         wrapper = if isOperator then parens else id
     wrapper $ p_rdrName (noLoc name)
   TExpBr NoExt expr -> do


### PR DESCRIPTION
closes #275 .

1. Haskell Reports [says that](https://www.haskell.org/onlinereport/haskell2010/haskellch2.html) any unicode symbol or punctuation can be used as operators, so I added `isSymbol` to the `isOperator`. This fixed the issue of not recognising `==` as an operator.

2. I modified `isOperator`'s definition so that it requires all characters to be an operator. This fixed the issue of recognising `foo_bar` as an operator.