### PR TITLE
Remove extra space before type variables with apostrophe

### DIFF
--- a/data/examples/declaration/data/kind-annotations-out.hs
+++ b/data/examples/declaration/data/kind-annotations-out.hs
@@ -1,1 +1,3 @@
 data Something (n :: Nat) = Something
+
+data Format (k :: *) (k' :: *) (k'' :: *)

--- a/data/examples/declaration/data/kind-annotations.hs
+++ b/data/examples/declaration/data/kind-annotations.hs
@@ -1,1 +1,3 @@
 data Something (n :: Nat) = Something
+
+data Format (k :: *) (k' :: *) (k'' :: *)

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -39,11 +39,12 @@ p_hsType = \case
       _ -> located t p_hsType
   HsTyVar NoExt p n -> do
     case p of
-      Promoted -> txt "'"
+      Promoted -> do
+        txt "'"
+        case showOutputable (unLoc n) of
+          _ : '\'' : _ -> space
+          _ -> return ()
       NotPromoted -> return ()
-    case showOutputable (unLoc n) of
-      _ : '\'' : _ -> space
-      _ -> return ()
     p_rdrName n
   HsAppTy NoExt f x -> sitcc $ do
     located f p_hsType


### PR DESCRIPTION
Closes #354.

We were putting a space before type variables if they contain the symbol `'`, but I think it is only necessary if the type is promoted.

I couldn't think of a case where this breaks; tests seem to pass, including `hackageTests`.