### PR TITLE
Support StandaloneKindSignatures

### DIFF
--- a/data/examples/declaration/signature/standalone-kind-out.hs
+++ b/data/examples/declaration/signature/standalone-kind-out.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+
+type T ::
+  (k -> Type) ->
+  k ->
+  Type
+data T m a = MkT (m a) (T Maybe (m a))
+
+type C1 :: Type -> Constraint
+class C1 a
+
+type F :: Type -> Type
+type family F

--- a/data/examples/declaration/signature/standalone-kind.hs
+++ b/data/examples/declaration/signature/standalone-kind.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE StandaloneKindSignatures #-}
+
+type T :: (k -> Type)
+       -> k
+       -> Type
+
+data T m a = MkT (m a) (T Maybe (m a))
+
+type C1 :: Type -> Constraint
+class C1 a
+
+type F :: Type -> Type
+type family F

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -7,6 +7,7 @@ module Ormolu.Printer.Meat.Declaration.Signature
   ( p_sigDecl,
     p_typeAscription,
     p_activation,
+    p_standaloneKindSig,
   )
 where
 
@@ -218,3 +219,16 @@ p_sccSig loc literal = pragma "SCC" . inci $ do
   forM_ literal $ \x -> do
     breakpoint
     atom x
+
+p_standaloneKindSig :: StandaloneKindSig GhcPs -> R ()
+p_standaloneKindSig (StandaloneKindSig NoExtField name bndrs) = do
+  txt "type"
+  space
+  p_rdrName name
+  space
+  txt "::"
+  breakpoint
+  inci $ case bndrs of
+    HsIB NoExtField sig -> located sig p_hsType
+    XHsImplicitBndrs x -> noExtCon x
+p_standaloneKindSig (XStandaloneKindSig c) = noExtCon c


### PR DESCRIPTION
Closes #530.

This PR implements supports for standalone kind signatures. It formats them similarly to type synonyms, and also groups them together with its relevant constructs.

This PR is based on top of #531, so it should be rebased (only the relevant commits, including and after 7130ac3) after that is merged to master.