### PR TITLE
Support infix pattern synonyms

### DIFF
--- a/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional-out.hs
@@ -8,18 +8,21 @@ pattern Arrow {t1, t2} = App "->" [t1, t2]
 pattern Arrow
   { t1,
     t2
-    } =
-  App "->" [t1, t2]
+    }
+  = App "->" [t1, t2]
 
-pattern Int =
-  App "Int" []
+pattern Int
+  = App "Int" []
 
-pattern Maybe {t} =
-  App
-    "Maybe"
-    [t]
+pattern Maybe {t}
+  = App
+      "Maybe"
+      [t]
 
-pattern Maybe t =
-  App
-    "Maybe"
-    [t]
+pattern Maybe t
+  = App
+      "Maybe"
+      [t]
+
+pattern a :< b
+  <- (a, b)

--- a/data/examples/declaration/value/pattern-synonyms/bidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/bidirectional.hs
@@ -15,3 +15,7 @@ pattern Maybe t     =
   App
     "Maybe"
     [t]
+
+pattern a :< b <-
+  (a , b)
+

--- a/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional-out.hs
@@ -1,16 +1,21 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-pattern HeadC x <-
-  x : xs
+pattern HeadC x
+  <- x : xs
   where
     HeadC x = [x]
 
-pattern HeadC' x <-
-  x : xs
+pattern HeadC' x
+  <- x : xs
   where
     HeadC' x = [x]
 
-pattern Simple <-
-  "Simple"
+pattern Simple
+  <- "Simple"
   where
     Simple = "Complicated"
+
+pattern a :< b
+  <- (a, b)
+  where
+    a :< b = (a, b)

--- a/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional.hs
+++ b/data/examples/declaration/value/pattern-synonyms/explicitely-bidirectional.hs
@@ -11,3 +11,9 @@ pattern HeadC' x <-
 pattern Simple <- "Simple"
   where
     Simple = "Complicated"
+
+pattern a :< b <-
+  (a , b)
+  where
+    a :< b = (a, b)
+

--- a/data/examples/declaration/value/pattern-synonyms/unidirectional-out.hs
+++ b/data/examples/declaration/value/pattern-synonyms/unidirectional-out.hs
@@ -2,20 +2,20 @@
 
 pattern Head x <- x : xs
 
-pattern Head' x <-
-  x : xs
+pattern Head' x
+  <- x : xs
 
-pattern Head'' {x} <-
-  x : xs
+pattern Head'' {x}
+  <- x : xs
 
-pattern FirstTwo {x, y} <-
-  x : (y : xs)
+pattern FirstTwo {x, y}
+  <- x : (y : xs)
 
 pattern FirstTwo'
   { x,
     y
-    } <-
-  x : (y : xs)
+    }
+  <- x : (y : xs)
 
 pattern Simple <- "Simple"
 


### PR DESCRIPTION
Closes #355.

This PR adds support for of infix pattern synonyms:

```haskell
pattern a :< b
  <- (c, d)
  where
    a :< b = (c, d)
```

While doing that, I had to refactor the pattern synonym printer; and while doing that changed the layout a bit.

Previously, we were putting the equals sign (`=` or `<-`) right after the lhs. This is quite different than how we format other stuff, where we put the equals sign on the next line. After this PR, we apply the same logic to pattern synonyms where the arrow starts on the next line. Here is the difference:

```haskell
-- previously
pattern Tup a =
  ( a,
    a
    )

-- now
pattern Tup a
  = ( a,
      a
      )

-- type synonyms
type Tup a
  = ( a,
      a
      )
```

Let me know if you're happy with the change of the formatting.