### PR TITLE
Hang expressions in if-then-else

### DIFF
--- a/data/examples/declaration/value/function/if-multi-line-out.hs
+++ b/data/examples/declaration/value/function/if-multi-line-out.hs
@@ -10,7 +10,14 @@ bar x =
     then
       foo x
         + 100
-    else
-      case x of
-        1 -> 10
-        _ -> 20
+    else case x of
+      1 -> 10
+      _ -> 20
+
+baz :: Int -> Bar
+baz x =
+  if x > 5
+    then \case
+      Foo -> bar
+    else do
+      undefined

--- a/data/examples/declaration/value/function/if-multi-line.hs
+++ b/data/examples/declaration/value/function/if-multi-line.hs
@@ -10,3 +10,13 @@ bar x =
   else case x of
          1 -> 10
          _ -> 20
+
+baz :: Int -> Bar
+baz x =
+  if x > 5
+  then
+    \case
+      Foo -> bar
+  else
+    do
+      undefined

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -540,14 +540,12 @@ p_hsExpr = \case
     breakpoint
     inci $ do
       txt "then"
-      located then' $ \x -> do
-        breakpoint
-        inci (p_hsExpr x)
+      located then' $ \x ->
+        placeHanging (exprPlacement x) (p_hsExpr x)
       breakpoint
       txt "else"
-      located else' $ \x -> do
-        breakpoint
-        inci (p_hsExpr x)
+      located else' $ \x ->
+        placeHanging (exprPlacement x) (p_hsExpr x)
   HsMultiIf NoExt guards -> do
     txt "if"
     breakpoint


### PR DESCRIPTION
Closes #316.

This PR hangs expressions in if-then-else expressions. eg.

```
if gen == gen0 && newlen <= cap0
  then do
    let newgen = gen + 1
    marr <- unsafeThaw arr0
    writeGen marr newgen
    A.copyI marr (off0 + len0) arr1 off1 (off0 + newlen)
    arr2 <- A.unsafeFreeze marr
    return (Buf arr2 off0 newlen cap0 newgen)
  else do
    let newcap = newlen * 2
        newgen = 1
    marr <- A.new (newcap + woff)
    writeGen marr newgen
    A.copyI marr woff arr0 off0 (woff + len0)
    A.copyI marr (woff + len0) arr1 off1 (woff + newlen)
    arr2 <- A.unsafeFreeze marr
    return (Buf arr2 woff newlen newcap newgen)
```