### PR TITLE
Allow to disable Ormolu with special comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Comments on pragmas are now preserved. [Issue
   216](https://github.com/tweag/ormolu/issues/216).
 
+* Ormolu can now be enabled and disabled via special comments. [Issue
+  435](https://github.com/tweag/ormolu/issues/435).
+
 ## Ormolu 0.0.4.0
 
 * When given several files to format, Ormolu does not stop on the first

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ formatted output.
 $ ormolu --mode inplace Module.hs
 ```
 
+## Magic comments
+
+Ormolu understands two magic comments:
+
+```haskell
+{- ORMOLU_DISABLE -}
+```
+
+and
+
+```haskell
+{- ORMOLU_ENABLE -}
+```
+
+This allows us to disable formatting selectively for code between these
+markers or disable it for the entire file. To achieve the latter, just put
+`{- ORMOLU_DISABLE -}` at the very top. Note that the source code should
+still be parseable even without the “excluded” part. Because of that the
+magic comments cannot be placed arbitrary, but should rather enclose
+independent top-level definitions.
+
 ## Current limitations
 
 * Does not handle CPP (wontfix, see [the design document][design]).

--- a/data/examples/other/disabling/single-definition-out.hs
+++ b/data/examples/other/disabling/single-definition-out.hs
@@ -1,0 +1,10 @@
+module Foo (foo, bar) where
+
+{- ORMOLU_DISABLE -}
+foo :: Int -> Int
+foo = (+5)
+{- ORMOLU_ENABLE -}
+
+bar :: Bool -> Bool
+bar True = True
+bar False = True

--- a/data/examples/other/disabling/single-definition.hs
+++ b/data/examples/other/disabling/single-definition.hs
@@ -1,0 +1,10 @@
+module Foo (foo,bar) where
+
+{- ORMOLU_DISABLE -}
+foo :: Int -> Int
+foo = (+5)
+{- ORMOLU_ENABLE -}
+
+bar :: Bool -> Bool
+bar True  = True
+bar False = True

--- a/data/examples/other/disabling/whole-file-out.hs
+++ b/data/examples/other/disabling/whole-file-out.hs
@@ -1,0 +1,10 @@
+{- ORMOLU_DISABLE -}
+
+module Foo (foo,bar) where
+
+foo :: Int -> Int
+foo = (+5)
+
+bar :: Bool -> Bool
+bar True  = True
+bar False = True

--- a/data/examples/other/disabling/whole-file.hs
+++ b/data/examples/other/disabling/whole-file.hs
@@ -1,0 +1,10 @@
+{-    ORMOLU_DISABLE     -}
+
+module Foo (foo,bar) where
+
+foo :: Int -> Int
+foo = (+5)
+
+bar :: Bool -> Bool
+bar True  = True
+bar False = True

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -109,6 +109,9 @@ library
                     , Ormolu.Printer.Meat.Type
                     , Ormolu.Printer.Operators
                     , Ormolu.Printer.SpanStream
+                    , Ormolu.Processing.Common
+                    , Ormolu.Processing.Postprocess
+                    , Ormolu.Processing.Preprocess
                     , Ormolu.Utils
   other-modules:      GHC
                     , GHC.DynFlags

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -11,6 +11,7 @@ import Ormolu.Parser.Result
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Module
 import Ormolu.Printer.SpanStream
+import Ormolu.Processing.Postprocess (postprocess)
 
 -- | Render a module.
 printModule ::
@@ -19,15 +20,16 @@ printModule ::
   -- | Resulting rendition
   Text
 printModule ParseResult {..} =
-  runR
-    ( p_hsModule
-        prStackHeader
-        prShebangs
-        prPragmas
-        prImportQualifiedPost
-        prParsedSource
-    )
-    (mkSpanStream prParsedSource)
-    prCommentStream
-    prAnns
-    prUseRecordDot
+  postprocess $
+    runR
+      ( p_hsModule
+          prStackHeader
+          prShebangs
+          prPragmas
+          prImportQualifiedPost
+          prParsedSource
+      )
+      (mkSpanStream prParsedSource)
+      prCommentStream
+      prAnns
+      prUseRecordDot

--- a/src/Ormolu/Processing/Common.hs
+++ b/src/Ormolu/Processing/Common.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Common definitions for pre- and post- processing.
+module Ormolu.Processing.Common
+  ( OrmoluState (..),
+    startDisabling,
+    endDisabling,
+  )
+where
+
+import Data.String (IsString (..))
+
+-- | Ormolu state.
+data OrmoluState
+  = -- | Enabled
+    OrmoluEnabled
+  | -- | Disabled
+    OrmoluDisabled
+  deriving (Eq, Show)
+
+-- | Marker for the beginning of the region where Ormolu should be disabled.
+startDisabling :: IsString s => s
+startDisabling = "{- ORMOLU_DISABLING_START"
+
+-- | Marker for the end of the region where Ormolu should be disabled.
+endDisabling :: IsString s => s
+endDisabling = "ORMOLU_DISABLE_END -}"

--- a/src/Ormolu/Processing/Postprocess.hs
+++ b/src/Ormolu/Processing/Postprocess.hs
@@ -1,0 +1,16 @@
+-- | Postprocessing for the results of printing.
+module Ormolu.Processing.Postprocess
+  ( postprocess,
+  )
+where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Ormolu.Processing.Common
+
+-- | Postprocess output of the formatter.
+postprocess :: Text -> Text
+postprocess = T.unlines . filter (not . magicComment) . T.lines
+  where
+    magicComment x =
+      x == startDisabling || x == endDisabling

--- a/src/Ormolu/Processing/Preprocess.hs
+++ b/src/Ormolu/Processing/Preprocess.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | Preprocessing for input source code.
+module Ormolu.Processing.Preprocess
+  ( preprocess,
+  )
+where
+
+import Control.Monad
+import Data.Char (isSpace)
+import qualified Data.List as L
+import Data.Maybe (isJust)
+import Data.Maybe (maybeToList)
+import FastString
+import Ormolu.Parser.Shebang (isShebang)
+import Ormolu.Processing.Common
+import SrcLoc
+
+-- | Transform given input possibly returning comments extracted from it.
+-- This handles LINE pragmas, shebangs, and the magic comments for
+-- enabling\/disabling of Ormolu.
+preprocess ::
+  -- | File name, just to use in the spans
+  FilePath ->
+  -- | Input to process
+  String ->
+  -- | Adjusted input with comments extracted from it
+  (String, [Located String])
+preprocess path input = go 1 OrmoluEnabled id id (lines input)
+  where
+    go !n ormoluState inputSoFar csSoFar = \case
+      [] ->
+        let input' = unlines (inputSoFar [])
+         in ( case ormoluState of
+                OrmoluEnabled -> input'
+                OrmoluDisabled -> input' ++ endDisabling,
+              csSoFar []
+            )
+      (x : xs) ->
+        let (x', ormoluState', cs) = processLine path n ormoluState x
+         in go
+              (n + 1)
+              ormoluState'
+              (inputSoFar . (x' :))
+              (csSoFar . (maybeToList cs ++))
+              xs
+
+-- | Transform a given line possibly returning a comment extracted from it.
+processLine ::
+  -- | File name, just to use in the spans
+  FilePath ->
+  -- | Line number of this line
+  Int ->
+  -- | Whether Ormolu is currently enabled
+  OrmoluState ->
+  -- | The actual line
+  String ->
+  -- | Adjusted line and possibly a comment extracted from it
+  (String, OrmoluState, Maybe (Located String))
+processLine path n ormoluState line
+  | "{-# LINE" `L.isPrefixOf` line =
+    let (pragma, res) = getPragma line
+        size = length pragma
+        ss = mkSrcSpan (mkSrcLoc' 1) (mkSrcLoc' (size + 1))
+     in (res, ormoluState, Just (L ss pragma))
+  | isOrmoluEnable line =
+    case ormoluState of
+      OrmoluEnabled ->
+        (enableMarker, OrmoluEnabled, Nothing)
+      OrmoluDisabled ->
+        (endDisabling ++ enableMarker, OrmoluEnabled, Nothing)
+  | isOrmoluDisable line =
+    case ormoluState of
+      OrmoluEnabled ->
+        (disableMarker ++ startDisabling, OrmoluDisabled, Nothing)
+      OrmoluDisabled ->
+        (disableMarker, OrmoluDisabled, Nothing)
+  | isShebang line =
+    let ss = mkSrcSpan (mkSrcLoc' 1) (mkSrcLoc' (length line))
+     in ("", ormoluState, Just (L ss line))
+  | otherwise = (line, ormoluState, Nothing)
+  where
+    mkSrcLoc' = mkSrcLoc (mkFastString path) n
+
+-- | Take a line pragma and output its replacement (where line pragma is
+-- replaced with spaces) and the contents of the pragma itself.
+getPragma ::
+  -- | Pragma line to analyze
+  String ->
+  -- | Contents of the pragma and its replacement line
+  (String, String)
+getPragma [] = error "Ormolu.Preprocess.getPragma: input must not be empty"
+getPragma s@(x : xs)
+  | "#-}" `L.isPrefixOf` s = ("#-}", "   " ++ drop 3 s)
+  | otherwise =
+    let (prag, remline) = getPragma xs
+     in (x : prag, ' ' : remline)
+
+-- | Canonical enable marker.
+enableMarker :: String
+enableMarker = "{- ORMOLU_ENABLE -}"
+
+-- | Canonical disable marker.
+disableMarker :: String
+disableMarker = "{- ORMOLU_DISABLE -}"
+
+-- | Return 'True' if the given string is an enabling marker.
+isOrmoluEnable :: String -> Bool
+isOrmoluEnable = magicComment "ORMOLU_ENABLE"
+
+-- | Return 'True' if the given string is a disabling marker.
+isOrmoluDisable :: String -> Bool
+isOrmoluDisable = magicComment "ORMOLU_DISABLE"
+
+-- | Construct a function for whitespace-insensitive matching of string.
+magicComment ::
+  -- | What to expect
+  String ->
+  -- | String to test
+  String ->
+  -- | Whether or not the two strings watch
+  Bool
+magicComment expected s0 = isJust $ do
+  s1 <- dropWhile isSpace <$> L.stripPrefix "{-" s0
+  s2 <- dropWhile isSpace <$> L.stripPrefix expected s1
+  s3 <- L.stripPrefix "-}" s2
+  guard (all isSpace s3)


### PR DESCRIPTION
Close #435.

Ormolu can be turned on and off via the special comments:

```haskell
{- ORMOLU_DISABLE -}
```

and

```haskell
{- ORMOLU_ENABLE -}
```

This allows us to disable formatting selectively for code between these
markers or disable it for the entire file. To achieve the latter, just put
`{- ORMOLU_DISABLE -}` at the very top. Note that the source code should
still be parseable even without the “excluded” part. Because of that the
magic comments cannot be placed arbitrary, but should rather enclose
independent top-level definitions.