### PR TITLE
Preserve the name of the expression bracket

### DIFF
--- a/data/examples/declaration/splice/bracket-out.hs
+++ b/data/examples/declaration/splice/bracket-out.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 foo =
-  [e|
+  [|
     foo bar
     |]
 

--- a/data/examples/declaration/splice/splice-decl-out.hs
+++ b/data/examples/declaration/splice/splice-decl-out.hs
@@ -10,7 +10,7 @@ $$foo
 
 foo bar
 
-[e|booya|]
+[|booya|]
 
 -- TemplateHaskell allows Q () at the top level
 do

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -10,6 +10,8 @@ module Ormolu.Printer.Combinators
   ( -- * The 'R' monad
     R
   , runR
+  , getAnns
+  , getEnclosingSpan
     -- * Combinators
     -- ** Basic
   , txt
@@ -25,6 +27,7 @@ module Ormolu.Printer.Combinators
     -- ** Formatting lists
   , sep
   , sepSemi
+  , canUseBraces
   , useBraces
   , dontUseBraces
     -- ** Wrapping

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -8,6 +8,7 @@ module Ormolu.Printer.Comments
   ( spitPrecedingComments
   , spitFollowingComments
   , spitRemainingComments
+  , isNewlineModified
   , hasMoreComments
   )
 where
@@ -77,7 +78,9 @@ spitFollowingComment
   -> R (Maybe RealSrcSpan)      -- ^ Location of this comment
 spitFollowingComment (L ref a) mlastSpn = do
   mnSpn <- nextEltSpan
-  meSpn <- getEnclosingSpan ref
+  -- Get first enclosing span that is not equal to reference span, i.e. it's
+  -- truly something enclosing the AST element.
+  meSpn <- getEnclosingSpan (/= ref)
   newlineModified <- isNewlineModified
   i <- getIndent
   withPoppedComment (commentFollowsElt ref mnSpn meSpn mlastSpn) $ \l comment ->

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -76,7 +76,7 @@ data RC = RC
   , rcDebug :: Bool
     -- ^ Whether to print debugging info as we go
   , rcEnclosingSpans :: [RealSrcSpan]
-    -- ^ Span of enclosing element of AST
+    -- ^ Spans of enclosing elements of AST
   , rcAnns :: Anns
     -- ^ Collection of annotations
   , rcCanUseBraces :: Bool
@@ -326,11 +326,13 @@ setIndent i m' = do
   R (local modRC m)
   traceR "set_indent_after" Nothing
 
--- | Get 'RealSrcSpan' of enclosing span for given referencne span.
+-- | Get the first enclosing 'RealSrcSpan' that satisfies given predicate.
 
-getEnclosingSpan :: RealSrcSpan -> R (Maybe RealSrcSpan)
-getEnclosingSpan r =
-  listToMaybe . dropWhile (== r) <$> R (asks rcEnclosingSpans)
+getEnclosingSpan
+  :: (RealSrcSpan -> Bool)      -- ^ Predicate to use
+  -> R (Maybe RealSrcSpan)
+getEnclosingSpan f =
+  listToMaybe . filter f <$> R (asks rcEnclosingSpans)
 
 -- | Set 'RealSrcSpan' of enclosing span for the given computation.
 

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -20,7 +20,6 @@ import GHC hiding (GhcPs, IE)
 import Name (nameStableString)
 import OccName (OccName (..))
 import Ormolu.Printer.Combinators
-import Ormolu.Printer.Internal (getAnns)
 import RdrName (RdrName (..))
 
 -- | Data and type family style.

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -16,7 +16,6 @@ import Ormolu.Imports
 import Ormolu.Parser.Pragma
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Comments
-import Ormolu.Printer.Internal (isNewlineModified)
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration
 import Ormolu.Printer.Meat.Declaration.Warning


### PR DESCRIPTION
Close #203 .

Both `[e|...|]` and `[||]` mean the same thing, and instead of sticking to a single style, we can just preserve what user wrote.