### PR TITLE
Place "qualified" after the module name when ImportQualifiedPost is enabled

### DIFF
--- a/data/examples/import/qualified-post-out.hs
+++ b/data/examples/import/qualified-post-out.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+import Data.Text qualified as T
+import Data.Text qualified (a, b, c)
+import Data.Text qualified hiding (a, b, c)

--- a/data/examples/import/qualified-post.hs
+++ b/data/examples/import/qualified-post.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+import qualified Data.Text as T
+import qualified Data.Text (a, c, b)
+import Data.Text qualified hiding (c, b, a)

--- a/src/Ormolu/Diff.hs
+++ b/src/Ormolu/Diff.hs
@@ -71,6 +71,7 @@ matchIgnoringSrcSpans = genericQuery
                 `extQ` hsModuleEq
                 `extQ` sourceTextEq
                 `extQ` hsDocStringEq
+                `extQ` importDeclQualifiedStyleEq
                 `ext2Q` forLocated
             )
             x
@@ -88,6 +89,13 @@ matchIgnoringSrcSpans = genericQuery
             hs1 {hsmodImports = sortImports (hsmodImports hs1)}
     sourceTextEq :: SourceText -> GenericQ Diff
     sourceTextEq _ _ = Same
+    importDeclQualifiedStyleEq :: ImportDeclQualifiedStyle -> GenericQ Diff
+    importDeclQualifiedStyleEq d0 d1' =
+      case (d0, cast d1' :: Maybe ImportDeclQualifiedStyle) of
+        (x, Just x') | x == x' -> Same
+        (QualifiedPre, Just QualifiedPost) -> Same
+        (QualifiedPost, Just QualifiedPre) -> Same
+        _ -> Different []
     hsDocStringEq :: HsDocString -> GenericQ Diff
     hsDocStringEq str0 str1' =
       case cast str1' :: Maybe HsDocString of

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -101,7 +101,9 @@ parseModule Config {..} path input' = liftIO $ do
                         prCommentStream = comments,
                         prExtensions = exts,
                         prShebangs = shebangs,
-                        prUseRecordDot = useRecordDot
+                        prUseRecordDot = useRecordDot,
+                        prImportQualifiedPost =
+                          GHC.xopt ImportQualifiedPost dynFlags
                       }
   return (warnings, r)
 
@@ -124,9 +126,11 @@ manualExts =
     MonadComprehensions,
     UnboxedSums,
     UnicodeSyntax, -- gives special meanings to operators like (→)
-    TemplateHaskellQuotes -- enables TH subset of quasi-quotes, this
+    TemplateHaskellQuotes, -- enables TH subset of quasi-quotes, this
     -- apparently interferes with QuasiQuotes in
     -- weird ways
+    ImportQualifiedPost -- affects how Ormolu renders imports, so the
+    -- decision of enabling this style is left to the user
   ]
 
 ----------------------------------------------------------------------------

--- a/src/Ormolu/Parser/Result.hs
+++ b/src/Ormolu/Parser/Result.hs
@@ -26,7 +26,9 @@ data ParseResult
         -- | Shebangs found in the input
         prShebangs :: [Located String],
         -- | Whether or not record dot syntax is enabled
-        prUseRecordDot :: Bool
+        prUseRecordDot :: Bool,
+        -- | Whether or not ImportQualifiedPost is enabled
+        prImportQualifiedPost :: Bool
       }
 
 -- | Pretty-print a 'ParseResult'.

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -20,7 +20,12 @@ printModule ::
   Text
 printModule ParseResult {..} =
   runR
-    (p_hsModule prShebangs prExtensions prParsedSource)
+    ( p_hsModule
+        prShebangs
+        prExtensions
+        prImportQualifiedPost
+        prParsedSource
+    )
     (mkSpanStream prParsedSource)
     prCommentStream
     prAnns

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -25,8 +25,8 @@ p_hsmodExports xs =
     layout <- getLayout
     sep breakpoint (sitcc . located' (uncurry (p_lie layout))) (attachPositions xs)
 
-p_hsmodImport :: ImportDecl GhcPs -> R ()
-p_hsmodImport ImportDecl {..} = do
+p_hsmodImport :: Bool -> ImportDecl GhcPs -> R ()
+p_hsmodImport useQualifiedPost ImportDecl {..} = do
   txt "import"
   space
   when ideclSource (txt "{-# SOURCE #-}")
@@ -34,7 +34,7 @@ p_hsmodImport ImportDecl {..} = do
   when ideclSafe (txt "safe")
   space
   when
-    (isImportDeclQualified ideclQualified)
+    (isImportDeclQualified ideclQualified && not useQualifiedPost)
     (txt "qualified")
   space
   case ideclPkgQual of
@@ -43,6 +43,9 @@ p_hsmodImport ImportDecl {..} = do
   space
   inci $ do
     located ideclName atom
+    when
+      (isImportDeclQualified ideclQualified && useQualifiedPost)
+      (space >> txt "qualified")
     case ideclAs of
       Nothing -> return ()
       Just l -> do
@@ -63,7 +66,7 @@ p_hsmodImport ImportDecl {..} = do
           layout <- getLayout
           sep breakpoint (sitcc . located' (uncurry (p_lie layout))) (attachPositions xs)
     newline
-p_hsmodImport (XImportDecl x) = noExtCon x
+p_hsmodImport _ (XImportDecl x) = noExtCon x
 
 p_lie :: Layout -> (Int, Int) -> IE GhcPs -> R ()
 p_lie encLayout (i, totalItems) = \case

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -26,10 +27,12 @@ p_hsModule ::
   [Located String] ->
   -- | Pragmas
   [Pragma] ->
+  -- | Whether to use postfix qualified imports
+  Bool ->
   -- | AST to print
   ParsedSource ->
   R ()
-p_hsModule shebangs pragmas (L moduleSpan HsModule {..}) = do
+p_hsModule shebangs pragmas qualifiedPost (L moduleSpan HsModule {..}) = do
   -- If span of exports in multiline, the whole thing is multiline. This is
   -- especially important because span of module itself always seems to have
   -- length zero, so it's not reliable for layout selection.
@@ -63,7 +66,7 @@ p_hsModule shebangs pragmas (L moduleSpan HsModule {..}) = do
         txt "where"
         newline
     newline
-    forM_ (sortImports hsmodImports) (located' p_hsmodImport)
+    forM_ (sortImports hsmodImports) (located' (p_hsmodImport qualifiedPost))
     newline
     switchLayout (getLoc <$> hsmodDecls) $ do
       p_hsDecls Free hsmodDecls


### PR DESCRIPTION
Closes #526.

This PR checks if `ImportQualifiedPost` language extension is enabled, and places the "qualified" keyword accordingly.

Since it causes a change on the AST, it also modifies Ormolu's AST diff check to ignore this change.

This PR is based on top of #531, so it should be rebased (only the relevant commits, including and after 8c0655e) after that is merged to master.