### PR TITLE
Make the first newline optional on class declarations

### DIFF
--- a/data/examples/declaration/class/default-implementations-out.hs
+++ b/data/examples/declaration/class/default-implementations-out.hs
@@ -1,12 +1,10 @@
 -- | Foo
 class Foo a where
-
   foo :: a -> a
   foo a = a
 
 -- | Bar
 class Bar a where
-
   bar
     :: a
     -> Int

--- a/data/examples/declaration/class/functional-dependencies-out.hs
+++ b/data/examples/declaration/class/functional-dependencies-out.hs
@@ -13,5 +13,4 @@ class
       a c -> b d, -- Baz
       a c d -> b,
       a b d -> a b c d where
-
   baz :: a -> b

--- a/data/examples/declaration/class/multi-parameters1-out.hs
+++ b/data/examples/declaration/class/multi-parameters1-out.hs
@@ -4,7 +4,6 @@ class Foo a b where foo :: a -> b
 
 -- | Something.
 class Bar a b c d where
-
   bar
     :: a
     -> b
@@ -13,5 +12,4 @@ class Bar a b c d where
 
 class -- Before name
   Baz where
-
   baz :: Int

--- a/data/examples/declaration/class/single-parameters-out.hs
+++ b/data/examples/declaration/class/single-parameters-out.hs
@@ -3,12 +3,10 @@ class Foo a where foo :: a
 
 -- | Something more.
 class Bar a where
-
   -- | Bar
   bar :: a -> a -> a
 
 class Baz a where
-
   -- | Baz
   baz
     :: ( a,

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -67,7 +67,9 @@ p_classDecl ctx name tvars fixity fdeps csigs cdefs cats catdefs = do
   unless (null allDecls) $ do
     txt " where"
     breakpoint -- Ensure whitespace is added after where clause.
-    breakpoint' -- Add newline before first declaration.
+    -- Add newline before first declaration if the body contains separate
+    -- declarations
+    when (hasSeparatedDecls $ map unLoc allDecls) breakpoint'
     inci (p_hsDecls Associated allDecls)
 
 p_classContext :: LHsContext GhcPs -> R ()


### PR DESCRIPTION
Closes #329.

The same as #170, but for type class definitions.