### PR TITLE
Group together pragmas after type signatures

### DIFF
--- a/data/examples/declaration/signature/inline/inline-out.hs
+++ b/data/examples/declaration/signature/inline/inline-out.hs
@@ -9,3 +9,7 @@ bar = id
 baz :: Int -> Int
 baz = id
 {-# INLINE [~2] baz #-}
+
+reVector :: Bundle u a -> Bundle v a
+{-# INLINE reVector #-}
+reVector = M.reVector

--- a/data/examples/declaration/signature/inline/inline.hs
+++ b/data/examples/declaration/signature/inline/inline.hs
@@ -11,3 +11,8 @@ bar = id
 baz :: Int -> Int
 baz = id
 {-#   INLINE [~2] baz #-}
+
+reVector :: Bundle u a -> Bundle v a
+
+{-# INLINE reVector #-}
+reVector = M.reVector

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -137,6 +137,7 @@ groupedDecls (DataDeclaration n) x | Just ns <- isPragma x =
   let f = occNameFS . rdrNameOcc in f n `elem` map f ns
 groupedDecls x y | Just ns <- isPragma x, Just ns' <- isPragma y = ns `intersects` ns'
 groupedDecls x (TypeSignature ns) | Just ns' <- isPragma x = ns `intersects` ns'
+groupedDecls (TypeSignature ns) x | Just ns' <- isPragma x = ns `intersects` ns'
 groupedDecls (PatternSignature ns) (Pattern n) = n `elem` ns
 groupedDecls _ _ = False
 


### PR DESCRIPTION
Closes #371.

This PR removes the newline after type signatures if the next declaration is a relevant pragma:

```
+reVector :: Bundle u a -> Bundle v a
+{-# INLINE reVector #-}
+reVector = M.reVector
```