### PR TITLE
Workaround for pattern constructs in expressions

### DIFF
--- a/data/examples/declaration/value/function/pattern/view-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/view-pattern-out.hs
@@ -13,3 +13,6 @@ multiline
         bar
         baz
     ) = True
+
+-- https://github.com/tweag/ormolu/issues/343
+foo = (f -> 4)

--- a/data/examples/declaration/value/function/pattern/view-pattern.hs
+++ b/data/examples/declaration/value/function/pattern/view-pattern.hs
@@ -10,3 +10,6 @@ g ((f, _), f -> 4) = True
 multiline (t -> Foo
                   bar
                   baz) = True
+
+-- https://github.com/tweag/ormolu/issues/343
+foo = (f -> 4)

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -705,10 +705,22 @@ p_hsExpr = \case
   HsTick {} -> notImplemented "HsTick"
   HsBinTick {} -> notImplemented "HsBinTick"
   HsTickPragma {} -> notImplemented "HsTickPragma"
+  -- These four constructs should never appear in correct programs.
+  -- See: https://github.com/tweag/ormolu/issues/343
   EWildPat NoExt -> txt "_"
-  EAsPat {} -> notImplemented "EAsPat"
-  EViewPat {} -> notImplemented "EViewPat"
-  ELazyPat {} -> notImplemented "ELazyPat"
+  EAsPat NoExt n p -> do
+    p_rdrName n
+    txt "@"
+    located p p_hsExpr
+  EViewPat NoExt p e -> do
+    located p p_hsExpr
+    space
+    txt "->"
+    breakpoint
+    inci (located e p_hsExpr)
+  ELazyPat NoExt p -> do
+    txt "~"
+    located p p_hsExpr
   HsWrap {} -> notImplemented "HsWrap"
   XExpr {} -> notImplemented "XExpr"
 


### PR DESCRIPTION
Closes #343.

This makes some syntactically incorrect programs not fail on Ormolu. The formatted code will still cause syntax errors.

See [my comment on #343](https://github.com/tweag/ormolu/issues/343#issuecomment-526401738) for details.

I'm happy to fix this issue in some other way if you are not happy with this.