### PR TITLE
Don't use braces inside parens

### DIFF
--- a/data/examples/declaration/value/function/parens-out.hs
+++ b/data/examples/declaration/value/function/parens-out.hs
@@ -1,0 +1,1 @@
+f = p (do foo; bar) baz

--- a/data/examples/declaration/value/function/parens.hs
+++ b/data/examples/declaration/value/function/parens.hs
@@ -1,0 +1,1 @@
+f = p (do foo; bar) baz

--- a/src/Ormolu/Printer/Meat/Declaration/Type.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Type.hs
@@ -30,7 +30,7 @@ p_synDecl name fixity tvars t = do
   let HsQTvs {..} = tvars
   switchLayout (getLoc name : map getLoc hsq_explicit) $ do
     p_infixDefHelper
-      (case fixity of { Infix -> True; _ -> False })
+      (case fixity of Infix -> True; _ -> False)
       inci
       (p_rdrName name)
       (map (located' p_hsTyVarBndr) hsq_explicit)

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -557,7 +557,8 @@ p_hsExpr' s = \case
     txt "-"
     space
     located e p_hsExpr
-  HsPar NoExt e -> parens s (located e p_hsExpr)
+  HsPar NoExt e ->
+    parens s (located e (dontUseBraces . p_hsExpr))
   SectionL NoExt x op -> do
     located x p_hsExpr
     breakpoint


### PR DESCRIPTION
Since parens already delimites the construct inside, we can omit braces there.

Saw this issue when formatting Ormolu itself (also on the diff).