### PR TITLE
Fix an issue with detecting spans of patterns with guards

### DIFF
--- a/data/examples/declaration/value/function/case-multi-line-guards-out.hs
+++ b/data/examples/declaration/value/function/case-multi-line-guards-out.hs
@@ -7,3 +7,8 @@ withGuards x =
           + bar
     x | x > 5 -> 10
     _ -> 20
+
+case x of
+  '-' | not isUrl ->
+    case xs of
+      _ -> emitc '-'

--- a/data/examples/declaration/value/function/case-multi-line-guards.hs
+++ b/data/examples/declaration/value/function/case-multi-line-guards.hs
@@ -7,3 +7,6 @@ withGuards x =
     x | x > 5 -> 10
     _ -> 20
 
+case x of
+  '-' | not isUrl -> case xs of
+        _ -> emitc '-'

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -902,7 +902,8 @@ liftAppend (x : xs) [] = x : xs
 liftAppend (x : xs) (y : ys) = x <> y : liftAppend xs ys
 
 getGRHSSpan :: GRHS GhcPs (Located body) -> SrcSpan
-getGRHSSpan (GRHS NoExt _ body) = getLoc body
+getGRHSSpan (GRHS NoExt guards body) =
+  combineSrcSpans' $ getLoc body :| map getLoc guards
 getGRHSSpan (XGRHS NoExt) = notImplemented "XGRHS"
 
 -- | Place a thing that may have a hanging form. This function handles how


### PR DESCRIPTION
closes #328.

Previously 'getGRHSSpan' function was only looking at the span of the body of the pattern ignoring the guard. This was causing an idempotence issue described in #328.

This PR makes 'getGRHSSpan' function merge the span of the body with spans of the guards.