### PR TITLE
Group declarations referring to multiple names

### DIFF
--- a/data/examples/declaration/signature/type/multi-value-out.hs
+++ b/data/examples/declaration/signature/type/multi-value-out.hs
@@ -1,6 +1,10 @@
 foo, bar :: Int
+foo = 1
+bar = 2
 
 foo,
   bar,
   baz
     :: Int
+bar = 2
+baz = 3

--- a/data/examples/declaration/signature/type/multi-value.hs
+++ b/data/examples/declaration/signature/type/multi-value.hs
@@ -1,5 +1,9 @@
 foo, bar :: Int
+foo = 1
+bar = 2
 
 foo,
   bar,
     baz :: Int
+bar = 2
+baz = 3

--- a/data/examples/declaration/value/function/case-single-line-out.hs
+++ b/data/examples/declaration/value/function/case-single-line-out.hs
@@ -3,5 +3,4 @@ foo x = case x of x -> x
 
 foo :: IO ()
 foo = case [1] of [_] -> "singleton"; _ -> "not singleton"
-
 foo = case [1] of { [] -> foo; _ -> bar } `finally` baz

--- a/data/examples/declaration/value/function/pattern/n-plus-k-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/n-plus-k-pattern-out.hs
@@ -8,3 +8,6 @@ multiline
   ( n
       + 1
     ) = n
+
+n :: Int
+(n + 1) = 3

--- a/data/examples/declaration/value/function/pattern/n-plus-k-pattern.hs
+++ b/data/examples/declaration/value/function/pattern/n-plus-k-pattern.hs
@@ -5,3 +5,6 @@ singleline (n + 1) = n
 multiline :: Int
 multiline(n
   + 1) = n
+
+n :: Int
+(n + 1) = 3

--- a/data/examples/declaration/warning/warning-multiline-out.hs
+++ b/data/examples/declaration/warning/warning-multiline-out.hs
@@ -5,6 +5,5 @@
     "Really bad!"
     ]
   #-}
-
 test :: IO ()
 test = pure ()

--- a/data/examples/declaration/warning/warning-single-line-out.hs
+++ b/data/examples/declaration/warning/warning-single-line-out.hs
@@ -1,5 +1,4 @@
 {-# DEPRECATED test, foo "This is a deprecation" #-}
-
 {-# WARNING test "This is a warning" #-}
 test :: IO ()
 test = pure ()

--- a/src/Ormolu/Printer/Meat/Declaration.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration.hs-boot
@@ -9,4 +9,4 @@ import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 
 p_hsDecls :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
-hasSeparatedDecls :: [HsDecl GhcPs] -> Bool
+hasSeparatedDecls :: [LHsDecl GhcPs] -> Bool

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -69,7 +69,7 @@ p_classDecl ctx name tvars fixity fdeps csigs cdefs cats catdefs = do
     breakpoint -- Ensure whitespace is added after where clause.
     -- Add newline before first declaration if the body contains separate
     -- declarations
-    when (hasSeparatedDecls $ map unLoc allDecls) breakpoint'
+    when (hasSeparatedDecls allDecls) breakpoint'
     inci (p_hsDecls Associated allDecls)
 
 p_classContext :: LHsContext GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -97,7 +97,7 @@ p_clsInstDecl = \case
             breakpoint
             -- Add newline before first declaration if the body contains separate
             -- declarations
-            when (hasSeparatedDecls $ map unLoc allDecls) breakpoint'
+            when (hasSeparatedDecls allDecls) breakpoint'
             dontUseBraces $ p_hsDecls Associated allDecls
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
   XClsInstDecl NoExt -> notImplemented "XClsInstDecl"


### PR DESCRIPTION
Closes #104.

This PR extends the declaration grouping logic to handle declarations referring to multiple names. eg:

```haskell
fst, snd :: Bool
(fst, snd) = (True, False)

fst, snd :: Bool
fst = True
snd = False
```

It makes the logic a bit more complex since now we can not decide whether to separate two declarations solely by themselves. This new method tries to separate given declarations to groups of relevant declarations; and then prints the groups together. It simply:

1. Takes the first declaration and calls it a group "header"
2. Keeps adding the next declaration to the group if it is relevant to either to the group header or to the previous element.

The relevancy logic(previously `separatedDecls`, now `groupedDecls`) is pretty much the same, but now it handles declarations binding multiple names, and groups them together if they share at least one name.