### PR TITLE
Correctly format when adding annotations to types

### DIFF
--- a/data/examples/declaration/annotation/annotation-out.hs
+++ b/data/examples/declaration/annotation/annotation-out.hs
@@ -17,4 +17,5 @@ foo = 5
   #-}
 
 data Foo = Foo Int
+{-# ANN type Foo ("HLint: ignore") #-}
 {- Comment -}

--- a/data/examples/declaration/annotation/annotation.hs
+++ b/data/examples/declaration/annotation/annotation.hs
@@ -15,4 +15,6 @@ foo = 5
 
 data Foo = Foo Int
 
+{-# ANN type Foo ("HLint: ignore") #-}
+
 {- Comment -}

--- a/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
@@ -23,5 +23,5 @@ p_annDecl = \case
 p_annProv :: AnnProvenance (IdP GhcPs) -> R ()
 p_annProv = \case
   ValueAnnProvenance name -> p_rdrName name
-  TypeAnnProvenance name -> p_rdrName name
+  TypeAnnProvenance name -> txt "type " >> p_rdrName name
   ModuleAnnProvenance -> txt "module"


### PR DESCRIPTION
Close #278.

GHC grammar [says](https://github.com/ghc/ghc/blob/284a2f44666c88616c9f4426e566014f8685669c/compiler/parser/Parser.y#L1776) that we need to use the "type" keyword when attaching annotations to types.