### PR TITLE
Hang after block arguments

### DIFF
--- a/data/examples/declaration/value/function/block-arguments-out.hs
+++ b/data/examples/declaration/value/function/block-arguments-out.hs
@@ -1,0 +1,24 @@
+f1 = foo do bar
+
+f2 =
+  foo do
+    bar
+
+f3 =
+  foo case True of
+    True -> bar
+    False -> baz
+
+f4 = foo let a = 3 in b
+
+f5 =
+  foo
+    let a = 3
+        b = a
+     in b
+
+f6 =
+  foo
+    if bar
+    then baz
+    else not baz

--- a/data/examples/declaration/value/function/block-arguments.hs
+++ b/data/examples/declaration/value/function/block-arguments.hs
@@ -1,0 +1,18 @@
+f1 = foo do bar
+
+f2 = foo do
+  bar
+
+f3 = foo case True of
+  True -> bar
+  False -> baz
+
+f4 = foo let a = 3 in b
+
+f5 = foo let a = 3
+             b = a
+          in b
+
+f6 = foo if bar
+         then baz
+         else not baz

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -459,8 +459,9 @@ p_hsExpr = \case
     inci (p_matchGroup LambdaCase mgroup)
   HsApp NoExt f x -> sitcc $ do
     located f p_hsExpr
-    breakpoint
-    inci (located x p_hsExpr)
+    -- Second argument can be a `do` or `case` block with `-XBlockArguments`.
+    placeHanging (exprPlacement (unLoc x)) $
+      located x p_hsExpr
   HsAppType a e -> do
     located e p_hsExpr
     breakpoint


### PR DESCRIPTION
Closes #241 .

When the value of the function application has a hanging form (can happen after `-XBlockArguments`), hang the construct.