### PR TITLE
Improve the error message in case of a parse error

### DIFF
--- a/expected-failures/aws.txt
+++ b/expected-failures/aws.txt
@@ -1,9 +1,11 @@
 Parsing of source code failed:
   Examples/PutBucketNearLine.hs:5:1-6
   parse error on input `import'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   Examples/Sqs.hs:(88,3)-(90,4)
   parse error on input `{- | Let's make sure the queue was actually deleted and that the same number of queues exist at when
      | the program ends as when it started.
   -}'
+GHC parser failed on this input, it is not an Ormolu bug.

--- a/expected-failures/distributed-process.txt
+++ b/expected-failures/distributed-process.txt
@@ -1,7 +1,9 @@
 Parsing of source code failed:
   benchmarks/Channels.hs:2:1-6
   parse error on input `import'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   benchmarks/Spawns.hs:5:1-6
   parse error on input `import'
+GHC parser failed on this input, it is not an Ormolu bug.

--- a/expected-failures/esqueleto.txt
+++ b/expected-failures/esqueleto.txt
@@ -1,7 +1,9 @@
 Parsing of source code failed:
   src/Database/Esqueleto/Internal/Internal.hs:379:1
   lexical error in string/character literal at character 's'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   test/PostgreSQL/Test.hs:510:9-41
   parse error on input `-- | Check the result is not null'
+GHC parser failed on this input, it is not an Ormolu bug.

--- a/expected-failures/fay.txt
+++ b/expected-failures/fay.txt
@@ -1,18 +1,22 @@
 Parsing of source code failed:
   examples/Separated.hs:12:1-6
   parse error on input `module'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   examples/calc.hs:(4,1)-(6,2)
   parse error on input `-- $ fay -p --html-wrapper --html-js-lib jquery.min.js examples/calc.hs
 -- You also need to download jquery.min.js.
 --'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   examples/canvaswater.hs:(6,1)-(7,17)
   parse error on input `-- | A demonstration of Fay using the canvas element to display a
 -- simple effect.'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   examples/data.hs:9:1-6
   parse error on input `module'
+GHC parser failed on this input, it is not an Ormolu bug.

--- a/expected-failures/idris.txt
+++ b/expected-failures/idris.txt
@@ -55,6 +55,7 @@ Please, consider reporting the bug.
 Parsing of source code failed:
   src/Idris/Parser.hs:1052:1
   parse error on input `@'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 AST of input and AST of formatted code differ.
   at src/Idris/Parser/Data.hs:281:1-29
@@ -63,6 +64,7 @@ Please, consider reporting the bug.
 Parsing of source code failed:
   src/Idris/Parser/Expr.hs:75:1
   parse error on input `@'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Formatting is not idempotent:
   src/Idris/PartialEval.hs<rendered>:280:42

--- a/expected-failures/lens.txt
+++ b/expected-failures/lens.txt
@@ -1,3 +1,4 @@
 Parsing of source code failed:
   src/Control/Exception/Lens.hs:180:13-37
   parse error on input `AllocationLimitExceeded__'
+GHC parser failed on this input, it is not an Ormolu bug.

--- a/expected-failures/pandoc.txt
+++ b/expected-failures/pandoc.txt
@@ -1,6 +1,7 @@
 Parsing of source code failed:
   benchmark/weigh-pandoc.hs:14:1-6
   parse error on input `import'
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Formatting is not idempotent:
   src/Text/Pandoc/Readers/Vimwiki.hs<rendered>:615:19

--- a/expected-failures/purescript.txt
+++ b/expected-failures/purescript.txt
@@ -2,17 +2,21 @@ Parsing of source code failed:
   src/Language/PureScript/AST/Declarations.hs:478:1-17
   Invalid type signature: pattern ValueDecl :: ...
 Perhaps you meant to use PatternSynonyms?
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   src/Language/PureScript/AST/SourcePos.hs:101:1-22
   Invalid type signature: pattern NullSourceSpan :: ...
 Perhaps you meant to use PatternSynonyms?
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   src/Language/PureScript/Constants.hs:42:1-15
   Invalid type signature: pattern Discard :: ...
 Perhaps you meant to use PatternSynonyms?
+GHC parser failed on this input, it is not an Ormolu bug.
 
 Parsing of source code failed:
   src/Language/PureScript/Crash.hs:16:1-6
   parse error on input `import'
+GHC parser failed on this input, it is not an Ormolu bug.

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -42,6 +42,7 @@ instance Exception OrmoluException where
         ]
     OrmoluParsingFailed s e ->
       showParsingErr "Parsing of source code failed:" s [e]
+        ++ "GHC parser failed on this input, it is not an Ormolu bug.\n"
     OrmoluOutputParsingFailed s e ->
       showParsingErr "Parsing of formatted code failed:" s [e]
         ++ "Please, consider reporting the bug.\n"


### PR DESCRIPTION
Parse errors are typically not Ormolu errors.