### PR TITLE
Enable checking the ‘tls’ package on CI

### DIFF
--- a/data/examples/other/comment-following-preceding-gap-out.hs
+++ b/data/examples/other/comment-following-preceding-gap-out.hs
@@ -1,0 +1,6 @@
+foo = bar
+  where
+    baz = return (quux) -- Foo
+
+    -- Bar
+    meme = gege

--- a/data/examples/other/comment-following-preceding-gap.hs
+++ b/data/examples/other/comment-following-preceding-gap.hs
@@ -1,0 +1,6 @@
+foo = bar
+  where
+    baz = return (quux) -- Foo
+
+    -- Bar
+    meme = gege

--- a/default.nix
+++ b/default.nix
@@ -53,6 +53,7 @@ in {
       "servant"
       "servant-server"
       "tensorflow"
+      "tls"
       "yesod-core"
 
       # Comment idempotence issue
@@ -68,7 +69,6 @@ in {
       # "pandoc"
       # "pipes"
       # "stack"
-      # "tls"
 
       # Missing language extension
 

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -218,7 +218,9 @@ spit dirty printingComments txt' = do
       , scDirtyLine = scDirtyLine sc || dirty
       , scRequestedDelimiter = RequestedNothing
       , scLastCommentSpan =
-          if printingComments
+          -- NOTE If there are pending comments, do not reset last comment
+          -- location.
+          if printingComments || (not . null . scPendingComments) sc
             then scLastCommentSpan sc
             else Nothing
       }


### PR DESCRIPTION
I noticed that `tls` fails the idempotence check, even though the example I extracted is terribly similar to the problem I just fixed in #356.