### PR TITLE
Mention a second vim integration: neoformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We know of the following editor integrations:
 
 * [Emacs][emacs-package]
 * [VS Code][vs-code-plugin]
-* [vim][vim-integration]
+* vim: [neoformat][neoformat], [vim-ormolu][vim-ormolu]
 
 ## Running on Hackage
 
@@ -136,4 +136,5 @@ Copyright © 2018–present Tweag I/O
 [haskell-src-exts]: https://hackage.haskell.org/package/haskell-src-exts
 [emacs-package]: https://github.com/vyorkin/ormolu.el
 [vs-code-plugin]: https://marketplace.visualstudio.com/items?itemName=sjurmillidahl.ormolu-vscode
-[vim-integration]: https://github.com/sdiehl/vim-ormolu
+[vim-ormolu]: https://github.com/sdiehl/vim-ormolu
+[neoformat]: https://github.com/sbdchd/neoformat


### PR DESCRIPTION
ormolu has been integrated in [neoformat](https://github.com/sbdchd/neoformat) 3 months ago and it simply works: call `:Neoformat` to format the current buffer in place using `ormolu`.