### PR TITLE
Conditionally add an extra newline on instances

### DIFF
--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -3,7 +3,6 @@
 instance Foo Int where data Bar Int = IntBar Int Int
 
 instance Foo Double where
-
   newtype
     Bar
       Double

--- a/data/examples/declaration/instance/contexts-comments-out.hs
+++ b/data/examples/declaration/instance/contexts-comments-out.hs
@@ -14,5 +14,4 @@ instance
            )
          )
   where
-
   readsPrec = undefined

--- a/data/examples/declaration/instance/contexts-out.hs
+++ b/data/examples/declaration/instance/contexts-out.hs
@@ -6,7 +6,6 @@ instance
     )
   => Ord (a, b)
   where
-
   compare _ _ = GT
 
 instance
@@ -16,5 +15,4 @@ instance
          b
          )
   where
-
   showsPrec _ _ = showString ""

--- a/data/examples/declaration/instance/instance-sigs-out.hs
+++ b/data/examples/declaration/instance/instance-sigs-out.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE InstanceSigs #-}
 
 instance Eq Int where
-
   (==) :: Int -> Int -> Bool
   (==) _ _ = False
 
 instance Ord Int where
-
   compare
     :: Int
     -> Int

--- a/data/examples/declaration/instance/overlappable-instances-out.hs
+++ b/data/examples/declaration/instance/overlappable-instances-out.hs
@@ -1,11 +1,9 @@
 instance {-# OVERLAPPABLE #-} Eq Int where (==) _ _ = False
 
 instance {-# OVERLAPPING #-} Ord Int where
-
   compare _ _ = GT
 
 instance {-# OVERLAPS #-} Eq Double where
-
   (==) _ _ = False
 
 instance
@@ -13,5 +11,4 @@ instance
   Ord
     Double
   where
-
   compare _ _ = GT

--- a/data/examples/declaration/type/misc-kind-signatures-out.hs
+++ b/data/examples/declaration/type/misc-kind-signatures-out.hs
@@ -1,5 +1,4 @@
 instance DemoteNodeTypes ('[] :: [NodeType]) where
-
   demoteNodeTypes _ = []
 
 b :: (Bool :: *)

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -8,6 +8,7 @@
 
 module Ormolu.Printer.Meat.Declaration
   ( p_hsDecls
+  , hasSeparatedDecls
   )
 where
 
@@ -115,6 +116,13 @@ separatedDecls x y | Just n <- isPragma x, Just n' <- isPragma y = n /= n'
 separatedDecls x (TypeSignature n') | Just n <- isPragma x = n /= n'
 separatedDecls (PatternSignature n) (Pattern n') = n /= n'
 separatedDecls _ _ = True
+
+-- | Checks if given list of declarations contain a pair which should
+-- be separated by a blank line.
+
+hasSeparatedDecls :: [HsDecl GhcPs] -> Bool
+hasSeparatedDecls xs
+  = any (uncurry separatedDecls) $ zip xs (tail xs)
 
 isPragma
   :: HsDecl GhcPs

--- a/src/Ormolu/Printer/Meat/Declaration.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration.hs-boot
@@ -1,5 +1,6 @@
 module Ormolu.Printer.Meat.Declaration
   ( p_hsDecls
+  , hasSeparatedDecls
   )
 where
 
@@ -8,3 +9,4 @@ import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 
 p_hsDecls :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
+hasSeparatedDecls :: [HsDecl GhcPs] -> Bool

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -93,8 +93,11 @@ p_clsInstDecl = \case
               txt "where"
         unless (null allDecls) $ do
           inci $ do
-            breakpoint -- Ensure whitespace is added after where clause.
-            breakpoint' -- Add newline before first declaration
+            -- Ensure whitespace is added after where clause.
+            breakpoint
+            -- Add newline before first declaration if the body contains separate
+            -- declarations
+            when (hasSeparatedDecls $ map unLoc allDecls) breakpoint'
             dontUseBraces $ p_hsDecls Associated allDecls
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
   XClsInstDecl NoExt -> notImplemented "XClsInstDecl"


### PR DESCRIPTION
Closes #170 .

This implements @mrkkrp's suggestion on the ticket of only adding a trailing newline after the instance header when there are multiple declarations.