### PR TITLE
Indent ‘then’ and ‘else’ clauses one level further

### DIFF
--- a/data/examples/declaration/value/function/block-arguments-out.hs
+++ b/data/examples/declaration/value/function/block-arguments-out.hs
@@ -20,8 +20,8 @@ f5 =
 f6 =
   foo
     if bar
-    then baz
-    else not baz
+      then baz
+      else not baz
 
 f7 = foo \x -> y
 

--- a/data/examples/declaration/value/function/case-multi-line-out.hs
+++ b/data/examples/declaration/value/function/case-multi-line-out.hs
@@ -8,8 +8,8 @@ bar x =
   case x of
     5 ->
       if x > 5
-      then 10
-      else 12
+        then 10
+        else 12
     _ -> 12
 
 baz :: Int -> Int

--- a/data/examples/declaration/value/function/do-out.hs
+++ b/data/examples/declaration/value/function/do-out.hs
@@ -28,8 +28,8 @@ quux = something $ do
     2 -> 20
   bar
   if something
-  then x
-  else y
+    then x
+    else y
   baz
 
 foo = do

--- a/data/examples/declaration/value/function/if-multi-line-out.hs
+++ b/data/examples/declaration/value/function/if-multi-line-out.hs
@@ -1,16 +1,16 @@
 foo :: Int -> Int
 foo x =
   if x > 5
-  then 10
-  else 12
+    then 10
+    else 12
 
 bar :: Int -> Int
 bar x =
   if x > 5
-  then
-    foo x
-      + 100
-  else
-    case x of
-      1 -> 10
-      _ -> 20
+    then
+      foo x
+        + 100
+    else
+      case x of
+        1 -> 10
+        _ -> 20

--- a/data/examples/declaration/value/function/lambda-multi-line-out.hs
+++ b/data/examples/declaration/value/function/lambda-multi-line-out.hs
@@ -5,8 +5,8 @@ foo x = \y ->
 bar :: Int -> Int -> Int
 bar x = \y ->
   if x > y
-  then 10
-  else 12
+    then 10
+    else 12
 
 tricky0 =
   flip all (zip ws gs) $ \(wt, gt) ->

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -538,15 +538,16 @@ p_hsExpr = \case
     txt "if "
     located if' p_hsExpr
     breakpoint
-    txt "then"
-    located then' $ \x -> do
+    inci $ do
+      txt "then"
+      located then' $ \x -> do
+        breakpoint
+        inci (p_hsExpr x)
       breakpoint
-      inci (p_hsExpr x)
-    breakpoint
-    txt "else"
-    located else' $ \x -> do
-      breakpoint
-      inci (p_hsExpr x)
+      txt "else"
+      located else' $ \x -> do
+        breakpoint
+        inci (p_hsExpr x)
   HsMultiIf NoExt guards -> do
     txt "if"
     breakpoint


### PR DESCRIPTION
Close #299.

This arguably improves readability especially when if-then-else is placed inside of a `do`-block.

Argumentation for choosing this style is that I like it more than the alternatives.