### PR TITLE
Take non-commutative nature of language pragmas into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 * Implemented correct handling of stack headers. [Issue
   393](https://github.com/tweag/ormolu/issues/393).
 
+* Sorting language pragmas cannot not change meaning of the input program
+  anymore. [Issue 404](https://github.com/tweag/ormolu/issues/404).
+
 ## Ormolu 0.0.1.0
 
 * Initial release.

--- a/data/examples/declaration/class/type-operators3-out.hs
+++ b/data/examples/declaration/class/type-operators3-out.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE NoStarIsType #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoStarIsType #-}
 
 class PNum x where
   type (a :: x) * (b :: x)

--- a/data/examples/other/pragma-sorting-out.hs
+++ b/data/examples/other/pragma-sorting-out.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE NondecreasingIndentation #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoMonoLocalBinds #-}
+
+-- This gap is necessary for stylish Haskell not to re-arrange
+-- NoMonoLocalBinds before TypeFamilies
+
+module Foo
+  ( bar,
+  )
+where

--- a/data/examples/other/pragma-sorting.hs
+++ b/data/examples/other/pragma-sorting.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE NondecreasingIndentation #-}
+-- This gap is necessary for stylish Haskell not to re-arrange
+-- NoMonoLocalBinds before TypeFamilies
+{-# LANGUAGE NoMonoLocalBinds    #-}
+
+module Foo (
+   bar
+  ) where

--- a/src/Ormolu/Printer/Meat/Pragma.hs
+++ b/src/Ormolu/Printer/Meat/Pragma.hs
@@ -8,18 +8,46 @@ module Ormolu.Printer.Meat.Pragma
   )
 where
 
+import Data.Char (isUpper)
+import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Ormolu.Parser.Pragma (Pragma (..))
 import Ormolu.Printer.Combinators
 
-data PragmaTy = Language | OptionsGHC | OptionsHaddock
+-- | Pragma classification.
+data PragmaTy
+  = Language LanguagePragmaClass
+  | OptionsGHC
+  | OptionsHaddock
+  deriving (Eq, Ord)
+
+-- | Language pragma classification.
+--
+-- The order in which language pragmas are put in the input sometimes
+-- matters. This is because some language extensions can enable other
+-- extensions, yet the extensions coming later in the list have the ability
+-- to change it. So here we classify all extensions by assigning one of the
+-- four groups to them. Then we only sort inside of the groups.
+--
+-- 'Ord' instance of this data type is what affects the sorting.
+--
+-- See also: <https://github.com/tweag/ormolu/issues/404>
+data LanguagePragmaClass
+  = -- | All other extensions
+    Normal
+  | -- | Extensions starting with "No"
+    Disabling
+  | -- | Extensions that should go after everything else
+    Final
   deriving (Eq, Ord)
 
 p_pragmas :: [Pragma] -> R ()
 p_pragmas ps =
   let prepare = concatMap $ \case
-        PragmaLanguage xs -> (Language,) <$> xs
+        PragmaLanguage xs ->
+          let f x = (Language (classifyLanguagePragma x), x)
+           in f <$> xs
         PragmaOptionsGHC x -> [(OptionsGHC, x)]
         PragmaOptionsHaddock x -> [(OptionsHaddock, x)]
    in mapM_ (uncurry p_pragma) (S.toAscList . S.fromList . prepare $ ps)
@@ -28,10 +56,26 @@ p_pragma :: PragmaTy -> String -> R ()
 p_pragma ty c = do
   txt "{-# "
   txt $ case ty of
-    Language -> "LANGUAGE"
+    Language _ -> "LANGUAGE"
     OptionsGHC -> "OPTIONS_GHC"
     OptionsHaddock -> "OPTIONS_HADDOCK"
   space
   txt (T.pack c)
   txt " #-}"
   newline
+
+-- | Classify a 'LanguagePragma'.
+classifyLanguagePragma :: String -> LanguagePragmaClass
+classifyLanguagePragma = \case
+  "ImplicitPrelude" -> Final
+  "CUSKs" -> Final
+  str ->
+    case splitAt 2 str of
+      ("No", rest) ->
+        case listToMaybe rest of
+          Nothing -> Normal
+          Just x ->
+            if isUpper x
+              then Disabling
+              else Normal
+      _ -> Normal


### PR DESCRIPTION
Close #404.

The order in which language pragmas are put in the input sometimes matters.
This is because some language extensions can enable other extensions, yet
the extensions coming later in the list have the ability to change it. So
here we classify all extensions by assigning one of the four groups to them.
Then we only sort inside of the groups.