### PR TITLE
Automatically test some Hackage packages on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             fi
       - run:
           name: Build the package (includes running the tests)
-          command: nix-build
+          command: nix-build --keep-going
       - run:
           name: Generate Haddocks
           command: nix-build --attr ormolu.doc

--- a/default.nix
+++ b/default.nix
@@ -14,12 +14,14 @@ let
     overrides = ormoluOverlay;
   };
   ormoluOverlay = self: super: {
-      "ormolu" = super.callCabal2nix "ormolu" source { };
-    };
+    "ormolu" = super.callCabal2nix "ormolu" source { };
+  };
   ormolize = import ./nix/ormolize {
     inherit pkgs;
     inherit haskellPackages;
   };
+  ormolizedPackages = doCheck:
+    pkgs.lib.mapAttrs (_: v: ormolize { package = v; inherit doCheck; }) haskellPackages;
 in {
   ormolu = haskellPackages.ormolu;
   ormoluShell = haskellPackages.shellFor {
@@ -27,5 +29,55 @@ in {
     buildInputs = [ haskellPackages.cabal-install haskellPackages.ghcid ];
   };
   inherit ormoluOverlay ormoluCompiler;
-  hackage = pkgs.lib.mapAttrs ormolize haskellPackages;
+  hackage = ormolizedPackages false;
+  hackageTests = with pkgs.lib; pkgs.recurseIntoAttrs (
+    let ps = [
+      "QuickCheck"
+      "ShellCheck"
+      "aeson"
+      "attoparsec"
+      "cassava"
+      "conduit"
+      "cryptonite"
+      "diagrams-core"
+      "distributed-process"
+      "esqueleto"
+      "fay"
+      "hedgehog"
+      "hlint"
+      "megaparsec"
+      "postgrest"
+      "servant"
+      "servant-server"
+      "tensorflow"
+
+      # Comment idempotence issue
+
+      # "Agda"
+      # "aws"
+      # "brick"
+      # "hakyll"
+      # "haxl"
+      # "hledger"
+      # "http-client"
+      # "idris"
+      # "intero"
+      # "leksah"
+      # "lens"
+      # "ormolu"
+      # "pandoc"
+      # "pipes"
+      # "purescript"
+      # "stack"
+      # "tls"
+      # "yesod-core"
+
+      # Missing language extension
+
+      # "lens" #fixed in master
+      # "purescript"
+
+    ];
+    in listToAttrs (map (p: nameValuePair p (ormolizedPackages true).${p}) ps)
+  );
 }

--- a/nix/ormolize/default.nix
+++ b/nix/ormolize/default.nix
@@ -1,15 +1,22 @@
-{ pkgs, haskellPackages }: _: p:
+{ pkgs, haskellPackages }: { package, doCheck ? false }:
   pkgs.stdenv.mkDerivation {
-    name = p.name + "-ormolized";
-    src = p.src;
+    name = package.name + "-ormolized";
+    src = package.src;
     buildInputs = [
       haskellPackages.cpphs
-      (pkgs.haskell.lib.dontCheck haskellPackages.ormolu)
+      (if doCheck
+        then haskellPackages.ormolu
+        else pkgs.haskell.lib.dontCheck haskellPackages.ormolu)
       pkgs.glibcLocales
     ];
     LANG = "en_US.UTF-8";
     buildPhase = ''
       find . -name '*.hs' -exec bash ${./ormolize.sh} {} \; 2> log.txt
+      cat log.txt
+    '';
+    inherit doCheck;
+    checkPhase = ''
+       if [[ -s log.txt ]]; then exit 1; fi
     '';
     installPhase = ''
       mkdir "$out"


### PR DESCRIPTION
closes #303 .

This PR introduces a `hackageTests` attribute, which, when evaluated runs `ormolize` on a few hand-picked Haskell packages and fails on errors.

While doing that, I also:

* Added a `doCheck` parameter to `ormolize` which causes the build to fail in case of issues.
* Passed `--keep-going` parameter to `nix-build` on CI, so that the first failed build won't immediately stop every other one (the whole command will still fail).
* Commented out some packages with known issues, so we can uncomment them once we fix the issues.