### PR TITLE
Respect grouping in classes and instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 * Fixed indentation in presence of type applications. [Issue
   493](https://github.com/tweag/ormolu/issues/493).
 
+* Class and instance declarations now do not have a blank line after
+  `where`. Grouping of methods from the original input is also preserved
+  with some normalizations. [Issue
+  431](https://github.com/tweag/ormolu/issues/431).
+
 ## Ormolu 0.0.2.0
 
 * Switched to `ghc-lib-parser` instead of depending on the `ghc` package

--- a/data/examples/declaration/class/associated-data1-out.hs
+++ b/data/examples/declaration/class/associated-data1-out.hs
@@ -4,7 +4,6 @@ class Foo a where data FooBar a
 
 -- | Something.
 class Bar a where
-
   -- | Bar bar
   data BarBar a
 

--- a/data/examples/declaration/class/associated-data2-out.hs
+++ b/data/examples/declaration/class/associated-data2-out.hs
@@ -4,7 +4,6 @@ module Main where
 
 -- | Something more.
 class Baz a where
-
   -- | Baz bar
   data
     BazBar

--- a/data/examples/declaration/class/associated-type-defaults-out.hs
+++ b/data/examples/declaration/class/associated-type-defaults-out.hs
@@ -4,7 +4,6 @@ class Foo a where type FooBar a = Int
 
 -- | Something.
 class Bar a where
-
   -- Define bar
   type
     BarBar a =
@@ -18,7 +17,6 @@ class Bar a where
         a
 
 class Baz a where
-
   type
     BazBar
       a

--- a/data/examples/declaration/class/associated-types1-out.hs
+++ b/data/examples/declaration/class/associated-types1-out.hs
@@ -4,7 +4,6 @@ class Foo a where type FooBar a
 
 -- | Something.
 class Bar a where
-
   -- | Bar bar
   type BarBar a
 

--- a/data/examples/declaration/class/associated-types2-out.hs
+++ b/data/examples/declaration/class/associated-types2-out.hs
@@ -4,7 +4,6 @@ module Main where
 
 -- | Something more.
 class Baz a where
-
   -- | Baz bar
   type
     BazBar

--- a/data/examples/declaration/class/default-implementations-comments-out.hs
+++ b/data/examples/declaration/class/default-implementations-comments-out.hs
@@ -2,7 +2,6 @@ module Main where
 
 -- | Baz
 class Baz a where
-
   foobar :: a -> a
   foobar a =
     barbaz (bazbar a)

--- a/data/examples/declaration/class/default-signatures-out.hs
+++ b/data/examples/declaration/class/default-signatures-out.hs
@@ -4,13 +4,11 @@ module Main where
 
 -- | Something else.
 class Bar a where
-
   -- | Bar
   bar ::
     String ->
     String ->
     a
-
   -- Pointless comment
   default bar ::
     ( Read a,

--- a/data/examples/declaration/class/default-signatures-simple-out.hs
+++ b/data/examples/declaration/class/default-signatures-simple-out.hs
@@ -2,9 +2,7 @@ module Main where
 
 -- | Something.
 class Foo a where
-
   -- | Foo
   foo :: a -> String
-
   default foo :: Show a => a -> String
   foo = show

--- a/data/examples/declaration/class/dependency-super-classes-out.hs
+++ b/data/examples/declaration/class/dependency-super-classes-out.hs
@@ -4,9 +4,7 @@ module Main where
 
 -- | Something.
 class (MonadReader r s, MonadWriter w m) => MonadState s m | m -> s where
-
   get :: m s
-
   put :: s -> m ()
 
 -- | 'MonadParsec'
@@ -16,7 +14,6 @@ class
   ) =>
   MonadParsec e s m
     | m -> e s where
-
   -- | 'getState' returns state
   getState ::
     m s

--- a/data/examples/declaration/class/multi-parameters2-out.hs
+++ b/data/examples/declaration/class/multi-parameters2-out.hs
@@ -11,10 +11,8 @@ class
     d -- Baz baz
     e -- Rest
     f where
-
   barbaz ::
     a -> f
-
   bazbar ::
     e ->
     f

--- a/data/examples/declaration/class/newlines-after-where-out.hs
+++ b/data/examples/declaration/class/newlines-after-where-out.hs
@@ -1,0 +1,5 @@
+class Num a where
+  (+) :: a -> a -> a
+
+class Num a where
+  (+) :: a -> a -> a

--- a/data/examples/declaration/class/newlines-after-where.hs
+++ b/data/examples/declaration/class/newlines-after-where.hs
@@ -1,0 +1,7 @@
+class Num a where
+  (+) :: a -> a -> a
+
+class Num a where
+
+
+  (+) :: a -> a -> a

--- a/data/examples/declaration/class/newlines-and-default-decls-out.hs
+++ b/data/examples/declaration/class/newlines-and-default-decls-out.hs
@@ -1,0 +1,11 @@
+class Foo a where
+  foo :: a
+  default foo :: ()
+  foo = ()
+  bar :: a
+  default bar :: ()
+  bar = ()
+
+  qux :: a
+  default qux :: ()
+  qux = ()

--- a/data/examples/declaration/class/newlines-and-default-decls.hs
+++ b/data/examples/declaration/class/newlines-and-default-decls.hs
@@ -1,0 +1,13 @@
+class Foo a where
+  foo :: a
+  default foo :: ()
+  foo = ()
+  bar :: a
+  default bar :: ()
+  bar = ()
+
+  qux :: a
+
+  default qux :: ()
+
+  qux = ()

--- a/data/examples/declaration/class/newlines-and-haddocks-out.hs
+++ b/data/examples/declaration/class/newlines-and-haddocks-out.hs
@@ -1,0 +1,23 @@
+class Foo a where
+  -- | Haddock
+  foo :: a
+
+  -- | Another Haddock
+  bar :: a
+
+  baz :: a
+  -- ^ Post-Haddock
+
+  raz :: a
+  -- ^ Another Post-Haddock
+
+  -- | One more Haddock
+  qux :: a
+
+  -- Comment before a Haddock
+
+  -- | And one more Haddock
+  xyz :: a
+
+  -- | Haddock followed by a blank line
+  abc :: a

--- a/data/examples/declaration/class/newlines-and-haddocks.hs
+++ b/data/examples/declaration/class/newlines-and-haddocks.hs
@@ -1,0 +1,19 @@
+class Foo a where
+  -- | Haddock
+  foo :: a
+  -- | Another Haddock
+  bar :: a
+  baz :: a
+  -- ^ Post-Haddock
+  raz :: a
+  -- ^ Another Post-Haddock
+
+  -- | One more Haddock
+  qux :: a
+  -- Comment before a Haddock
+  -- | And one more Haddock
+  xyz :: a
+
+  -- | Haddock followed by a blank line
+
+  abc :: a

--- a/data/examples/declaration/class/newlines-between-methods-out.hs
+++ b/data/examples/declaration/class/newlines-between-methods-out.hs
@@ -1,0 +1,17 @@
+class Num a where
+  (+) :: a -> a -> a
+  (-) :: a -> a -> a
+  (*) :: a -> a -> a
+
+  -- Comment before definition
+  negate :: a -> a
+
+  -- Comment after definition
+
+  -- Separator
+
+  abs :: a -> a
+  signum :: a -> a
+
+  -- Comment between unrelated definitions
+  fromInteger :: Integer -> a

--- a/data/examples/declaration/class/newlines-between-methods.hs
+++ b/data/examples/declaration/class/newlines-between-methods.hs
@@ -1,0 +1,15 @@
+class Num a where
+  (+) :: a -> a -> a
+  (-) :: a -> a -> a
+  (*) :: a -> a -> a
+
+  -- Comment before definition
+  negate :: a -> a
+  -- Comment after definition
+
+  -- Separator
+
+  abs :: a -> a
+  signum :: a -> a
+  -- Comment between unrelated definitions
+  fromInteger :: Integer -> a

--- a/data/examples/declaration/class/single-parameters-out.hs
+++ b/data/examples/declaration/class/single-parameters-out.hs
@@ -21,8 +21,6 @@ class Baz a where
     a
 
 class BarBaz a where
-
   barbaz ::
     a -> b
-
   bazbar :: b -> a

--- a/data/examples/declaration/instance/associated-data-out.hs
+++ b/data/examples/declaration/instance/associated-data-out.hs
@@ -11,9 +11,7 @@ instance Foo Double where
         Double
 
 instance Foo [a] where
-
   data Bar [a]
     = ListBar [Bar a]
-
   data Baz [a]
     = ListBaz

--- a/data/examples/declaration/instance/associated-data.hs
+++ b/data/examples/declaration/instance/associated-data.hs
@@ -13,6 +13,7 @@ instance Foo Double where
 
 instance Foo [a]
   where
+
     data Bar [a] =
             ListBar [Bar a]
     data Baz [a] =

--- a/data/examples/declaration/instance/associated-types-out.hs
+++ b/data/examples/declaration/instance/associated-types-out.hs
@@ -3,7 +3,6 @@
 instance Foo Int where type Bar Int = Double
 
 instance Foo Double where
-
   type
     Bar
       Double =

--- a/data/examples/declaration/instance/associated-types.hs
+++ b/data/examples/declaration/instance/associated-types.hs
@@ -9,5 +9,7 @@ instance Foo Double
         Double
         =
           [Double]
+
+
     type instance Baz  Double
       = [Double]

--- a/data/examples/declaration/instance/instance-sigs-multiple-out.hs
+++ b/data/examples/declaration/instance/instance-sigs-multiple-out.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE InstanceSigs #-}
 
 instance Applicative [] where
-
   pure ::
     a ->
     [a]
   pure a = [a]
-
   (<*>) ::
     [a] -> [a] -> [a]
   (<*>) _ _ = []

--- a/data/examples/declaration/instance/multi-parameter-out.hs
+++ b/data/examples/declaration/instance/multi-parameter-out.hs
@@ -1,7 +1,5 @@
 instance MonadReader a ((->) a) where ask = id
 
 instance MonadState s (State s) where
-
   get = State.get
-
   put = State.put

--- a/data/examples/declaration/instance/newlines-after-where-out.hs
+++ b/data/examples/declaration/instance/newlines-after-where-out.hs
@@ -1,0 +1,5 @@
+instance Num X where
+  (+) = undefined
+
+instance Num Y where
+  (+) = undefined

--- a/data/examples/declaration/instance/newlines-after-where.hs
+++ b/data/examples/declaration/instance/newlines-after-where.hs
@@ -1,0 +1,7 @@
+instance Num X where
+  (+) = undefined
+
+instance Num Y where
+
+
+  (+) = undefined

--- a/data/examples/declaration/instance/newlines-between-methods-out.hs
+++ b/data/examples/declaration/instance/newlines-between-methods-out.hs
@@ -1,0 +1,18 @@
+instance Num a => Num (Diff a) where
+  D u dudx + D v dvdx = D (u + v) (dudx + dvdx)
+  D u dudx - D v dvdx = D (u - v) (dudx - dvdx)
+  D u dudx * D v dvdx = D (u * v) (u * dvdx + v * dudx)
+
+  -- Comment before definition
+  negate (D u dudx) = D (- u) (- dudx)
+  negate (Z u dudx) = undefined
+
+  -- Comment after definition
+
+  -- Separator
+
+  abs (D u _) = D (abs u) (signum u)
+  signum (D u _) = D (signum u) 0
+
+  -- Comment between unrelated definitions
+  fromInteger n = D (fromInteger n) 0

--- a/data/examples/declaration/instance/newlines-between-methods.hs
+++ b/data/examples/declaration/instance/newlines-between-methods.hs
@@ -1,0 +1,16 @@
+instance Num a => Num (Diff a) where
+  D u dudx + D v dvdx = D (u + v) (dudx + dvdx)
+  D u dudx - D v dvdx = D (u - v) (dudx - dvdx)
+  D u dudx * D v dvdx = D (u * v) (u * dvdx + v * dudx)
+
+  -- Comment before definition
+  negate (D u dudx) = D (-u) (-dudx)
+  negate (Z u dudx) = undefined
+  -- Comment after definition
+
+  -- Separator
+
+  abs (D u _) = D (abs u) (signum u)
+  signum (D u _) = D (signum u) 0
+  -- Comment between unrelated definitions
+  fromInteger n = D (fromInteger n) 0

--- a/data/examples/declaration/instance/single-parameter-out.hs
+++ b/data/examples/declaration/instance/single-parameter-out.hs
@@ -1,9 +1,7 @@
 instance Monoid Int where (<>) x y = x + y
 
 instance Enum Int where
-
   fromEnum x = x
-
   toEnum =
     \x ->
       x

--- a/data/examples/declaration/signature/minimal/minimal-out.hs
+++ b/data/examples/declaration/signature/minimal/minimal-out.hs
@@ -1,5 +1,4 @@
 class Foo a where
-
   {-# MINIMAL (==) | ((/=), foo) #-}
 
   {-# MINIMAL
@@ -12,5 +11,4 @@ class Foo a where
     #-}
 
   (==) :: a -> a -> Bool
-
   (/=) :: a -> a -> Bool

--- a/data/examples/declaration/signature/specialize/specialize-instance-out.hs
+++ b/data/examples/declaration/signature/specialize/specialize-instance-out.hs
@@ -3,16 +3,12 @@ data Foo a = Foo a
 data VT v m r = VT v m r
 
 instance (Eq a) => Eq (Foo a) where
-
   {-# SPECIALIZE instance Eq (Foo [(Int, Bar)]) #-}
-
   (==) (Foo a) (Foo b) = (==) a b
 
 instance (Num r, V.Vector v r, Factored m r) => Num (VT v m r) where
-
   {-# SPECIALIZE instance
     ( Factored m Int => Num (VT U.Vector m Int)
     )
     #-}
-
   VT x + VT y = VT $ V.zipWith (+) x y

--- a/data/examples/other/comment-alignment-out.hs
+++ b/data/examples/other/comment-alignment-out.hs
@@ -1,5 +1,4 @@
 class Foo a where
-
   -- | Foo.
   foo ::
     Int ->

--- a/src/Ormolu/Printer/Meat/Declaration.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration.hs-boot
@@ -1,6 +1,6 @@
 module Ormolu.Printer.Meat.Declaration
   ( p_hsDecls,
-    hasSeparatedDecls,
+    p_hsDeclsRespectGrouping,
   )
 where
 
@@ -10,4 +10,4 @@ import Ormolu.Printer.Meat.Common
 
 p_hsDecls :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
 
-hasSeparatedDecls :: [LHsDecl GhcPs] -> Bool
+p_hsDeclsRespectGrouping :: FamilyStyle -> [LHsDecl GhcPs] -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -68,10 +68,7 @@ p_classDecl ctx name HsQTvs {..} fixity fdeps csigs cdefs cats catdefs cdocs = d
     space
     txt "where"
     breakpoint -- Ensure whitespace is added after where clause.
-    -- Add newline before first declaration if the body contains separate
-    -- declarations.
-    when (hasSeparatedDecls allDecls) breakpoint'
-    inci (p_hsDecls Associated allDecls)
+    inci (p_hsDeclsRespectGrouping Associated allDecls)
 p_classDecl _ _ XLHsQTyVars {} _ _ _ _ _ _ _ = notImplemented "XLHsQTyVars"
 
 p_classContext :: LHsContext GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -95,10 +95,7 @@ p_clsInstDecl = \case
           $ do
             -- Ensure whitespace is added after where clause.
             breakpoint
-            -- Add newline before first declaration if the body contains separate
-            -- declarations
-            when (hasSeparatedDecls allDecls) breakpoint'
-            dontUseBraces $ p_hsDecls Associated allDecls
+            dontUseBraces $ p_hsDeclsRespectGrouping Associated allDecls
       XHsImplicitBndrs NoExt -> notImplemented "XHsImplicitBndrs"
   XClsInstDecl NoExt -> notImplemented "XClsInstDecl"
 

--- a/src/Ormolu/Printer/Operators.hs
+++ b/src/Ormolu/Printer/Operators.hs
@@ -17,6 +17,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (Down (Down), comparing)
 import GHC
 import OccName (mkVarOcc)
+import Ormolu.Utils (unSrcSpan)
 import RdrName (mkRdrUnqual)
 import SrcLoc (combineSrcSpans)
 
@@ -171,8 +172,6 @@ buildFixityMap getOpName opTree =
               maybe 0 srcSpanStartCol (unSrcSpan o),
               go r
             ]
-    unSrcSpan (RealSrcSpan r) = Just r
-    unSrcSpan (UnhelpfulSpan _) = Nothing
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Closes #431. Related to #74.

Default signatures are silly and I have no idea what's the right treatment for them re/ newlines, but whatever.

Declarations with Haddocks are always given newlines from both sides. I'm not sure it's the best thing, but it's really easy to get rid of in the future, so also whatever.