### PR TITLE
Render type applications similar to value applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Fixed the bug pertaining to rendering of arrow notation with multiline
   expressions. [Issue 513](https://github.com/tweag/ormolu/issues/513).
 
+* Made rendering of data type definitions, value-level applications, and
+  application of types use the same style. [Issue
+  427](https://github.com/tweag/ormolu/issues/427).
+
 * Implemented support for the new language extension `ImportQualifiedPost`.
 
 * Implemented support for the new language extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@
   expressions. [Issue 513](https://github.com/tweag/ormolu/issues/513).
 
 * Made rendering of data type definitions, value-level applications, and
-  application of types use the same style. [Issue
-  427](https://github.com/tweag/ormolu/issues/427).
+  application of types use the same style. Moreover, existential now doesn't
+  cause the data constructor be unconditionally rendered in multiline layout
+  [Issue 427](https://github.com/tweag/ormolu/issues/427).
 
 * Implemented support for the new language extension `ImportQualifiedPost`.
 

--- a/data/examples/declaration/data/existential-multiline-out.hs
+++ b/data/examples/declaration/data/existential-multiline-out.hs
@@ -3,3 +3,15 @@
 data Foo
   = forall a. MkFoo a (a -> Bool)
   | forall a. Eq a => MkBar a
+
+data Bar
+  = forall x y.
+    Bar x y x y
+
+data Baz
+  = forall x y.
+    Baz
+      x
+      y
+      x
+      y

--- a/data/examples/declaration/data/existential-multiline.hs
+++ b/data/examples/declaration/data/existential-multiline.hs
@@ -3,3 +3,10 @@
 data Foo
   = forall a. MkFoo a (a -> Bool)
   | forall a. Eq a => MkBar a
+
+data Bar = forall x y.
+         Bar x y x y
+
+data Baz = forall x y.
+         Baz x y x
+             y

--- a/data/examples/declaration/data/field-layout/gadt-out.hs
+++ b/data/examples/declaration/data/field-layout/gadt-out.hs
@@ -6,5 +6,6 @@ data Foo a b where
   Foo :: Foo Int Int
   -- | Something else
   Bar ::
-    Foo Char
+    Foo
+      Char
       Char

--- a/data/examples/declaration/data/field-layout/record-out.hs
+++ b/data/examples/declaration/data/field-layout/record-out.hs
@@ -7,6 +7,7 @@ data Foo
         foo :: Foo Int Int,
         -- | Something else
         bar ::
-          Bar Char
+          Bar
+            Char
             Char
       }

--- a/data/examples/declaration/instance/data-family-instances-gadt-out.hs
+++ b/data/examples/declaration/instance/data-family-instances-gadt-out.hs
@@ -3,9 +3,11 @@
 
 data instance Bar Int a where
   SameBar ::
-    Bar Int
+    Bar
+      Int
       Int
   CloseBar :: Bar Int Double
   OtherBar ::
-    Bar Int
+    Bar
+      Int
       a

--- a/data/examples/other/multiline-forall-out.hs
+++ b/data/examples/other/multiline-forall-out.hs
@@ -12,8 +12,7 @@ data D
       )
       (x :: *)
       (y :: *).
-    D
-      (f x y)
+    D (f x y)
 
 data G where
   G ::

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -124,18 +124,19 @@ p_conDecl = \case
         p_hsType (unLoc con_res_ty)
   ConDeclH98 {..} -> do
     mapM_ (p_hsDocString Pipe True) con_doc
-    let conDeclSpn =
-          [getLoc con_name]
-            <> [getLoc con_forall]
+    let conDeclWithContextSpn =
+          [getLoc con_forall]
             <> fmap getLoc con_ex_tvs
             <> maybeToList (fmap getLoc con_mb_cxt)
-            <> conArgsSpans con_args
-    switchLayout conDeclSpn $ do
+            <> conDeclSpn
+        conDeclSpn =
+          getLoc con_name : conArgsSpans con_args
+    switchLayout conDeclWithContextSpn $ do
       when (unLoc con_forall) $ do
         p_forallBndrs ForallInvis p_hsTyVarBndr con_ex_tvs
         breakpoint
       forM_ con_mb_cxt p_lhsContext
-      case con_args of
+      switchLayout conDeclSpn $ case con_args of
         PrefixCon xs -> do
           p_rdrName con_name
           unless (null xs) breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -21,7 +21,7 @@ import Data.Char (isPunctuation, isSymbol)
 import Data.Data hiding (Infix, Prefix)
 import Data.Functor ((<&>))
 import Data.List (intersperse, sortOn)
-import Data.List.NonEmpty ((<|), NonEmpty ((:|)))
+import Data.List.NonEmpty ((<|), NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import qualified Data.Text as Text


### PR DESCRIPTION
Close #427.

----

One change is that we now render type applications in the same style as data type definitions and value applications:

```haskell
-- input
f :: forall x y.
      D x y x y

-- output before
f ::
  forall x y.
  D x y x
    y

-- output after
f ::
  forall x y.
  D x y x y
```

Now in general if there is a newline in the sequence of applications the whole thing will be formatted like this:

```haskell
f ::
  forall x y.
  D
    x
    y
    x
    y
```

instead of being split in some awkward place in the middle of the sequence.

----

Another change is that we do not lump together `forall` and data constructor when deciding on layout.

```haskell
-- input
data D = forall x y.
         D x y x y

-- output before
data D
  = forall x y.
    D
      x
      y
      x
      y

-- output after
data D
  = forall x y.
    D x y x y
```