### PR TITLE
Refactor comment handling logic

### DIFF
--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -14,6 +14,7 @@ import Ormolu.Parser.Result
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Module
 import Ormolu.Printer.SpanStream
+import Ormolu.Printer.Comments
 
 -- | Render a module.
 
@@ -22,8 +23,10 @@ printModule
   -> ParseResult                -- ^ Result of parsing
   -> Text                       -- ^ Resulting rendition
 printModule debugOn ParseResult {..} =
-  runR debugOn
-       (p_hsModule prExtensions prParsedSource)
-       (mkSpanStream prParsedSource)
-       prCommentStream
-       prAnns
+  let (ret, sm) =
+        runR debugOn
+          (p_hsModule prExtensions prParsedSource)
+          (mkSpanStream prParsedSource)
+          prAnns
+      commented = insertComments prCommentStream sm ret
+  in  commented

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -1,240 +1,68 @@
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-
--- | Helpers for formatting of comments. This is low-level code, use
--- "Ormolu.Printer.Combinators" unless you know what you are doing.
+{-# LANGUAGE LambdaCase #-}
 
 module Ormolu.Printer.Comments
-  ( spitPrecedingComments
-  , spitFollowingComments
-  , spitRemainingComments
-  , isNewlineModified
-  , hasMoreComments
-  )
-where
+  ( insertComments
+  ) where
 
-import Control.Monad
-import Data.Coerce (coerce)
-import Data.Data (Data)
+import Control.Applicative
+import Data.Maybe
+import Data.List
+import Debug.Trace
 import Ormolu.Parser.CommentStream
 import Ormolu.Printer.Internal
-import Ormolu.Utils (isModule)
 import SrcLoc
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 
-----------------------------------------------------------------------------
--- Top-level
+insertComments :: CommentStream -> SourceMap -> T.Text -> T.Text
+insertComments (CommentStream cs) m t =
+  traceShow
+    (map (\c ->
+      ( attach m . srcSpanStartLine $ getLoc c
+      , unLoc c
+      )) cs)
+    ( T.unlines
+      . map (\(c, l) -> T.pack (show c) <> T.pack ": " <> l)
+      . zip [(0 :: Int)..]
+      $ T.lines t
+    )
 
--- | Output all preceding comments for an element at given location.
+data CommentLocation = After Int
+                     | Above Int
+                     | Below Int
+   deriving Show
 
-spitPrecedingComments
-  :: Data a
-  => RealLocated a              -- ^ AST element to attach comments to
-  -> R ()
-spitPrecedingComments = handleCommentSeries . spitPrecedingComment
+attach :: SourceMap -> Int -> Maybe CommentLocation
+attach sm l = do
+  (After <$> attachAfter sm l)
+    <|> (Above <$> attachAbove sm l)
+    <|> (Below <$> attachBelow sm l)
 
--- | Output all comments following an element at given location.
 
-spitFollowingComments
-  :: Data a
-  => RealLocated a              -- ^ AST element of attach comments to
-  -> R ()
-spitFollowingComments ref = do
-  trimSpanStream (getLoc ref)
-  handleCommentSeries (spitFollowingComment ref)
+attachAfter :: SourceMap -> Int -> Maybe Int
+attachAfter (SourceMap sps) line =
+  let matching = flip filter sps $ \case
+        (s, t) | srcSpanLine s == Just line -> True
+        _ -> False
+   in listToMaybe
+        . map (srcSpanStartLine . snd)
+        . sortOn (srcSpanEndCol . fst)
+        $ matching
 
--- | Output all remaining comments in the comment stream.
+attachAbove :: SourceMap -> Int -> Maybe Int
+attachAbove (SourceMap sps) line =
+  let matching = flip filter sps $ \case
+        (s, t) | srcSpanLine s > Just line -> True
+        _ -> False
+   in listToMaybe
+        . map (srcSpanStartLine . snd)
+        . sortOn (\(i, _) -> (srcSpanStartLine i, srcSpanStartCol i))
+        $ matching
 
-spitRemainingComments :: R ()
-spitRemainingComments = handleCommentSeries spitRemainingComment
+attachBelow :: SourceMap -> Int -> Maybe Int
+attachBelow _ _ = Nothing
 
-----------------------------------------------------------------------------
--- Single-comment functions
-
--- | Output a single preceding comment for an element at given location.
-
-spitPrecedingComment
-  :: Data a
-  => RealLocated a              -- ^ AST element to attach comments to
-  -> Maybe RealSrcSpan          -- ^ Location of last comment in the series
-  -> R (Maybe RealSrcSpan)      -- ^ Location of this comment
-spitPrecedingComment (L ref a) mlastSpn = do
-  let p (L l _) = realSrcSpanEnd l <= realSrcSpanStart ref
-  withPoppedComment p $ \l comment -> do
-    when (needsNewlineBefore l mlastSpn) newline
-    spitComment comment
-    if theSameLine l ref && not (isModule a)
-      then spit " "
-      else newline
-
--- | Output a comment that follows element at given location immediately on
--- the same line, if there is any.
-
-spitFollowingComment
-  :: Data a
-  => RealLocated a              -- ^ AST element to attach comments to
-  -> Maybe RealSrcSpan          -- ^ Location of last comment in the series
-  -> R (Maybe RealSrcSpan)      -- ^ Location of this comment
-spitFollowingComment (L ref a) mlastSpn = do
-  mnSpn <- nextEltSpan
-  -- Get first enclosing span that is not equal to reference span, i.e. it's
-  -- truly something enclosing the AST element.
-  meSpn <- getEnclosingSpan (/= ref)
-  newlineModified <- isNewlineModified
-  i <- getIndent
-  withPoppedComment (commentFollowsElt ref mnSpn meSpn mlastSpn) $ \l comment ->
-    if theSameLine l ref && not (isModule a)
-      then modNewline $ \m -> setIndent i $ do
-        if newlineModified
-          then do
-            -- This happens when we have several lines each with its own
-            -- comment and they get merged by the formatter.
-            m
-            spitComment comment
-            newline
-          else do
-            spit " "
-            spitComment comment
-            m
-      else modNewline $ \m -> setIndent i $ do
-        m
-        when (needsNewlineBefore l mlastSpn) newline
-        spitComment comment
-        newline
-
--- | Output a single remaining comment from the comment stream.
-
-spitRemainingComment
-  :: Maybe RealSrcSpan          -- ^ Location of last comment in the series
-  -> R (Maybe RealSrcSpan)      -- ^ Location of this comment
-spitRemainingComment mlastSpn =
-  withPoppedComment (const True) $ \l comment -> do
-    when (needsNewlineBefore l mlastSpn) newline
-    spitComment comment
-    newline
-
-----------------------------------------------------------------------------
--- Helpers
-
--- | Output series of comments.
-
-handleCommentSeries
-  :: (Maybe RealSrcSpan -> R (Maybe RealSrcSpan))
-     -- ^ Given location of previous comment, output the next comment
-     -- returning its location, or 'Nothing' if we are done
-  -> R ()
-handleCommentSeries f = go Nothing
-  where
-    go mlastSpn = do
-      r <- f mlastSpn
-      case r of
-        Nothing -> return ()
-        Just spn -> go (Just spn)
-
--- | Try to pop a comment using given predicate and if there is a comment
--- matching the predicate, print it out.
-
-withPoppedComment
-  :: (RealLocated Comment -> Bool) -- ^ Comment predicate
-  -> (RealSrcSpan -> Comment -> R ()) -- ^ Priting function
-  -> R (Maybe RealSrcSpan)
-withPoppedComment p f = do
-  r <- popComment p
-  case r of
-    Nothing -> return Nothing
-    Just (L l comment) -> Just l <$ f l comment
-
--- | Determine if we need to insert a newline between current comment and
--- last printed comment.
-
-needsNewlineBefore
-  :: RealSrcSpan                -- ^ Current comment span
-  -> Maybe RealSrcSpan          -- ^ Last printed comment span
-  -> Bool
-needsNewlineBefore l mlastSpn =
-  case mlastSpn of
-    Nothing -> False
-    Just lastSpn ->
-      srcSpanStartLine l > srcSpanEndLine lastSpn + 1
-
--- | Is the comment and AST element are on the same line?
-
-theSameLine
-  :: RealSrcSpan                -- ^ Current comment span
-  -> RealSrcSpan                -- ^ AST element location
-  -> Bool
-theSameLine l ref =
-  srcSpanEndLine l == srcSpanStartLine ref
-
--- | Determine if given comment follows AST element.
-
-commentFollowsElt
-  :: RealSrcSpan                -- ^ Location of AST element
-  -> Maybe RealSrcSpan          -- ^ Location of next AST element
-  -> Maybe RealSrcSpan          -- ^ Location of enclosing AST element
-  -> Maybe RealSrcSpan          -- ^ Location of last comment in the series
-  -> RealLocated Comment        -- ^ Comment to test
-  -> Bool
-commentFollowsElt ref mnSpn meSpn mlastSpn (L l comment) =
-  -- A comment follows a AST element if all 4 conditions are satisfied:
-  goesAfter
-    && logicallyFollows
-    && noEltBetween
-    && (continuation || lastInEnclosing || supersedesParentElt)
-  where
-    -- 1) The comment starts after end of the AST element:
-    goesAfter =
-      realSrcSpanStart l >= realSrcSpanEnd ref
-    -- 2) The comment logically belongs to the element, four cases:
-    logicallyFollows
-      = theSameLine l ref -- a) it's on the same line
-      || isPrevHaddock comment -- b) it's a Haddock string starting with -- ^
-      || continuation -- c) it's a continuation of a comment block
-      || lastInEnclosing -- d) it's the last element in the enclosing construct
-
-    -- 3) There is no other AST element between this element and the comment:
-    noEltBetween =
-      case mnSpn of
-        Nothing -> True
-        Just nspn ->
-          realSrcSpanStart nspn >= realSrcSpanEnd l
-    -- 4) Less obvious: if column of comment is closer to the start of
-    -- enclosing element, it probably related to that parent element, not to
-    -- the current child element. This rule is important because otherwise
-    -- all comments would end up assigned to closest inner elements, and
-    -- parent elements won't have a chance to get any comments assigned to
-    -- them. This is not OK because comments will get indented according to
-    -- the AST elements they are attached to.
-    --
-    -- Skip this rule if the comment is a continuation of a comment block.
-    supersedesParentElt =
-      case meSpn of
-        Nothing -> True
-        Just espn ->
-          let startColumn = srcLocCol . realSrcSpanStart
-          in if startColumn espn > startColumn ref
-               then True
-               else abs (startColumn espn - startColumn l)
-                      >= abs (startColumn ref - startColumn l)
-    continuation =
-      case mlastSpn of
-        Nothing -> False
-        Just spn -> srcSpanEndLine spn + 1 == srcSpanStartLine l
-
-    lastInEnclosing =
-      case (,) <$> meSpn <*> mnSpn of
-        Nothing -> False
-        Just (espn, nspn) ->
-          -- Make sure that the comment is inside the parent
-          realSrcSpanEnd l <= realSrcSpanEnd espn
-            -- Check if the next element is outside of the parent
-            && realSrcSpanEnd espn < realSrcSpanStart nspn
-
--- | Output a 'Comment'. This is a low-level printing function.
-
-spitComment :: Comment -> R ()
-spitComment =
-  sitcc . sequence_ . NE.intersperse newline . fmap f . coerce
-  where
-    f x = ensureIndent >> spit (T.pack x)
+srcSpanLine :: RealSrcSpan -> Maybe Int
+srcSpanLine s =
+  let start = srcSpanStartLine s
+      end   = srcSpanEndLine s
+   in if start == end then Just start else Nothing

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -15,7 +15,6 @@ import GHC
 import Ormolu.Imports
 import Ormolu.Parser.Pragma
 import Ormolu.Printer.Combinators
