### PR TITLE
Remove TypeApplications from default extensions

### DIFF
--- a/data/examples/declaration/value/function/pattern/as-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/as-pattern-out.hs
@@ -1,0 +1,3 @@
+main = case [1] of
+  xs@(x : _) -> print (x, xs)
+  xs@[] -> print xs

--- a/data/examples/declaration/value/function/pattern/as-pattern.hs
+++ b/data/examples/declaration/value/function/pattern/as-pattern.hs
@@ -1,0 +1,3 @@
+main = case [1] of
+  xs @ (x:_) -> print (x, xs)
+  xs@[] -> print xs

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -82,6 +82,7 @@ manualExts =
   , TransformListComp -- steals the group keyword
   , UnboxedTuples -- breaks (#) lens operator
   , MagicHash -- screws {-# these things #-}
+  , TypeApplications -- steals (@) operator on some cases
   , AlternativeLayoutRule
   , AlternativeLayoutRuleTransitional
   , MonadComprehensions


### PR DESCRIPTION
Closes #348.

Turns out TypeApplications interferes with as-patterns in some cases, eg:

```haskell
main = case [1] of
  xs @ (x:_) -> print (x, xs)
```