### PR TITLE
Dedent parallel list comprehensions by one step

### DIFF
--- a/data/examples/declaration/value/function/parallel-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/parallel-comprehensions-out.hs
@@ -21,19 +21,19 @@ baz x y z w =
       a
         `mod` b -- Value
         == 0
-      | c <- -- Baz 1
-          z
-            * z -- Baz 2
-            -- Baz 3
-      | d <- w -- Other
-      | e <- x * x -- Foo bar
-      | f <- -- Foo baz 1
-          y + y -- Foo baz 2
-      | h <- z + z * w ^ 2 -- Bar foo
-      | i <- -- Bar bar 1
-          a
-            + b, -- Bar bar 2
-            -- Bar bar 3
-        j <- -- Bar baz 1
-          a + b -- Bar baz 2
+    | c <- -- Baz 1
+        z
+          * z -- Baz 2
+          -- Baz 3
+    | d <- w -- Other
+    | e <- x * x -- Foo bar
+    | f <- -- Foo baz 1
+        y + y -- Foo baz 2
+    | h <- z + z * w ^ 2 -- Bar foo
+    | i <- -- Bar bar 1
+        a
+          + b, -- Bar bar 2
+          -- Bar bar 3
+      j <- -- Bar baz 1
+        a + b -- Bar baz 2
     ]

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -563,7 +563,7 @@ p_hsExpr = \case
           ub <- vlayout (return useBraces) (return id)
           inci $ sepSemi (located' (ub . p_stmt)) (unLoc es)
         compBody = brackets $ located es $ \xs -> do
-          let p_parBody = sitcc . sep
+          let p_parBody = sep
                 (breakpoint >> txt "| ")
                 p_seqBody
               p_seqBody = sitcc . sep


### PR DESCRIPTION
Close #301.

This pull request removes indentation of the '|' character in parallel list comprehensions by one layer, as specified in #301. Said indentation was caused by a use of `sitcc` which, when removed, aligns things properly.

A comment is also added to document this in case anyone later wonders why one expression uses `sitcc` and the other does not.