### PR TITLE
Use GHC 8.6.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build_ghc864:
+  build:
     docker:
       - image: nixos/nix:2.1.3
     steps:
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: Setup Cachix
           command: |
-            nix-env -f nix/nixpkgs/ -iA cachix
+            nix-env -iA cachix -f https://cachix.org/api/v1/install
             USER=dummy cachix use tweag
       - run:
           name: Build environment
@@ -40,5 +40,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_ghc864:
+      - build:
           context: org-global

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alternatively, `stack` could be used with a `stack.yaml` file as follows.
 
 ```console
 $ cat stack.yaml
-resolver: lts-13.19
+resolver: lts-14.3
 packages:
 - '.'
 

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? (import ./nix/nixpkgs) }:
 
 let
-  ormoluCompiler = "ghc864";
+  ormoluCompiler = "ghc865";
   source = pkgs.lib.sourceByRegex ./.[
     "^.*\.md$"
     "^app.*$"

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,6 +1,6 @@
 let
-  rev = "454eea84a757ca5f733c4ec0f234eba2281c74eb";
-  sha256 = "1k9jbix4w43brqlfmvwy218pf5fbmzsnc08shaww9qfdl1rdlaxy";
+  rev = "3f4144c30a6351dd79b177328ec4dea03e2ce45f";
+  sha256 = "1qg5n60n3fr6cypihnrjw451fadps5pysj5p0vvfb320mpfvlbjb";
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -1,7 +1,7 @@
 name:                 ormolu
 version:              0.0.1.0
 cabal-version:        1.18
-tested-with:          GHC==8.6.4
+tested-with:          GHC==8.6.5
 license:              BSD3
 license-file:         LICENSE.md
 maintainer:           Mark Karpov <mark.karpov@tweag.io>
@@ -69,8 +69,8 @@ library
                     , containers     >= 0.5 && < 0.7
                     , dlist          >= 0.8 && < 0.9
                     , exceptions     >= 0.6 && < 0.11
-                    , ghc            >= 8.4.3
-                    , ghc-boot-th    >= 8.4.3
+                    , ghc            == 8.6.5
+                    , ghc-boot-th    == 8.6.5
                     , ghc-paths      >= 0.1 && < 0.2
                     , mtl            >= 2.0 && < 3.0
                     , syb            >= 0.7 && < 0.8
@@ -149,7 +149,7 @@ executable ormolu
   main-is:            Main.hs
   hs-source-dirs:     app
   build-depends:      base           >= 4.12 && < 5.0
-                    , ghc            >= 8.4.3
+                    , ghc            == 8.6.5
                     , gitrev         >= 1.3 && < 1.4
                     , optparse-applicative >= 0.14 && < 0.15
                     , ormolu


### PR DESCRIPTION
As the first release is approaching, we better switch to the ~~latest~~ GHC 8.6.5.