### PR TITLE
Restore ‘--ghc-opt’ options again, report unrecognized options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   necessarily depending on the newest version of the compiler. In addition
   to that Ormolu is now GHCJS-compatible.
 
+* Now unrecognized GHC options passed with `--ghc-opt` cause Ormolu to fail
+  (exit code 7).
+
 * Fixed formatting of result type in closed type families. See [issue
   420](https://github.com/tweag/ormolu/issues/420).
 

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -51,11 +51,11 @@ ormolu ::
   String ->
   m Text
 ormolu cfg path str = do
-  (ws, result0) <-
+  (warnings, result0) <-
     parseModule' cfg OrmoluParsingFailed path str
   when (cfgDebug cfg) $ do
     traceM "warnings:\n"
-    traceM (concatMap showWarn ws)
+    traceM (concatMap showWarn warnings)
     traceM (prettyPrintParseResult result0)
   -- NOTE We're forcing 'txt' here because otherwise errors (such as
   -- messages about not-yet-supported functionality) will be thrown later
@@ -133,10 +133,10 @@ parseModule' ::
   String ->
   m ([GHC.Warn], ParseResult)
 parseModule' cfg mkException path str = do
-  (ws, r) <- parseModule cfg path str
+  (warnings, r) <- parseModule cfg path str
   case r of
     Left (spn, err) -> liftIO $ throwIO (mkException spn err)
-    Right x -> return (ws, x)
+    Right x -> return (warnings, x)
 
 -- | Pretty-print a 'GHC.Warn'.
 showWarn :: GHC.Warn -> String


### PR DESCRIPTION
Close #437.

While migrating to `ghc-lib-parser` we accidentally stopped taking into account the `--ghc-opt` options. This commit fixes that and makes sure we do not ignore unrecognized GHC options.