### PR TITLE
Use new operator style in types & declarations

### DIFF
--- a/data/examples/declaration/class/type-operators-out.hs
+++ b/data/examples/declaration/class/type-operators-out.hs
@@ -11,25 +11,33 @@ class
 class a :* b
 
 class
-  a :+ -- Before operator
-    b -- After operator
+  a -- Before operator
+    :+ b -- After operator
 
 class
-  ( f :.
-      g
+  ( f
+      :. g
     )
     a
 
 class a `Pair` b
 
 class
-  a `Sum`
-    b
+  a
+    `Sum` b
 
 class (f `Product` g) a
 
 class
-  ( f `Sum`
-      g
+  ( f
+      `Sum` g
     )
     a
+
+type API
+  = "route1" :> ApiRoute1
+      :<|> "route2"
+      :> ApiRoute2 -- comment here
+      :<|> OmitDocs
+      :> "i"
+      :> ASomething API

--- a/data/examples/declaration/class/type-operators.hs
+++ b/data/examples/declaration/class/type-operators.hs
@@ -30,3 +30,10 @@ class (f`Product`g)a
 class (
     f `Sum` g
   ) a
+
+type API
+  = "route1" :> ApiRoute1
+      :<|> "route2" :> ApiRoute2 -- comment here
+      :<|> OmitDocs :> "i" :> ASomething API
+
+

--- a/data/examples/declaration/data/multiline-names-out.hs
+++ b/data/examples/declaration/data/multiline-names-out.hs
@@ -9,8 +9,8 @@ data a :-> b = Arrow (a -> b)
 data (f :* g) a = f a :* g a
 
 data
-  ( f :+
-      g
+  ( f
+      :+ g
     )
     a
   = L (f a)
@@ -21,8 +21,8 @@ data a `Arrow` b = Arrow' (a -> b)
 data (f `Product` g) a = f a `Product` g a
 
 data
-  ( f `Sum`
-      g
+  ( f
+      `Sum` g
     )
     a
   = L' (f a)

--- a/data/examples/declaration/value/function/infix-out.hs
+++ b/data/examples/declaration/value/function/infix-out.hs
@@ -8,5 +8,5 @@ bar :: Int -> Int -> Int -> Int
 (x `bar` y) z = z
 
 multiline :: Int -> Int -> Int
-x `multiline`
-  y = z
+x
+  `multiline` y = z

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -124,10 +124,11 @@ p_infixDefHelper isInfix inci' name args =
               else parens
       parens' $ do
         p0
-        space
-        name
         breakpoint
-        inci' p1
+        inci $ sitcc $ do
+          name
+          space
+          p1
       unless (null ps) . inci' $ do
         breakpoint
         sitcc (sep breakpoint sitcc ps)


### PR DESCRIPTION
Closes #259 .

This changes the type-level infix operators on infix operators on pattern matches use the new style (newline after the operator instead of before).

This slightly makes the Servant-like signatures a bit more bearable, and makes the type-level and value-level code look more alike (example from #171):

```haskell
type API
  = "sso" :> APISSO
      :<|> "sso-initiate-bind"
      :> APIAuthReq
      :<|> "identity-providers"
      :> APIIDP
      :<|> "scim"
      :> APIScim
      :<|> OmitDocs
      :> "i"
      :> APIINTERNAL

-- value level equivalent
api =
  "sso" :> APISSO
    :<|> "sso-initiate-bind"
    :> APIAuthReq
    :<|> "identity-providers"
    :> APIIDP
    :<|> "scim"
    :> APIScim
    :<|> OmitDocs
    :> "i"
    :> APIINTERNAL
```