### PR TITLE
Fix GHC panic on showOutputable

### DIFF
--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -22,6 +22,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC
+import GHC.DynFlags (baseDynFlags)
 import qualified Outputable as GHC
 
 -- | Combine all source spans from the given list.
@@ -38,7 +39,7 @@ notImplemented msg = error $ "not implemented yet: " ++ msg
 
 -- | Pretty-print an 'GHC.Outputable' thing.
 showOutputable :: GHC.Outputable o => o -> String
-showOutputable = GHC.showSDocUnsafe . GHC.ppr
+showOutputable = GHC.showSDoc baseDynFlags . GHC.ppr
 
 -- | Split and normalize a doc string. The result is a list of lines that
 -- make up the comment.


### PR DESCRIPTION
Closes #544.

It looks like when we call 'showSDocUnsafe' it uses `unsafeGlobalDynFlags`
which the `settings` field is not initialised (unless someone calls
`setUnsafeGlobalDynFlags`, `initGhcMonad` or `runGhc`) and throws a panic.

I couldn't pinpoint the exact cause, but I suspect probably there was
a change either on Ormolu or ghc-lib-parser which removed a call to one
of the functions above before we print manualExts.

Anyway, we actually don't need to call `showSDocUnsafe` since we already
have a populated `DynFlags`. This commit removes the unsafe call and passes
the `DynFlags` we have to `showSDoc`.