### PR TITLE
Handle operators as record fields

### DIFF
--- a/data/examples/declaration/value/function/record-constructors-out.hs
+++ b/data/examples/declaration/value/function/record-constructors-out.hs
@@ -7,6 +7,8 @@ bar = Bar
 
 baz = Baz {}
 
+sym = Foo {(+) = 3}
+
 aLongVariableName =
   ALongRecordName
     { short = baz,

--- a/data/examples/declaration/value/function/record-constructors.hs
+++ b/data/examples/declaration/value/function/record-constructors.hs
@@ -4,7 +4,7 @@ bar = Bar {
     def = Foo {a = 10}
 }
 baz = Baz{ }
-
+sym = Foo { (+) = 3 }
 aLongVariableName =
   ALongRecordName
     { short = baz,

--- a/data/examples/declaration/value/function/record-updaters-out.hs
+++ b/data/examples/declaration/value/function/record-updaters-out.hs
@@ -7,3 +7,5 @@ bar x =
       }
 
 baz x = x {}
+
+sym x = x {(+) = 4}

--- a/data/examples/declaration/value/function/record-updaters.hs
+++ b/data/examples/declaration/value/function/record-updaters.hs
@@ -4,3 +4,4 @@ bar x = x {
     def = Foo {a = 10}
 }
 baz x = x{ }
+sym x = x { (+) = 4 }

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -26,7 +26,6 @@ import Ormolu.Printer.Meat.Declaration.Signature
 import Ormolu.Printer.Meat.Type
 import Ormolu.Printer.Operators
 import Ormolu.Utils
-import Outputable (Outputable (..))
 import RdrName (rdrNameOcc)
 import SrcLoc (combineSrcSpans, isOneLineSpan)
 import qualified Data.List.NonEmpty as NE
@@ -455,11 +454,10 @@ p_hsLocalBinds = \case
   XHsLocalBindsLR _ -> notImplemented "XHsLocalBindsLR"
 
 p_hsRecField
-  :: (Data id, Outputable id)
-  => HsRecField' id (LHsExpr GhcPs)
+  :: HsRecField' RdrName (LHsExpr GhcPs)
   -> R ()
 p_hsRecField = \HsRecField {..} -> do
-  located hsRecFieldLbl atom
+  p_rdrName hsRecFieldLbl
   unless hsRecPun $ do
     space
     txt "="
@@ -612,7 +610,12 @@ p_hsExpr = \case
     located rcon_con_name atom
     breakpoint
     let HsRecFields {..} = rcon_flds
-        fields = located' p_hsRecField <$> rec_flds
+        updName f = f {
+          hsRecFieldLbl = case unLoc $ hsRecFieldLbl f of
+            FieldOcc _ n -> n
+            XFieldOcc _ -> notImplemented "XFieldOcc"
+          }
+        fields = located' (p_hsRecField . updName) <$> rec_flds
         dotdot =
           case rec_dotdot of
             Just {} -> [txt ".."]
@@ -621,8 +624,17 @@ p_hsExpr = \case
   RecordUpd {..} -> do
     located rupd_expr p_hsExpr
     breakpoint
+    let updName f = f {
+          hsRecFieldLbl = case unLoc $ hsRecFieldLbl f of
+            Ambiguous _ n -> n
+            Unambiguous _ n -> n
+            XAmbiguousFieldOcc _ -> notImplemented "XAmbiguousFieldOcc"
+          }
     inci . braces . sitcc $
-      sep (comma >> breakpoint) (sitcc . located' p_hsRecField) rupd_flds
+      sep
+        (comma >> breakpoint)
+        (sitcc . located' (p_hsRecField . updName))
+        rupd_flds
   ExprWithTySig affix x -> sitcc $ do
     located x p_hsExpr
     breakpoint


### PR DESCRIPTION
Closes #383.

This PR puts parenthesis arounds operators when used as record accessors.