### PR TITLE
Implement correct handling of shebangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
   [440](https://github.com/tweag/ormolu/issues/440) and
   [448](https://github.com/tweag/ormolu/issues/448).
 
+* Implemented correct handling of shebangs. [Issue
+  377](https://github.com/tweag/ormolu/issues/377).
+
 ## Ormolu 0.0.1.0
 
 * Initial release.

--- a/data/examples/module-header/shebang-out.hs
+++ b/data/examples/module-header/shebang-out.hs
@@ -1,4 +1,5 @@
 #! /usr/bin/env runhaskell
+
 import Prelude
 
 main :: IO ()

--- a/data/examples/module-header/shebang-with-pragmas-out.hs
+++ b/data/examples/module-header/shebang-with-pragmas-out.hs
@@ -1,0 +1,5 @@
+#!/usr/bin/env stack
+
+{-# LANGUAGE OverloadedStrings #-}
+
+main = pure ()

--- a/data/examples/module-header/shebang-with-pragmas.hs
+++ b/data/examples/module-header/shebang-with-pragmas.hs
@@ -1,0 +1,5 @@
+#!/usr/bin/env stack
+
+{-# LANGUAGE OverloadedStrings #-}
+
+main = pure ()

--- a/data/examples/module-header/shebang.hs
+++ b/data/examples/module-header/shebang.hs
@@ -1,4 +1,5 @@
 #! /usr/bin/env runhaskell
+
 import Prelude
 
 main :: IO ()

--- a/src/Ormolu/Parser/Result.hs
+++ b/src/Ormolu/Parser/Result.hs
@@ -22,7 +22,9 @@ data ParseResult
         -- | Comment stream
         prCommentStream :: CommentStream,
         -- | Extensions enabled in that module
-        prExtensions :: [Pragma]
+        prExtensions :: [Pragma],
+        -- | Shebangs found in the input
+        prShebangs :: [Located String]
       }
 
 -- | Pretty-print a 'ParseResult'.

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -20,7 +20,7 @@ printModule ::
   Text
 printModule ParseResult {..} =
   runR
-    (p_hsModule prExtensions prParsedSource)
+    (p_hsModule prShebangs prExtensions prParsedSource)
     (mkSpanStream prParsedSource)
     prCommentStream
     prAnns


### PR DESCRIPTION
Close #377.

Also: rename and document some functions we took from `ghc-exact-print`.