### PR TITLE
Hang guarded equations

### DIFF
--- a/data/examples/declaration/value/function/case-multi-line-guards-out.hs
+++ b/data/examples/declaration/value/function/case-multi-line-guards-out.hs
@@ -9,6 +9,8 @@ withGuards x =
     _ -> 20
 
 case x of
-  '-' | not isUrl ->
+  '-' | not isUrl -> case xs of
+    _ -> emitc '-'
+  '*' | not isUrl ->
     case xs of
-      _ -> emitc '-'
+      _ -> emitc '*'

--- a/data/examples/declaration/value/function/case-multi-line-guards.hs
+++ b/data/examples/declaration/value/function/case-multi-line-guards.hs
@@ -10,3 +10,6 @@ withGuards x =
 case x of
   '-' | not isUrl -> case xs of
         _ -> emitc '-'
+  '*' | not isUrl ->
+        case xs of
+          _ -> emitc '*'


### PR DESCRIPTION
Previously guarded expressions were always printed in non-hanging fashion even if they had a hanging form. This change fixes this behavior.