### PR TITLE
Support inline specs inside specialize pragmas

### DIFF
--- a/data/examples/declaration/signature/specialize/specialize-out.hs
+++ b/data/examples/declaration/signature/specialize/specialize-out.hs
@@ -1,9 +1,9 @@
 foo :: Num a => a -> a
 foo = id
 {-# SPECIALIZE foo :: Int -> Int #-}
-{-# SPECIALIZE foo :: Float -> Float #-}
+{-# SPECIALIZE INLINE foo :: Float -> Float #-}
 
-{-# SPECIALIZE [2] bar :: Int -> Int #-}
+{-# SPECIALIZE NOINLINE [2] bar :: Int -> Int #-}
 bar :: Num a => a -> a
 bar = id
 

--- a/data/examples/declaration/signature/specialize/specialize.hs
+++ b/data/examples/declaration/signature/specialize/specialize.hs
@@ -2,9 +2,9 @@ foo :: Num a => a -> a
 foo = id
 
 {-# SPECIALIZE foo :: Int -> Int #-}
-{-# SPECIALIZE foo :: Float -> Float #-}
+{-# SPECIALIZE INLINE foo :: Float -> Float #-}
 
-{-# SPECIALIZE [2] bar :: Int -> Int #-}
+{-# SPECIALIZE NOINLINE [2] bar :: Int -> Int #-}
 
 bar :: Num a => a -> a
 bar = id

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -97,11 +97,7 @@ p_inlineSig
   -> InlinePragma               -- ^ Inline pragma specification
   -> R ()
 p_inlineSig name InlinePragma {..} = pragmaBraces $ do
-  txt $ case inl_inline of
-    Inline -> "INLINE "
-    Inlinable -> "INLINEABLE "
-    NoInline -> "NOINLINE "
-    NoUserInline -> notImplemented "NoUserInline"
+  p_inlineSpec inl_inline
   case inl_rule of
     ConLike -> txt "CONLIKE "
     FunLike -> return ()
@@ -117,6 +113,7 @@ p_specSig
 p_specSig name ts InlinePragma {..} = pragmaBraces $ do
   txt "SPECIALIZE"
   space
+  p_inlineSpec inl_inline
   p_activation inl_act
   when (visibleActivation inl_act) space
   p_rdrName name
@@ -124,6 +121,13 @@ p_specSig name ts InlinePragma {..} = pragmaBraces $ do
   inci $ do
     txt ":: "
     sep (comma >> breakpoint) (located' p_hsType . hsib_body) ts
+
+p_inlineSpec :: InlineSpec -> R ()
+p_inlineSpec = txt . \case
+  Inline -> "INLINE "
+  Inlinable -> "INLINEABLE "
+  NoInline -> "NOINLINE "
+  NoUserInline -> ""
 
 p_activation :: Activation -> R ()
 p_activation = \case


### PR DESCRIPTION
This PR makes `SPECIALIZE` pragma's render `InlineSpec`'s, like:

```haskell
{-# SPECIALIZE INLINE mapTCMT :: () #-}
```