### PR TITLE
Use braces when placing `$` after an expression

### DIFF
--- a/data/examples/declaration/value/function/infix/dollar-chains-out.hs
+++ b/data/examples/declaration/value/function/infix/dollar-chains-out.hs
@@ -16,3 +16,7 @@ foo =
   bar
     $ baz
     $ quux
+
+x =
+  case l of { A -> B } $
+    case q of r -> s

--- a/data/examples/declaration/value/function/infix/dollar-chains.hs
+++ b/data/examples/declaration/value/function/infix/dollar-chains.hs
@@ -16,3 +16,7 @@ foo =
   bar
     $ baz
     $ quux
+
+x =
+  case l of { A -> B } $
+  case q of r -> s

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1259,21 +1259,24 @@ p_exprOpTree isDollarSpecial s (OpBranch x op y) = do
       gotDollar = case getOpName (unLoc op) of
         Just rname -> mkVarOcc "$" == (rdrNameOcc rname)
         _ -> False
-  switchLayout [opTreeLoc x]
-    $ ub
-    $ p_exprOpTree (not gotDollar) s x
+      lhs =
+        switchLayout [opTreeLoc x] $
+          p_exprOpTree (not gotDollar) s x
   let p_op = located op (opWrapper . p_hsExpr)
       p_y = switchLayout [opTreeLoc y] (p_exprOpTree True N y)
   if isDollarSpecial && gotDollar && placement == Normal && isOneLineSpan (opTreeLoc x)
     then do
+      useBraces lhs
       space
       p_op
       breakpoint
       inci p_y
-    else placeHanging placement $ do
-      p_op
-      space
-      p_y
+    else do
+      ub lhs
+      placeHanging placement $ do
+        p_op
+        space
+        p_y
 
 -- | Get annotations for the enclosing element.
 getEnclosingAnns :: R [AnnKeywordId]


### PR DESCRIPTION
Closes #446.

When we are putting an operator after an expression (we
do that when special-casing `$`), we have to make sure that
there are braces in LHS.