### PR TITLE
Preserve newlines in class instance declarations

### DIFF
--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -11,9 +11,7 @@ instance Foo Double where
         Double
 
 instance Foo [a] where
-
   data Bar [a]
     = ListBar [Bar a]
-
   data Baz [a]
     = ListBaz

--- a/data/examples/declaration/instance/associated-data.hs
+++ b/data/examples/declaration/instance/associated-data.hs
@@ -13,6 +13,7 @@ instance Foo Double where
 
 instance Foo [a]
   where
+
     data Bar [a] =
             ListBar [Bar a]
     data Baz [a] =

--- a/data/examples/declaration/instance/associated-types-out.hs
+++ b/data/examples/declaration/instance/associated-types-out.hs
@@ -3,7 +3,6 @@
 instance Foo Int where type Bar Int = Double
 
 instance Foo Double where
-
   type
     Bar
       Double =

--- a/data/examples/declaration/instance/associated-types.hs
+++ b/data/examples/declaration/instance/associated-types.hs
@@ -9,5 +9,7 @@ instance Foo Double
         Double
         =
           [Double]
+
+
     type instance Baz  Double
       = [Double]

--- a/data/examples/declaration/instance/instance-sigs-multiple-out.hs
+++ b/data/examples/declaration/instance/instance-sigs-multiple-out.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE InstanceSigs #-}
 
 instance Applicative [] where
-
   pure ::
     a ->
     [a]
   pure a = [a]
-
   (<*>) ::
     [a] -> [a] -> [a]
   (<*>) _ _ = []

--- a/data/examples/declaration/instance/multi-parameter-out.hs
+++ b/data/examples/declaration/instance/multi-parameter-out.hs
@@ -1,7 +1,5 @@
 instance MonadReader a ((->) a) where ask = id
 
 instance MonadState s (State s) where
-
   get = State.get
-
   put = State.put

--- a/data/examples/declaration/instance/preserve-newline-out.hs
+++ b/data/examples/declaration/instance/preserve-newline-out.hs
@@ -1,0 +1,11 @@
+instance Num a => Num (Diff a) where
+  D u dudx + D v dvdx = D (u + v) (dudx + dvdx)
+  D u dudx - D v dvdx = D (u - v) (dudx - dvdx)
+  D u dudx * D v dvdx = D (u * v) (u * dvdx + v * dudx)
+
+  negate (D u dudx) = D (- u) (- dudx)
+  negate (Z u dudx) = undefined
+
+  abs (D u _) = D (abs u) (signum u)
+  signum (D u _) = D (signum u) 0
+  fromInteger n = D (fromInteger n) 0

--- a/data/examples/declaration/instance/preserve-newline.hs
+++ b/data/examples/declaration/instance/preserve-newline.hs
@@ -1,0 +1,13 @@
+instance Num a => Num (Diff a) where
+
+  D u dudx + D v dvdx = D (u + v) (dudx + dvdx)
+  D u dudx - D v dvdx = D (u - v) (dudx - dvdx)
+  D u dudx * D v dvdx = D (u * v) (u * dvdx + v * dudx)
+
+  negate (D u dudx) = D (-u) (-dudx)
+  negate (Z u dudx) = undefined
+
+
+  abs (D u _) = D (abs u) (signum u)
+  signum (D u _) = D (signum u) 0
+  fromInteger n = D (fromInteger n) 0

--- a/data/examples/declaration/instance/single-parameter-out.hs
+++ b/data/examples/declaration/instance/single-parameter-out.hs
@@ -1,9 +1,7 @@
 instance Monoid Int where (<>) x y = x + y
 
 instance Enum Int where
-
   fromEnum x = x
-
   toEnum =
     \x ->
       x

--- a/data/examples/declaration/signature/specialize/specialize-instance-out.hs
+++ b/data/examples/declaration/signature/specialize/specialize-instance-out.hs
@@ -3,16 +3,12 @@ data Foo a = Foo a
 data VT v m r = VT v m r
 
 instance (Eq a) => Eq (Foo a) where
-
   {-# SPECIALIZE instance Eq (Foo [(Int, Bar)]) #-}
-
   (==) (Foo a) (Foo b) = (==) a b
 
 instance (Num r, V.Vector v r, Factored m r) => Num (VT v m r) where
-
   {-# SPECIALIZE instance
     ( Factored m Int => Num (VT U.Vector m Int)
     )
     #-}
-
   VT x + VT y = VT $ V.zipWith (+) x y

--- a/src/Ormolu/Printer/Meat/Declaration.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration.hs-boot
@@ -1,5 +1,6 @@
 module Ormolu.Printer.Meat.Declaration
   ( p_hsDecls,
+    p_hsDeclsPreserveNl,
     hasSeparatedDecls,
   )
 where
@@ -9,5 +10,7 @@ import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 
 p_hsDecls :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
+
+p_hsDeclsPreserveNl :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
 
 hasSeparatedDecls :: [LHsDecl GhcPs] -> Bool

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -95,10 +95,7 @@ p_clsInstDecl = \case
           $ do
             -- Ensure whitespace is added after where clause.
             breakpoint
-            -- Add newline before first declaration if the body contains separate
-            -- declarations
-            when (hasSeparatedDecls allDecls) breakpoint'
-            dontUseBraces $ p_hsDecls Associated allDecls
+            dontUseBraces $ p_hsDeclsPreserveNl Associated allDecls
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
   XClsInstDecl NoExt -> notImplemented "XClsInstDecl"
 

--- a/src/Ormolu/Printer/Operators.hs
+++ b/src/Ormolu/Printer/Operators.hs
@@ -17,6 +17,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (Down (Down), comparing)
 import GHC
 import OccName (mkVarOcc)
+import Ormolu.Utils
 import RdrName (mkRdrUnqual)
 import SrcLoc (combineSrcSpans)
 
@@ -171,8 +172,6 @@ buildFixityMap getOpName opTree =
               maybe 0 srcSpanStartCol (unSrcSpan o),
               go r
             ]
-    unSrcSpan (RealSrcSpan r) = Just r
-    unSrcSpan (UnhelpfulSpan _) = Nothing
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Preserve user-added newlines with the following normalizations:

* No newlines below `where`
* Consecutive newlines are compressed into a single newline

Add a new test fixture, in addition to modifying the existing ones.

Fixes #431 

## Todo

- [x] Preserve newlines in instance declarations
- [ ] Preserve newlines in class declarations as well
- [ ] Fix: Do _not_ preserve newline _after_ the comment and above the declaration (possibly via using `groupDecls`)

## Open questions

- [ ] Preserve newlines _within_ a _group_ of declarations (`groupedDecls`)?