### PR TITLE
Decrease syntax noise by changing if-then-else 2-level layout to 1-level

### DIFF
--- a/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
@@ -23,8 +23,8 @@ foo
           ( b + 1, -- Funnel into arrow
             d * b
           )
-      if x `mod` y == 0 -- Basic condition
-        then case e of -- Only left case is relevant
+      if x `mod` y == 0 then -- Basic condition
+        case e of -- Only left case is relevant
           Left
             ( z,
               w
@@ -36,23 +36,24 @@ foo
                       -- Just do the calculation
                       (x + y * z)
                   )
-        else do
-          let u = x -- Let bindings bind expressions, not commands
-            -- Could pattern match directly on x
-          i <- case u of
-            0 -> (g . h -< u)
-            n ->
-              ( ( h . g -<
-                    y -- First actual use of y
-                )
+      else do
+        let u = x -- Let bindings bind expressions, not commands
+          -- Could pattern match directly on x
+        i <- case u of
+          0 -> (g . h -< u)
+          n ->
+            ( ( h . g -<
+                  y -- First actual use of y
               )
-          returnA -< ()
-          -- Sometimes execute effects
-          if i > 0
-            then ma -< ()
-            else returnA -< ()
-          returnA -<
-            ( i
-                + x
-                * y -- Just do the calculation
             )
+        returnA -< ()
+        -- Sometimes execute effects
+        if i > 0 then
+          ma -< ()
+        else
+          returnA -< ()
+        returnA -<
+          ( i
+              + x
+              * y -- Just do the calculation
+          )

--- a/data/examples/declaration/value/function/arrow/proc-ifs-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-ifs-out.hs
@@ -3,11 +3,10 @@
 foo f = proc a -> if a then f -< 0 else f -< 1
 
 bar f g = proc a ->
-  if f a
-    then
-      f
-        . g -<
-        a
-    else
-      g -<
-        b
+  if f a then
+    f
+      . g -<
+      a
+  else
+    g -<
+      b

--- a/data/examples/declaration/value/function/block-arguments-out.hs
+++ b/data/examples/declaration/value/function/block-arguments-out.hs
@@ -17,9 +17,10 @@ f5 =
 
 f6 =
   foo
-    if bar
-      then baz
-      else not baz
+    if bar then
+      baz
+    else
+      not baz
 
 f7 = foo \x -> y
 

--- a/data/examples/declaration/value/function/case-multi-line-out.hs
+++ b/data/examples/declaration/value/function/case-multi-line-out.hs
@@ -7,9 +7,10 @@ bar :: Int -> Int
 bar x =
   case x of
     5 ->
-      if x > 5
-        then 10
-        else 12
+      if x > 5 then
+        10
+      else
+        12
     _ -> 12
 
 baz :: Int -> Int

--- a/data/examples/declaration/value/function/do/applications-and-parens-out.hs
+++ b/data/examples/declaration/value/function/do/applications-and-parens-out.hs
@@ -1,9 +1,10 @@
 warningFor var place = do
   guard $ isVariableName var
   guard . not $ isInArray var place || isGuarded place
-  ( if includeGlobals || isLocal var
-      then warningForLocals
-      else warningForGlobals
+  ( if includeGlobals || isLocal var then
+      warningForLocals
+    else
+      warningForGlobals
     )
     var
     place

--- a/data/examples/declaration/value/function/do/expr-out.hs
+++ b/data/examples/declaration/value/function/do/expr-out.hs
@@ -4,7 +4,8 @@ quux = something $ do
     1 -> 10
     2 -> 20
   bar
-  if something
-    then x
-    else y
+  if something then
+    x
+  else
+    y
   baz

--- a/data/examples/declaration/value/function/if-multi-line-out.hs
+++ b/data/examples/declaration/value/function/if-multi-line-out.hs
@@ -1,23 +1,32 @@
 foo :: Int -> Int
 foo x =
-  if x > 5
-    then 10
-    else 12
+  if x > 5 then
+    10
+  else
+    12
 
 bar :: Int -> Int
 bar x =
-  if x > 5
-    then
-      foo x
-        + 100
-    else case x of
+  if x > 5 then
+    foo x
+      + 100
+  else
+    case x of
       1 -> 10
       _ -> 20
 
 baz :: Int -> Bar
 baz x =
-  if x > 5
-    then \case
+  if x > 5 then
+    \case
       Foo -> bar
-    else do
-      undefined
+  else do
+    undefined
+
+qux :: Int -> Bar
+qux x =
+  if x > 5
+    && x < 7 then
+    Ok
+  else
+    NotOk

--- a/data/examples/declaration/value/function/if-multi-line.hs
+++ b/data/examples/declaration/value/function/if-multi-line.hs
@@ -20,3 +20,10 @@ baz x =
   else
     do
       undefined
+
+qux :: Int -> Bar
+qux x =
+  if x > 5 &&
+     x < 7
+  then Ok
+  else NotOk

--- a/data/examples/declaration/value/function/lambda-multi-line1-out.hs
+++ b/data/examples/declaration/value/function/lambda-multi-line1-out.hs
@@ -4,9 +4,10 @@ foo x = \y ->
 
 bar :: Int -> Int -> Int
 bar x = \y ->
-  if x > y
-    then 10
-    else 12
+  if x > y then
+    10
+  else
+    12
 
 foo =
   prop "is inverse to closure" $

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -60,7 +60,7 @@ data Placement
     -- should use it and avoid bumping one level
     -- of indentation
     Hanging
-  deriving (Eq)
+  deriving (Eq, Show)
 
 p_valDecl :: HsBindLR GhcPs GhcPs -> R ()
 p_valDecl = \case
@@ -337,7 +337,7 @@ p_hsCmd = \case
   HsCmdCase NoExt e mgroup ->
     p_case cmdPlacement p_hsCmd e mgroup
   HsCmdIf NoExt _ if' then' else' ->
-    p_if cmdPlacement p_hsCmd if' then' else'
+    p_if cmdThenElsePlacement p_hsCmd if' then' else'
   HsCmdLet NoExt localBinds c ->
     p_let p_hsCmd localBinds c
   HsCmdDo NoExt es -> do
@@ -612,7 +612,7 @@ p_hsExpr' s = \case
   HsCase NoExt e mgroup ->
     p_case exprPlacement p_hsExpr e mgroup
   HsIf NoExt _ if' then' else' ->
-    p_if exprPlacement p_hsExpr if' then' else'
+    p_if exprThenElsePlacement p_hsExpr if' then' else'
   HsMultiIf NoExt guards -> do
     txt "if"
     breakpoint
@@ -866,15 +866,14 @@ p_if placer render if' then' else' = do
   txt "if"
   space
   located if' p_hsExpr
+  space
+  txt "then"
+  p_body then'
   breakpoint
-  inci $ do
-    txt "then"
-    located then' $ \x ->
-      placeHanging (placer x) (render x)
-    breakpoint
-    txt "else"
-    located else' $ \x ->
-      placeHanging (placer x) (render x)
+  txt "else"
+  p_body else'
+  where
+    p_body body = placeHanging (placer $ unLoc body) $ located body render
 
 p_let ::
   Data body =>
@@ -1167,6 +1166,12 @@ blockPlacement ::
 blockPlacement placer [(L _ (GRHS NoExt _ (L _ x)))] = placer x
 blockPlacement _ _ = Normal
 
+-- | Check if given command has a hanging form for if-then-else body.
+cmdThenElsePlacement :: HsCmd GhcPs -> Placement
+cmdThenElsePlacement = \case
+  HsCmdDo NoExt _ -> Hanging
+  _ -> Normal
+
 -- | Check if given command has a hanging form.
 cmdPlacement :: HsCmd GhcPs -> Placement
 cmdPlacement = \case
@@ -1179,6 +1184,13 @@ cmdTopPlacement :: HsCmdTop GhcPs -> Placement
 cmdTopPlacement = \case
   HsCmdTop NoExt (L _ x) -> cmdPlacement x
   XCmdTop {} -> notImplemented "XCmdTop"
+
+-- | Check if given expression has a hanging form for if-then-else body.
+exprThenElsePlacement :: HsExpr GhcPs -> Placement
+exprThenElsePlacement = \case
+  HsDo NoExt DoExpr _ -> Hanging
+  HsDo NoExt MDoExpr _ -> Hanging
+  _ -> Normal
 
 -- | Check if given expression has a hanging form.
 exprPlacement :: HsExpr GhcPs -> Placement


### PR DESCRIPTION
Motivation
----------

Before:

```hs
if condition
  then do
    2nd level of indentation
  else do
    2nd level of indentation
-- 5 lines, 2 of them are purely syntactical, with no semantics
```

After:

```hs
if condition then do
  1st level of indentation
else do
  1st level of indentation
-- 4 lines
```

1. Exactly 1 indentation for 1 code block => Lesser code depth. Currently, the number of indentation levels is twice greater than the number of semantic layers.
2. Closer to if-statement layout in other languages. => More friendly to newcomers with experience in other languages.

Drawbacks (not problems in my opinion)
---------------------------------------

1.  In Haskell98 mode, usage in do-blocks needs NonDecreasingIndentation extension.
    Usage in pure expressions works out of the box.
    In Haskell2010 mode, it works out of the box.

2.  Longer lines in some cases due to ` then` ending.

3.  More lines in short cases:

	```hs
	-- before: 3 lines
	if condition
	  then x
	  else y
	```

    vs.

	```hs
	-- after: 4 lines
	if condition then
	  x
	else
	  y
	```

4.  Reformatting code formatted with ormolu 0.0.1.0. This is not a problem since 0.0.1.0 doesn't commit being stable.

    Compensated by the decrease in longer cases, see example in Motivation section.