### PR TITLE
Don't use newlines on LambdaCases on single-line layouts

### DIFF
--- a/data/examples/declaration/value/function/lambda-case-out.hs
+++ b/data/examples/declaration/value/function/lambda-case-out.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 
+foo = bar (\case JKey {} -> True; _ -> False)
+
 foo :: Int -> Int
 foo = \case
   5 -> 10

--- a/data/examples/declaration/value/function/lambda-case.hs
+++ b/data/examples/declaration/value/function/lambda-case.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 
+foo = bar (\case JKey{} -> True; _ -> False)
+
 foo :: Int -> Int
 foo = \case
   5 -> 10

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -493,7 +493,7 @@ p_hsExpr = \case
     p_matchGroup Lambda mgroup
   HsLamCase NoExt mgroup -> do
     txt "\\case"
-    newline
+    breakpoint
     inci (p_matchGroup LambdaCase mgroup)
   HsApp NoExt f x -> sitcc $ do
     located f p_hsExpr


### PR DESCRIPTION
Closes #347.

Always using a newline causes idempotence issues where previously single-line constructs formatted as multi-line on subsequent runs.