### PR TITLE
Preserve & collapse blank lines when possible for do/let/where

### DIFF
--- a/src/Ormolu/Printer/Operators.hs
+++ b/src/Ormolu/Printer/Operators.hs
@@ -18,6 +18,7 @@ import GHC
 import OccName (mkVarOcc)
 import RdrName (mkRdrUnqual)
 import SrcLoc (combineSrcSpans)
+import Ormolu.Utils (unSrcSpan)
 
 -- | Intermediate representation of operator trees. It has two type
 -- parameters: @ty@ is the type of sub-expressions, while @op@ is the type
@@ -159,9 +160,6 @@ buildFixityMap getOpName opTree =
           , maybe 0 srcSpanStartCol (unSrcSpan o)
           , go r
           ]
-
-    unSrcSpan (RealSrcSpan r) = Just r
-    unSrcSpan (UnhelpfulSpan _) = Nothing
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -7,6 +7,7 @@ module Ormolu.Utils
   , isModule
   , notImplemented
   , showOutputable
+  , unSrcSpan
   )
 where
 
@@ -34,3 +35,7 @@ notImplemented msg = error $ "not implemented yet: " ++ msg
 
 showOutputable :: GHC.Outputable o => o -> String
 showOutputable = GHC.showSDocUnsafe . GHC.ppr
+
+unSrcSpan :: SrcSpan -> Maybe RealSrcSpan
+unSrcSpan (RealSrcSpan r) = Just r
+unSrcSpan (UnhelpfulSpan _) = Nothing


### PR DESCRIPTION
This respects blank lines (and collapses if there are more than one) for `do`/`let`/`where` blocks.

A start towards #74.