### PR TITLE
Try to contain comments inside enclosing contructs

### DIFF
--- a/data/examples/declaration/rewrite-rule/prelude-out.hs
+++ b/data/examples/declaration/rewrite-rule/prelude-out.hs
@@ -63,10 +63,10 @@
 "unpack" [~1] forall a. unpackCString# a = build (unpackFoldrCString# a)
 "unpack-list" [1] forall a. unpackFoldrCString# a (:) [] = unpackCString# a
 "unpack-append" forall a n. unpackFoldrCString# a (:) n = unpackAppendCString# a n
-  #-}
-
 -- There's a built-in rule (in PrelRules.lhs) for
 --      unpackFoldr "foo" c (unpackFoldr "baz" c n)  =  unpackFoldr "foobaz" c n
+  #-}
+
 {-# RULES
 "foldr/build" forall f n (g :: forall b. (a -> b -> b) -> b -> b).
   foldr f n (build g) =

--- a/data/examples/declaration/value/other/comments-get-before-op-out.hs
+++ b/data/examples/declaration/value/other/comments-get-before-op-out.hs
@@ -4,7 +4,7 @@ main = do
     [ migration1,
       migration1,
       migration3
+      -- When adding migrations here, don't forget to update
+      -- 'schemaVersion' in Galley.Data
       ]
-    -- When adding migrations here, don't forget to update
-    -- 'schemaVersion' in Galley.Data
     `finally` Log.close

--- a/data/examples/other/comment-inside-construct-out.hs
+++ b/data/examples/other/comment-inside-construct-out.hs
@@ -1,0 +1,8 @@
+xs =
+  [ outer list item,
+    [ inner list first item,
+      inner list second item
+      -- inner list last item commented
+      ],
+    outer list item
+    ]

--- a/data/examples/other/comment-inside-construct.hs
+++ b/data/examples/other/comment-inside-construct.hs
@@ -1,0 +1,9 @@
+xs =
+  [ outer list item,
+    [ inner list first item,
+      inner list second item
+      -- inner list last item commented
+    ],
+    outer list item
+  ]
+


### PR DESCRIPTION
Closes #295 .

In this PR, I try to attach the comment if the next element is not a sibling. I think this is quite often what we want, since if we put a comment inside a construct, we prefer it to stay inside the same element.