### PR TITLE
Do not use GHC's defaultErrorHandler

### DIFF
--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -131,9 +131,10 @@ initDynFlagsPure fp input = do
 -- | Default runner of 'GHC.Ghc' action in 'IO'.
 
 ghcWrapper :: GHC.Ghc a -> IO a
-ghcWrapper
-  = GHC.defaultErrorHandler GHC.defaultFatalMessager GHC.defaultFlushOut
-  . GHC.runGhc (Just libdir)
+ghcWrapper act =
+  let GHC.FlushOut flushOut = GHC.defaultFlushOut
+  in  GHC.runGhc (Just libdir) act
+        `finally` flushOut
 
 -- | Run a 'GHC.P' computation.
 


### PR DESCRIPTION
Close #380.

`defaultErrorHandler` makes the exceptions get wrapped as GHC panic's, which is misleading.

It doesn't look like `defaultErrorHandler` is doing a lot other than running `FlushOut`, wrapping exceptions and handling exit codes; so in our case I think just running `FlushOut` should be enough.

GHC sources for details: https://gitlab.haskell.org/ghc/ghc/blob/993804bf40dea77c36f50ff772d112ec69c8a222/compiler/main/GHC.hs#L391