### PR TITLE
Insert comments between declarations and their preceding Haddocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
 * Fixed [issue 446](https://github.com/tweag/ormolu/issues/446), which
   involved braces and operators.
 
+* When there are comments between preceding Haddock (pipe-style) and its
+  corresponding declaration they are preserved like this in the output
+  instead of being shifted. To be clear, this is not a very good idea to
+  have comments in that position because the Haddock will end up not being
+  associated with the declarations. Issues
+  [440](https://github.com/tweag/ormolu/issues/440) and
+  [448](https://github.com/tweag/ormolu/issues/448).
+
 ## Ormolu 0.0.1.0
 
 * Initial release.

--- a/data/examples/other/comment-after-preceding-haddock-out.hs
+++ b/data/examples/other/comment-after-preceding-haddock-out.hs
@@ -1,0 +1,12 @@
+module Main where
+
+-- | A
+
+-- B
+
+type D = E
+
+-- | This is 'f'
+
+--     * Comment
+f :: a -> b

--- a/data/examples/other/comment-after-preceding-haddock.hs
+++ b/data/examples/other/comment-after-preceding-haddock.hs
@@ -1,0 +1,12 @@
+module Main where
+
+-- | A
+
+-- B
+
+type D = E
+
+-- | This is 'f'
+
+--     * Comment
+f :: a -> b

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -29,19 +29,12 @@ spitPrecedingComments ::
   RealLocated a ->
   R ()
 spitPrecedingComments ref = do
-  r <- getLastCommentSpan
-  case r of
-    Just (Just Pipe, _) ->
-      -- We should not insert comments between pipe Haddock and the thing
-      -- it's attached to.
-      return ()
-    _ -> do
-      gotSome <- handleCommentSeries (spitPrecedingComment ref)
-      when gotSome $ do
-        -- Insert a blank line between the preceding comments and the thing
-        -- after them if there was a blank line in the input.
-        lastSpn <- fmap snd <$> getLastCommentSpan
-        when (needsNewlineBefore (getRealSrcSpan ref) lastSpn) newline
+  gotSome <- handleCommentSeries (spitPrecedingComment ref)
+  when gotSome $ do
+    -- Insert a blank line between the preceding comments and the thing
+    -- after them if there was a blank line in the input.
+    lastSpn <- fmap snd <$> getLastCommentSpan
+    when (needsNewlineBefore (getRealSrcSpan ref) lastSpn) newline
 
 -- | Output all comments following an element at given location.
 spitFollowingComments ::


### PR DESCRIPTION
Close #440, close #448.

I originally thought it's a good idea to prevent this, but it looks like it
makes things arguably worse in certain cases even though the Haddocks end up
not associated with their declarations (but they are not associated with
them in the input either, so it's OK).