### PR TITLE
Implement implicit parameter bindings

### DIFF
--- a/data/examples/declaration/value/function/let-multi-line-out.hs
+++ b/data/examples/declaration/value/function/let-multi-line-out.hs
@@ -16,3 +16,8 @@ inlineComment =
   let {- join -} go = case () of
                    () -> undefined
    in go
+
+implicitParams :: HasCallStack => Int
+implicitParams =
+  let ?cs = ?callstack
+   in foo cs

--- a/data/examples/declaration/value/function/let-multi-line.hs
+++ b/data/examples/declaration/value/function/let-multi-line.hs
@@ -16,3 +16,8 @@ inlineComment =
   let {- join -} go = case () of
                    () -> undefined
   in go
+
+implicitParams :: HasCallStack => Int
+implicitParams =
+  let ?cs = ?callstack
+  in  foo cs

--- a/data/examples/declaration/value/function/let-single-line-out.hs
+++ b/data/examples/declaration/value/function/let-single-line-out.hs
@@ -7,3 +7,5 @@ foo x = let g :: Int -> Int; g = id in ()
 let a = b; c = do { foo; bar }; d = baz in b
 
 let a = case True of { True -> foo; False -> bar }; b = foo a in b
+
+foo x = let ?g = id; ?f = g in x

--- a/data/examples/declaration/value/function/let-single-line.hs
+++ b/data/examples/declaration/value/function/let-single-line.hs
@@ -5,4 +5,4 @@ foo x = let x = z where { z = 2; }; a = 3 in x
 foo x = let {g :: Int -> Int; g = id} in ()
 let a = b; c = do { foo; bar }; d = baz in b
 let a = case True of { True -> foo; False -> bar }; b = foo a in b
-
+foo x = let {?g = id; ?f = g} in x

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -414,7 +414,16 @@ p_hsLocalBinds = \case
         p_item (Right x) = located x p_sigDecl
     sitcc $ sepSemi (useBraces . p_item) (sortOn ssStart items)
   HsValBinds NoExt _ -> notImplemented "HsValBinds"
-  HsIPBinds NoExt _ -> notImplemented "HsIPBinds"
+  HsIPBinds NoExt (IPBinds NoExt xs) ->
+    -- Second argument of IPBind is always Left before type-checking.
+    let p_ipBind (IPBind NoExt (Left name) expr) = do
+          atom name
+          txt " ="
+          breakpoint
+          dontUseBraces $ inci $ located expr p_hsExpr
+        p_ipBind _ = notImplemented "XHsIPBinds"
+     in sepSemi (located' p_ipBind) xs
+  HsIPBinds NoExt _ -> notImplemented "HsIpBinds"
   EmptyLocalBinds NoExt -> return ()
   XHsLocalBindsLR _ -> notImplemented "XHsLocalBindsLR"
 


### PR DESCRIPTION
Closes: #276 .

This PR implements implicit parameter bindings. eg.

```
let ?a = b
in  foo
```

This PR is based on #271, so we should wait until that is merged. You can look at the [last commit](https://github.com/tweag/ormolu/pull/293/commits/0592786527e0f4c25cf0252048a0402776cef258) to see the changes.