### PR TITLE
Fix rendering of type signatures concerning several identifiers

### DIFF
--- a/data/examples/declaration/signature/type/multi-value-out.hs
+++ b/data/examples/declaration/signature/type/multi-value-out.hs
@@ -2,6 +2,11 @@ foo, bar :: Int
 foo = 1
 bar = 2
 
+a, b, c :: Int
+a = 1
+b = 2
+c = 3
+
 foo,
   bar,
   baz ::

--- a/data/examples/declaration/signature/type/multi-value.hs
+++ b/data/examples/declaration/signature/type/multi-value.hs
@@ -2,6 +2,11 @@ foo, bar :: Int
 foo = 1
 bar = 2
 
+a, b, c :: Int
+a = 1
+b = 2
+c = 3
+
 foo,
   bar,
     baz :: Int

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -48,11 +48,12 @@ p_typeSig indentTail (n : ns) hswc = do
   p_rdrName n
   if null ns
     then p_typeAscription hswc
-    else bool id inci indentTail $ do
+    else do
       comma
       breakpoint
-      sep (comma >> breakpoint) p_rdrName ns
-      p_typeAscription hswc
+      bool id inci indentTail $ do
+        sep (comma >> breakpoint) p_rdrName ns
+        p_typeAscription hswc
 
 p_typeAscription ::
   LHsSigWcType GhcPs ->
@@ -74,7 +75,11 @@ p_patSynSig ::
   R ()
 p_patSynSig names hsib = do
   txt "pattern"
-  let body = p_typeSig False names HsWC {hswc_ext = NoExtField, hswc_body = hsib}
+  let body =
+        p_typeSig
+          False
+          names
+          HsWC {hswc_ext = NoExtField, hswc_body = hsib}
   if length names > 1
     then breakpoint >> inci body
     else space >> body


### PR DESCRIPTION
Close #566.

Previously an extra space were erroneously inserted if the first identifier
happened to be one character long.