### PR TITLE
Handle string gaps

### DIFF
--- a/data/examples/declaration/type/lits-out.hs
+++ b/data/examples/declaration/type/lits-out.hs
@@ -1,0 +1,6 @@
+type A = "foo"
+
+type B
+  = "foo\
+    \bar"
+  -> ()

--- a/data/examples/declaration/type/lits.hs
+++ b/data/examples/declaration/type/lits.hs
@@ -1,0 +1,4 @@
+type A = "foo"
+
+type B = "foo\
+         \bar" -> ()

--- a/data/examples/declaration/value/function/strings-out.hs
+++ b/data/examples/declaration/value/function/strings-out.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE MagicHash #-}
+
+foo = "foobar"
+
+bar = "foo\&barbaz"
+
+baz =
+  "foo\
+  \bar\
+  \baz"

--- a/data/examples/declaration/value/function/strings.hs
+++ b/data/examples/declaration/value/function/strings.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE MagicHash #-}
+
+foo = "foobar"
+bar = "foo\&bar\   \baz"
+baz = "foo\
+      \bar\
+    \baz"

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
@@ -3,6 +3,7 @@ module Ormolu.Printer.Meat.Declaration.Value
   , p_pat
   , p_hsExpr
   , p_hsSplice
+  , p_stringLit
   )
 where
 
@@ -16,3 +17,5 @@ p_pat :: Pat GhcPs -> R ()
 p_hsExpr :: HsExpr GhcPs -> R ()
 
 p_hsSplice :: HsSplice GhcPs -> R ()
+
+p_stringLit :: String -> R ()

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -14,11 +14,12 @@ module Ormolu.Printer.Meat.Type
 where
 
 import GHC
+import BasicTypes
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Operators
 import Ormolu.Utils
-import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsSplice)
+import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsSplice, p_stringLit)
 
 p_hsType :: HsType GhcPs -> R ()
 p_hsType = \case
@@ -131,7 +132,10 @@ p_hsType = \case
         ((L _ t):_) | isPromoted t -> space
         _ -> return ()
       sep (comma >> breakpoint) (located' p_hsType) xs
-  HsTyLit NoExt t -> atom t
+  HsTyLit NoExt t ->
+    case t of
+      HsStrTy (SourceText s) _ -> p_stringLit s
+      a -> atom a
   HsWildCardTy NoExt -> txt "_"
   XHsType (NHsCoreTy t) -> atom t
   where


### PR DESCRIPTION
Closes #369.

Haskell strings can have "gaps", where any amount of whitespace between
two backslashes are ignored. This allows writing multi-line strings. As
an example, all strings below are the same:

```
"foobar"
"foo\   \bar"
"foo\

   \bar"
```

When parsing a string literal, lexer usually produces two fields, one
of them is the actual string user wrote as a 'SourceText', the other one
is the sanitized version where gaps and other special characters removed.

While printing the string, GHC's Outputable instance uses the 'SourceText'
field, however since that text contains gaps as-is, we can not change
the original indentation. In order to fix this, this commit splits the
strings by the gaps and print each line separately applying the layout
rules.

Also, it applies the same logic to type-level strings.