-import Ormolu.Printer.Comments
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration
 import Ormolu.Printer.Meat.Declaration.Warning
@@ -58,13 +57,4 @@ p_hsModule pragmas (L moduleSpan HsModule {..}) = do
     when (hasImports && hasDecls) newline
     switchLayout (map getLoc hsmodDecls) $ do
       p_hsDecls Free hsmodDecls
-      trailingComments <- hasMoreComments
-      when hasDecls $ do
-        newlineModified <- isNewlineModified
-        newline
-        -- In this case we need to insert a newline between the comments
-        -- output as a side effect of the previous newline and trailing
-        -- comments to prevent them from merging.
-        when (newlineModified && trailingComments) newline
-      when (trailingComments && hasModuleHeader) newline
-      spitRemainingComments
+      when hasDecls newline


### PR DESCRIPTION
This PR is an experiment to explore an alternative way to insert comments.

Currently there are two issues we need to solve with our commenting method.

1.  Printing comments sometimes affect formatting (eg. it can insert a newline
    between two constructs that's supposed to be on the same line)
2.  We "attach" comments to AST nodes, and sometimes we attach the same comment
    to a different AST node after formatting. Both the way we format code
    and the way we attach comments affect this, so just formatting the
    code in a different way can cause issues with the comment placement.

I think, the underlying issue is that currently comment placement
happens automatically when we are printing a located element; and this
can make the formatted code syntactically incorrect, or introduce
idempotence issues.

I can think of a few solutions:

1. Tweak the comment attaching rules and the AST printer code until
   they play well with each other. However I think this might be an
   uphill battle where changing either formatter or the commenting code
   can cause new and more exciting issues.
2. We can attach comments to AST nodes on the parser (probably using
   those "trees that grow" extension points on the AST), and let the
   printer print comments alongside with the source code. This approach
   is probably the most flexible one; since it can both reproduce the
   current behavior, and gives the printers ability to print comments
   in a way they want. However, it is a tedious process to write custom
   comment handling code to every AST element that can be commented,
   and we must still make sure that the comments will be attached to
   the same AST nodes on the second pass.
3. Or we can go the other way around, and stop attaching comments to
   AST nodes, at least directly. The premise is that; in the end, users
   do not comment an AST node; they comment a specific line in the source
   code. So, we can place that comment in the corresponding line on the
   formatted code without looking at AST at all. I think this approach
   will be conceptually the simplest solution. The disadvantage is that,
   not having any information about the AST might make things harder;
   however I believe we can find workarounds for those cases.

In this branch, I am trying the third approach.

1. I format the code disregarding comments. While formatting the code,
   I create a "SourceMap" mapping the `SrcSpan`s in the input to `SrcSpan`s
   in the output.
2. I classify every comment as "Below \<line>", "Above \<line>" or "Next
   to \<line>" according to their location on the input.
3. I map the line numbers of the comments on the input to line numbers on
   the output using the "SourceMap".
4. I attach the comments to formatted output (as a raw `Text`, without any
   syntactic information),

Currently I only implemented step 1, and am in the process of implementing
step 2 and 3.

This is a relatively big change, so if there is a simpler solution I am
happy to stop working on this branch; and maybe we can revisit the idea
if we keep having similar issues.