### PR TITLE
Fix printing of the rewrite rule names

### DIFF
--- a/data/examples/declaration/rewrite-rule/basic-out.hs
+++ b/data/examples/declaration/rewrite-rule/basic-out.hs
@@ -27,3 +27,9 @@
 "concat" xs `concat` ys = augment (\c n -> foldr c n xs) ys
 "map/Double" fmap f xs = foldr (++) f xs
   #-}
+
+{-# RULES
+"fb' >\\ (Request b' fb )" forall fb' b' fb.
+  fb' >\\ (Request b' fb) =
+    fb' b' >>= \b -> fb' >\\ fb b
+  #-}

--- a/data/examples/declaration/rewrite-rule/basic.hs
+++ b/data/examples/declaration/rewrite-rule/basic.hs
@@ -25,3 +25,9 @@
 "concat" xs `concat` ys = augment (\c n -> foldr c n xs) ys;
 "map/Double" fmap f xs = foldr (++) f xs
   #-}
+
+{-# RULES
+    "fb' >\\ (Request b' fb )" forall fb' b' fb  .
+        fb' >\\ (Request b' fb ) = fb' b' >>= \b -> fb' >\\ fb  b;
+#-}
+

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -9,14 +9,12 @@ where
 
 import BasicTypes
 import Control.Monad
-import FastString (unpackFS)
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration.Signature
 import Ormolu.Printer.Meat.Declaration.Value
 import Ormolu.Utils
-import qualified Data.Text as T
 
 p_ruleDecls :: RuleDecls GhcPs -> R ()
 p_ruleDecls = \case
@@ -43,10 +41,7 @@ p_ruleDecl = \case
   XRuleDecl NoExt -> notImplemented "XRuleDecl"
 
 p_ruleName :: (SourceText, RuleName) -> R ()
-p_ruleName (_, name) = do
-  txt "\""
-  txt $ T.pack $ unpackFS $ name
-  txt "\""
+p_ruleName (_, name) = atom $ HsString NoSourceText name
 
 p_ruleBndrs :: [LRuleBndr GhcPs] -> R ()
 p_ruleBndrs [] = return ()


### PR DESCRIPTION
Closes #279 .

It looks like rewrite rule names are parsed exactly as string literals. Therefore, `\` is used as escape character, and we have to unescape it when printing.

Instead of manually unescaping it, I just print it as a string literal. Another way would be to just use SourceText, but this one feels nicer to me.