### PR TITLE
Do not enable -XBangPatterns by default

### DIFF
--- a/data/examples/declaration/value/function/lambda-single-line-out.hs
+++ b/data/examples/declaration/value/function/lambda-single-line-out.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 foo :: a -> a -> a
 foo x = \y -> x
 

--- a/data/examples/declaration/value/function/lambda-single-line.hs
+++ b/data/examples/declaration/value/function/lambda-single-line.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 foo :: a -> a -> a
 foo x = \y -> x
 

--- a/data/examples/declaration/value/function/pattern/strictness-out.hs
+++ b/data/examples/declaration/value/function/pattern/strictness-out.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 !a = ()
 
 ~b = ()

--- a/data/examples/declaration/value/function/pattern/strictness.hs
+++ b/data/examples/declaration/value/function/pattern/strictness.hs
@@ -1,2 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
+
 !a = ()
 ~b = ()

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -76,6 +76,7 @@ manualExts :: [Extension]
 manualExts =
   [ Arrows -- steals proc
   , Cpp -- forbidden
+  , BangPatterns -- makes certain patterns with ! fail
   , PatternSynonyms -- steals the pattern keyword
   , RecursiveDo -- steals the rec keyword
   , StaticPointers -- steals static keyword


### PR DESCRIPTION
Here is an example which fails to parse with bang patterns but succeeds otherwise:

```haskell
(!) :: Foo -> Int -> Int
(Foo n) ! p = n + p
```

To run Ormolu on this we must not enable bang patterns by default.