### PR TITLE
Only force braces on hsLocalBinds on a single-line layout

### DIFF
--- a/data/examples/declaration/value/function/where-nested-out.hs
+++ b/data/examples/declaration/value/function/where-nested-out.hs
@@ -1,0 +1,12 @@
+foo = bar
+  where
+    f1 = f1
+      where
+        f1 = 3
+    f2 = f2
+      where
+        f2 = 3
+
+foo2 = bar
+  where
+    f1 = f1 where { f1 = 3; f1' = 4 }; f2 = f2 where f2 = 3; f2' = 4

--- a/data/examples/declaration/value/function/where-nested.hs
+++ b/data/examples/declaration/value/function/where-nested.hs
@@ -1,0 +1,13 @@
+foo = bar
+  where
+    f1 = f1
+      where
+        f1 = 3
+    f2 = f2
+      where
+        f2 = 3
+
+foo2 = bar
+  where
+   { f1 = f1 where { f1 = 3; f1' = 4 }; f2 = f2 where { f2 = 3; f2' = 4 } }
+

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -420,8 +420,9 @@ p_hsLocalBinds = \case
     -- NOTE When in a single-line layout, there is a chance that the inner
     -- elements will also contain semicolons and they will confuse the
     -- parser. so we request braces around every element except the last.
+    br <- vlayout (return useBraces) (return id)
     sitcc $ sepSemi
-      (\(m, i) -> (if m then useBraces else id) $ p_item i)
+      (\(m, i) -> (if m then br else id) $ p_item i)
       (markInit $ sortOn ssStart items)
   HsValBinds NoExt _ -> notImplemented "HsValBinds"
   HsIPBinds NoExt (IPBinds NoExt xs) ->


### PR DESCRIPTION
This fixes an issue where braces are inserted unnecessarily on some cases like:

```
foo = bar
  where
    f1 = f1
      where
        { f1 = 3 }
    f2 = f2
      where
        f2 = 3
```