### PR TITLE
Remove UnicodeSyntax from default extensions

### DIFF
--- a/data/examples/declaration/signature/type/unicode-out.hs
+++ b/data/examples/declaration/signature/type/unicode-out.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+foo :: forall a. Show a => a -> String
+foo = const ()

--- a/data/examples/declaration/signature/type/unicode.hs
+++ b/data/examples/declaration/signature/type/unicode.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+foo ∷ ∀a. Show a ⇒ a → String
+foo = const ()

--- a/data/examples/declaration/value/function/infix/unicode-out.hs
+++ b/data/examples/declaration/value/function/infix/unicode-out.hs
@@ -1,0 +1,3 @@
+main = print ('a' → 'a')
+  where
+    (→) = (,)

--- a/data/examples/declaration/value/function/infix/unicode.hs
+++ b/data/examples/declaration/value/function/infix/unicode.hs
@@ -1,0 +1,3 @@
+main = print ('a' → 'a')
+  where
+    (→) = (,)

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -86,6 +86,7 @@ manualExts =
   , AlternativeLayoutRuleTransitional
   , MonadComprehensions
   , UnboxedSums
+  , UnicodeSyntax -- gives special meanings to operators like (→)
   , TemplateHaskellQuotes -- enables TH subset of quasi-quotes, this
                           -- apparently interferes with QuasiQuotes in
                           -- weird ways


### PR DESCRIPTION
Without `-XUnicodeSyntax`, this is a working Haskell program:

```
main = print ('a' → 'a')
  where
    (→) = (,)
```

However with `-XUnicodeSyntax`, `→` is interpreted as function arrrow (`->`) and it causes a parse error.

Therefore, this PR removes `UnicodeSyntax` from default extensions since it makes Ormolu fail on valid Haskell programs.

We can successfully format `fay` with this PR.