### PR TITLE
Introduce a breakpoint after ‘forall’ in type signatures

### DIFF
--- a/data/examples/declaration/rewrite-rule/type-signature-out.hs
+++ b/data/examples/declaration/rewrite-rule/type-signature-out.hs
@@ -7,7 +7,8 @@
   k
   z
   ( g
-      :: forall b. (a -> b -> b)
+      :: forall b.
+         (a -> b -> b)
       -> b
       -> b
     ).

--- a/data/examples/declaration/signature/type/arguments-out.hs
+++ b/data/examples/declaration/signature/type/arguments-out.hs
@@ -4,7 +4,8 @@ functionName
   :: (C1, C2, C3, C4, C5)
   => a
   -> b
-  -> ( forall a. (C6, C7)
+  -> ( forall a.
+          (C6, C7)
        => LongDataTypeName
        -> a
        -> AnotherLongDataTypeName

--- a/data/examples/declaration/type/forall-out.hs
+++ b/data/examples/declaration/type/forall-out.hs
@@ -1,0 +1,4 @@
+type CoerceLocalSig m m'
+  = forall r a.
+     LocalSig m r a
+  -> LocalSig m' r a

--- a/data/examples/declaration/type/forall.hs
+++ b/data/examples/declaration/type/forall.hs
@@ -1,0 +1,4 @@
+type CoerceLocalSig m m' =
+  forall r a.
+  LocalSig m  r a ->
+  LocalSig m' r a

--- a/data/examples/declaration/value/function/fancy-forall-0-out.hs
+++ b/data/examples/declaration/value/function/fancy-forall-0-out.hs
@@ -1,0 +1,10 @@
+wrapError
+  :: forall outertag innertag t outer inner m a.
+     ( forall x. Coercible (t m x) (m x),
+       forall m'.
+          HasCatch outertag outer m'
+       => HasCatch innertag inner (t m'),
+       HasCatch outertag outer m
+       )
+  => (forall m'. HasCatch innertag inner m' => m' a)
+  -> m a

--- a/data/examples/declaration/value/function/fancy-forall-0.hs
+++ b/data/examples/declaration/value/function/fancy-forall-0.hs
@@ -1,0 +1,6 @@
+wrapError :: forall outertag innertag t outer inner m a.
+  ( forall x. Coercible (t m x) (m x)
+  , forall m'. HasCatch outertag outer m'
+    => HasCatch innertag inner (t m')
+  , HasCatch outertag outer m )
+  => (forall m'. HasCatch innertag inner m' => m' a) -> m a

--- a/data/examples/declaration/value/function/fancy-forall-1-out.hs
+++ b/data/examples/declaration/value/function/fancy-forall-1-out.hs
@@ -1,0 +1,10 @@
+magnify
+  :: forall outertag innertag t outer inner m a.
+     ( forall x. Coercible (t m x) (m x),
+       forall m'.
+          HasReader outertag outer m'
+       => HasReader innertag inner (t m'),
+       HasReader outertag outer m
+       )
+  => (forall m'. HasReader innertag inner m' => m' a)
+  -> m a

--- a/data/examples/declaration/value/function/fancy-forall-1.hs
+++ b/data/examples/declaration/value/function/fancy-forall-1.hs
@@ -1,0 +1,6 @@
+magnify :: forall outertag innertag t outer inner m a.
+  ( forall x. Coercible (t m x) (m x)
+  , forall m'. HasReader outertag outer m'
+    => HasReader innertag inner (t m')
+  , HasReader outertag outer m )
+  => (forall m'. HasReader innertag inner m' => m' a) -> m a

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -27,7 +27,8 @@ p_hsType = \case
     txt "forall "
     sep space (located' p_hsTyVarBndr) bndrs
     txt "."
-    space
+    breakpoint
+    vlayout (return ()) (txt "   ")
     p_hsType (unLoc t)
   HsQualTy NoExt qs t -> do
     located qs p_hsContext


### PR DESCRIPTION
Close #148.

@utdemir I remember you tried to fix this one as well and found it hard to fix properly. I understand that my fix is a bit hacky because of the `txt "   "` bit which I imagine may look very strange in certain situations, but I fail to come up with any such realistic examples. Please take a look at this and tell me what you think.