### PR TITLE
Correctly place comments inside enclosing expressions at the end of the module

### DIFF
--- a/data/examples/declaration/rewrite-rule/prelude4-out.hs
+++ b/data/examples/declaration/rewrite-rule/prelude4-out.hs
@@ -2,6 +2,6 @@
 "unpack" [~1] forall a. unpackCString # a = build (unpackFoldrCString # a)
 "unpack-list" [1] forall a. unpackFoldrCString # a (:) [] = unpackCString # a
 "unpack-append" forall a n. unpackFoldrCString # a (:) n = unpackAppendCString # a n
-  #-}
 -- There's a built-in rule (in PrelRules.lhs) for
 --      unpackFoldr "foo" c (unpackFoldr "baz" c n)  =  unpackFoldr "foobaz" c n
+  #-}

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -242,13 +242,18 @@ commentFollowsElt ref mnSpn meSpn mlastSpn (L l comment) =
         Just spn -> srcSpanEndLine spn + 1 == srcSpanStartLine l
 
     lastInEnclosing =
-      case (,) <$> meSpn <*> mnSpn of
+      case meSpn of
+        -- When there is no enclosing element, return false
         Nothing -> False
-        Just (espn, nspn) ->
-          -- Make sure that the comment is inside the parent
-          realSrcSpanEnd l <= realSrcSpanEnd espn
-            -- Check if the next element is outside of the parent
-            && realSrcSpanEnd espn < realSrcSpanStart nspn
+        -- When there is an enclosing element,
+        Just espn ->
+          let -- Make sure that the comment is inside the enclosing element
+              insideParent = realSrcSpanEnd l <= realSrcSpanEnd espn
+              -- And check if the next element is outside of the parent
+              nextOutsideParent = case mnSpn of
+                Nothing -> True
+                Just nspn -> realSrcSpanEnd espn < realSrcSpanStart nspn
+           in insideParent && nextOutsideParent
 
 -- | Output a 'Comment'. This is a low-level printing function.
 


### PR DESCRIPTION
Closes #295.

Previously, `lastInEnclosing` predicate did not correctly handling the case where the comment is the last element in the module.

This PR changes the cases to handle the case where `mnSpn == Nothing`.