### PR TITLE
Use build-tool-depends instead of build-tools

### DIFF
--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -130,7 +130,7 @@ test-suite tests
                     , path           >= 0.6 && < 0.7
                     , path-io        >= 1.4.2 && < 2.0
                     , text           >= 0.2 && < 1.3
-  build-tools:        hspec-discover >= 2.0 && < 3.0
+  build-tool-depends: hspec-discover:hspec-discover >= 2.0 && < 3.0
   other-modules:
                       Ormolu.Printer.CombinatorsSpec
                     , Ormolu.Parser.PragmaSpec


### PR DESCRIPTION
It looks like [using build-tools was deprecated](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-build-tool-depends) since Cabal version [2.0](https://github.com/haskell/cabal/blob/1d2ff3450ee7fd99e89545e2468bf8f512b6e00a/Cabal/doc/file-format-changelog.rst#id55). This commit changes "build-tools" usage to "built-tool-depends" with the correct syntax.

However, there is an issue within "nix-shell" that `cabal new-test` can not resolve "hspec-discover". I couldn't pinpoint the exact issue, but it works outside of "nix-shell"; and old-style commands also keep working.

Before we merge this, I would like to figure out why it doesn't work in "nix-shell". Please let me know if anyone knows why.