### PR TITLE
Implement --check-idempotency flag

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -137,6 +137,11 @@ configParser = Config
     , short 'p'
     , help "Do not fail if CPP pragma is present"
     ]
+  <*> (switch . mconcat)
+    [ long "check-idempotency"
+    , short 'c'
+    , help "Fail if formatting is not idempotent."
+    ]
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/nix/ormolize/ormolize.sh
+++ b/nix/ormolize/ormolize.sh
@@ -13,4 +13,5 @@ mv "$1-nocpp" "$1"
 cp "$1" "$1-original"
 
 # run ormolu
-ormolu --tolerate-cpp --mode inplace "$1" || ormolu --tolerate-cpp --unsafe --mode inplace "$1"
+ormolu --tolerate-cpp --check-idempotency --mode inplace "$1" ||
+  ormolu --tolerate-cpp --unsafe --mode inplace "$1"

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -27,6 +27,8 @@ data Config = Config
     -- ^ Do not fail if CPP pragma is present (still doesn't handle CPP but
     -- useful for formatting of files that enable the extension without
     -- actually containing CPP macros)
+  , cfgCheckIdempotency :: !Bool
+    -- ^ Checks if re-formatting the result is idempotent.
   } deriving (Eq, Show)
 
 -- | Default 'Config'.
@@ -37,6 +39,7 @@ defaultConfig = Config
   , cfgUnsafe = False
   , cfgDebug = False
   , cfgTolerateCpp = False
+  , cfgCheckIdempotency = False
   }
 
 -- | A wrapper for dynamic options.

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -12,7 +12,9 @@ import Control.Exception
 import Ormolu.Utils (showOutputable)
 import System.Exit (ExitCode (..), exitWith)
 import System.IO
+import Data.Text (Text)
 import qualified GHC
+import qualified Outputable as GHC
 
 -- | Ormolu exception representing all cases when Ormolu can fail.
 
@@ -25,6 +27,8 @@ data OrmoluException
     -- ^ Parsing of formatted source code failed
   | OrmoluASTDiffers FilePath [GHC.SrcSpan]
     -- ^ Original and resulting ASTs differ
+  | OrmoluNonIdempotentOutput GHC.RealSrcLoc Text Text
+    -- ^ Formatted source code is not idempotent
   deriving (Eq, Show)
 
 instance Exception OrmoluException where
@@ -34,9 +38,9 @@ instance Exception OrmoluException where
       , withIndent path
       ]
     OrmoluParsingFailed s e ->
-      showParsingErr "Parsing of source code failed:" s e
+      showParsingErr "Parsing of source code failed:" s [e]
     OrmoluOutputParsingFailed s e ->
-      showParsingErr "Parsing of formatted code failed:" s e ++
+      showParsingErr "Parsing of formatted code failed:" s [e] ++
         "Please, consider reporting the bug.\n"
     OrmoluASTDiffers path ss -> unlines $
       [ "AST of input and AST of formatted code differ."
@@ -44,8 +48,12 @@ instance Exception OrmoluException where
       ++ (fmap withIndent $ case fmap (\s -> "at " ++ showOutputable s) ss of
            [] -> ["in " ++ path]
            xs -> xs) ++
-      [ "Please, consider reporting the bug."
-      ]
+      [ "Please, consider reporting the bug." ]
+    OrmoluNonIdempotentOutput loc left right ->
+      showParsingErr "Formatting is not idempotent:" loc
+        [ "before: " ++ show left , "after:  " ++ show right ]
+        ++ "Please, consider reporting the bug.\n"
+
 
 -- | Inside this wrapper 'OrmoluException' will be caught and displayed
 -- nicely using 'displayException'.
@@ -65,18 +73,18 @@ withPrettyOrmoluExceptions m = m `catch` h
           OrmoluParsingFailed _ _ -> 3
           OrmoluOutputParsingFailed _ _ -> 4
           OrmoluASTDiffers _ _ -> 5
+          OrmoluNonIdempotentOutput _ _ _ -> 6
 
 ----------------------------------------------------------------------------
 -- Helpers
 
 -- | Show a parse error.
 
-showParsingErr :: String -> GHC.SrcSpan -> String -> String
-showParsingErr msg spn err = unlines
+showParsingErr :: GHC.Outputable a => String -> a -> [String] -> String
+showParsingErr msg spn err = unlines $
   [ msg
   , withIndent (showOutputable spn)
-  , withIndent err
-  ]
+  ] ++ map withIndent err
 
 -- | Indent with 2 spaces for readability.
 


### PR DESCRIPTION
Closes #274 .

This PR adds a new command line flag called "--check-idempotency" which formats the output again and checks if the output is exactly the same as the first pass.

In order to get nicer error messages, I also added a simple support for showing where the errors differ on the error messages. Here is an example error message:

```
Formatting is not idempotent:
  test/Tests/Writers/RST.hs<rendered>:106:13
  before: "       =: -- pandoc "
  after:  "       =: strong (sp"
Please, consider reporting the bug.
```

I checked a few packages and it looks like most of the issues are about newlines or comment placement.