### PR TITLE
Tweak hanging logic on HsApp

### DIFF
--- a/data/examples/declaration/value/function/block-arguments-out.hs
+++ b/data/examples/declaration/value/function/block-arguments-out.hs
@@ -1,13 +1,11 @@
 f1 = foo do bar
 
-f2 =
-  foo do
-    bar
+f2 = foo do
+  bar
 
-f3 =
-  foo case True of
-    True -> bar
-    False -> baz
+f3 = foo case True of
+  True -> bar
+  False -> baz
 
 f4 = foo let a = 3 in b
 
@@ -25,6 +23,5 @@ f6 =
 
 f7 = foo \x -> y
 
-f8 =
-  foo \x ->
-    y
+f8 = foo \x ->
+  y

--- a/data/examples/declaration/value/function/record-constructors-out.hs
+++ b/data/examples/declaration/value/function/record-constructors-out.hs
@@ -13,13 +13,12 @@ aLongVariableName =
       aLongRecordFieldName = YetAnotherLongRecordName
         { yetAnotherLongRecordFieldName = "a long string"
           },
-      aLongRecordFieldName2 =
-        Just YetAnotherLongRecordName
-          { yetAnotherLongRecordFieldName = "a long string",
-            yetAnotherLongRecordFieldName =
-              Just
-                "a long string"
-            },
+      aLongRecordFieldName2 = Just YetAnotherLongRecordName
+        { yetAnotherLongRecordFieldName = "a long string",
+          yetAnotherLongRecordFieldName =
+            Just
+              "a long string"
+          },
       aLongRecordFieldName3 = do
         foo
         bar


### PR DESCRIPTION
Closes #381.

This PR makes a few changes on HsApp printer mainly to play well with `-XBlockArguments`.

1. Only hang the last argument.

This is to fix #381. If we hang any other argument, there is a chance that the next argument will be fused to it.

2. Use braces on `HsApp` arguments.

Otherwise:

```haskell
foo = foo bar do { bar } baz
```

causes the AST to differ.

3. Only use the hanging placement when the LHS is one line:

Otherwise it looks strange:

```haskell
foo =
  f
    bar
    baz do
    foo
```

4. Hang the construct when the rightmost argument is hanging

This is to allow:

```haskell
foo = foo bar do
  baz
```

5. Do not sit when we're using hanging placement

Otherwise we get:

```haskell
func = foo bar do
         baz
```

Which is different compared to how we handle `$`:

```haskell
func = foo bar $ do
  baz
```

---

First two are pretty much obligatory, but let me know of your opinions of the rest.