### PR TITLE
Make multi-line multi-name patterns prettier

### DIFF
--- a/data/examples/declaration/signature/pattern/multiline-out.hs
+++ b/data/examples/declaration/signature/pattern/multiline-out.hs
@@ -4,3 +4,16 @@ pattern Arrow
   :: Type
   -> Type
   -> Type
+
+pattern
+  Foo,
+  Bar
+    :: Type -> Type -> Type
+
+pattern
+  TypeSignature,
+  FunctionBody,
+  PatternSignature,
+  WarningPragma
+    :: [RdrName]
+    -> HsDecl GhcPs

--- a/data/examples/declaration/signature/pattern/multiline.hs
+++ b/data/examples/declaration/signature/pattern/multiline.hs
@@ -1,3 +1,13 @@
 {-# LANGUAGE PatternSynonyms #-}
+
 pattern Arrow :: Type
   -> Type -> Type
+
+pattern Foo, Bar ::
+  Type -> Type -> Type
+
+pattern TypeSignature
+      , FunctionBody
+      , PatternSignature
+      , WarningPragma :: [RdrName]
+        -> HsDecl GhcPs

--- a/data/examples/declaration/signature/pattern/single-line-out.hs
+++ b/data/examples/declaration/signature/pattern/single-line-out.hs
@@ -1,3 +1,5 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 pattern Arrow :: Type -> Type -> Type
+
+pattern Foo, Bar :: Type -> Type -> Type

--- a/data/examples/declaration/signature/pattern/single-line.hs
+++ b/data/examples/declaration/signature/pattern/single-line.hs
@@ -1,3 +1,5 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 pattern Arrow :: Type -> Type -> Type
+
+pattern Foo, Bar :: Type -> Type -> Type


### PR DESCRIPTION
Closes #335.

This PR adds a newline after `pattern` keyword in pattern synonyms
when there are multiple names. eg.

```
pattern
  TypeSignature,
  FunctionBody,
  PatternSignature,
  WarningPragma
    :: [RdrName]
    -> HsDecl GhcPs
```

It only adds the newline when there are multiple names, because I think this:

```
pattern Arrow
  :: Type
  -> Type
  -> Type
```

looks better than:

```
pattern
  Arrow
    :: Type
    -> Type
    -> Type
```

I would be happy to change it if you disagree.