### PR TITLE
Print multiline comments without changing the contents

### DIFF
--- a/data/examples/declaration/value/function/operators-out.hs
+++ b/data/examples/declaration/value/function/operators-out.hs
@@ -7,6 +7,11 @@ main =
     $ baz -- bar
     -- baz
 
+bar
+  $ {- foo
+     -}
+  bar
+
 f =
   Foo <$> bar
     <*> baz

--- a/data/examples/declaration/value/function/operators.hs
+++ b/data/examples/declaration/value/function/operators.hs
@@ -6,6 +6,11 @@ main =
   bar $ -- bar
     baz -- baz
 
+bar $
+  {- foo
+   -}
+  bar
+
 f =
   Foo <$> bar
       <*> baz

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -221,6 +221,6 @@ commentFollowsElt ref mnSpn meSpn mlastSpn (L l comment) =
 
 spitComment :: Comment -> R ()
 spitComment =
-  sequence_ . NE.intersperse newline . fmap f . coerce
+  sitcc . sequence_ . NE.intersperse newline . fmap f . coerce
   where
     f x = ensureIndent >> spit (T.pack x)


### PR DESCRIPTION
Closes #294 .

It looks like changing the relative position of the closing brace can cause whitespace changes.