### PR TITLE
Fix the idempotence bug 340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Fixed an idempotence issue related to different indentation levels in a
   comment series. [Issue 512](https://github.com/tweag/ormolu/issues/512).
 
+* Fixed an idempotence related to comments which may happen to be separated
+  from the elements they are attached to by the equality sign. [Issue
+  340](https://github.com/tweag/ormolu/issues/340).
+
 * Renamed the `--check-idempotency` flag to `--check-idempotence`.
   Apparently only the latter is correct.
 

--- a/data/examples/declaration/value/function/awkward-comment-0-out.hs
+++ b/data/examples/declaration/value/function/awkward-comment-0-out.hs
@@ -1,0 +1,6 @@
+mergeErrorReply :: ParseError -> Reply s u a -> Reply s u a
+mergeErrorReply err1 reply -- XXX where to put it?
+  =
+  case reply of
+    Ok x state err2 -> Ok x state (mergeError err1 err2)
+    Error err2 -> Error (mergeError err1 err2)

--- a/data/examples/declaration/value/function/awkward-comment-0.hs
+++ b/data/examples/declaration/value/function/awkward-comment-0.hs
@@ -1,0 +1,5 @@
+mergeErrorReply :: ParseError -> Reply s u a -> Reply s u a
+mergeErrorReply err1 reply -- XXX where to put it?
+    = case reply of
+        Ok x state err2 -> Ok x state (mergeError err1 err2)
+        Error err2      -> Error (mergeError err1 err2)

--- a/data/examples/declaration/value/function/awkward-comment-1-out.hs
+++ b/data/examples/declaration/value/function/awkward-comment-1-out.hs
@@ -1,0 +1,9 @@
+doForeign :: Vars -> [Name] -> [Term] -> Idris LExp
+doForeign x = x
+  where
+    splitArg tm | (_, [_, _, l, r]) <- unApply tm -- pair, two implicits
+      =
+      do
+        let l' = toFDesc l
+        r' <- irTerm (sMN 0 "__foreignCall") vs env r
+        return (l', r')

--- a/data/examples/declaration/value/function/awkward-comment-1.hs
+++ b/data/examples/declaration/value/function/awkward-comment-1.hs
@@ -1,0 +1,7 @@
+doForeign :: Vars -> [Name] -> [Term] -> Idris LExp
+doForeign x = x
+  where
+    splitArg tm | (_, [_,_,l,r]) <- unApply tm -- pair, two implicits
+        = do let l' = toFDesc l
+             r' <- irTerm (sMN 0 "__foreignCall") vs env r
+             return (l', r')

--- a/default.nix
+++ b/default.nix
@@ -107,6 +107,7 @@ in {
       "optics"
       "ormolu"
       "pandoc"
+      "parsec3"
       "pipes"
       "postgrest"
       "purescript"

--- a/expected-failures/Agda.txt
+++ b/expected-failures/Agda.txt
@@ -1,4 +1,10 @@
 Formatting is not idempotent:
+  dist/build/Agda/Syntax/Parser/Lexer.hs<rendered>:1597:17
+  before: "         = (check_ac"
+  after:  "         =\n         "
+Please, consider reporting the bug.
+
+Formatting is not idempotent:
   src/full/Agda/Syntax/Internal.hs<rendered>:236:12
   before: "pe Elims = -- | elim"
   after:  "pe Elims =\n  -- | el"
@@ -7,12 +13,6 @@ Please, consider reporting the bug.
 Parsing of formatted code failed:
   src/full/Agda/Syntax/Translation/ConcreteToAbstract.hs<rendered>:524:7-13
   parse error on input `C.QName'
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/full/Agda/Termination/CallGraph.hs<rendered>:151:38
-  before: "2, old2) = -- TODO: "
-  after:  "2, old2) =\n        -"
 Please, consider reporting the bug.
 
 Formatting is not idempotent:

--- a/expected-failures/idris.txt
+++ b/expected-failures/idris.txt
@@ -11,39 +11,15 @@ Formatting is not idempotent:
 Please, consider reporting the bug.
 
 Formatting is not idempotent:
-  src/Idris/Core/ProofTerm.hs<rendered>:351:19
-  before: "f c e pt = -- @(PT p"
-  after:  "f c e pt =\n  -- @(PT"
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
   src/Idris/Core/TT.hs<rendered>:1963:13
   before: "   text op <> pretty"
   after:  "   text op\n        <"
 Please, consider reporting the bug.
 
 Formatting is not idempotent:
-  src/Idris/Core/WHNF.hs<rendered>:105:46
-  before: " n b sc) = -- stk mu"
-  after:  " n b sc) =\n      -- "
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/Delaborate.hs<rendered>:627:6
+  src/Idris/Delaborate.hs<rendered>:628:6
   before: "ity\n      -- Issue #"
   after:  "ity\n        -- Issue"
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/Elab/Term.hs<rendered>:432:47
-  before: "K\" _ _)) = -- for ch"
-  after:  "K\" _ _)) =\n      -- "
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/ModeCommon.hs<rendered>:34:26
-  before: "s toline = -- furthe"
-  after:  "s toline =\n  -- furt"
 Please, consider reporting the bug.
 
 Formatting is not idempotent:
@@ -65,37 +41,7 @@ The GHC parser (in Haddock mode) failed:
   parse error on input `@'
 
 Formatting is not idempotent:
-  src/Idris/PartialEval.hs<rendered>:281:42
-  before: ": ns) as = -- Droppe"
-  after:  ": ns) as =\n      -- "
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/ProofSearch.hs<rendered>:487:20
-  before: "OK ty hs = -- if any"
-  after:  "OK ty hs =\n      -- "
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
   src/Idris/Prover.hs<rendered>:239:10
   before: "      line <> bindin"
   after:  "      line\n        <"
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/REPL.hs<rendered>:1270:33
-  before: "ht c) _) = -- consta"
-  after:  "ht c) _) =\n  -- cons"
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/Reflection.hs<rendered>:934:27
-  before: "attern _ = -- for al"
-  after:  "attern _ =\n  -- for "
-Please, consider reporting the bug.
-
-Formatting is not idempotent:
-  src/Idris/Transforms.hs<rendered>:26:32
-  before: "s, rhs)) = -- apply "
-  after:  "s, rhs)) =\n      -- "
 Please, consider reporting the bug.

--- a/expected-failures/intero.txt
+++ b/expected-failures/intero.txt
@@ -1,5 +1,5 @@
 Formatting is not idempotent:
-  src/InteractiveUI.hs<rendered>:2635:36
-  before: "Decl d2) = -- A bit "
-  after:  "Decl d2) =\n  -- A bi"
+  src/InteractiveUI.hs<rendered>:3688:33
+  before: "text \"Try\" <+> doWha"
+  after:  "text \"Try\"\n         "
 Please, consider reporting the bug.

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -51,6 +51,7 @@ module Ormolu.Printer.Combinators
 
     -- ** Literals
     comma,
+    equals,
 
     -- ** Stateful markers
     SpanMark (..),
@@ -275,3 +276,7 @@ brackets_ needBreaks open close style m = sitcc (vlayout singleLine multiLine)
 -- | Print @,@.
 comma :: R ()
 comma = txt ","
+
+-- | Print @=@. Do not use @'txt' "="@.
+equals :: R ()
+equals = interferingTxt "="

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -67,7 +67,7 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
           if singleConstRec
             then space
             else breakpoint
-          txt "="
+          equals
           space
           let s =
                 vlayout

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -43,7 +43,7 @@ p_ruleDecl = \case
     inci $ do
       located lhs p_hsExpr
       space
-      txt "="
+      equals
       inci $ do
         breakpoint
         located rhs p_hsExpr

--- a/src/Ormolu/Printer/Meat/Declaration/Type.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Type.hs
@@ -32,7 +32,7 @@ p_synDecl name fixity HsQTvs {..} t = do
       (p_rdrName name)
       (map (located' p_hsTyVarBndr) hsq_explicit)
   space
-  txt "="
+  equals
   breakpoint
   inci (located t p_hsType)
 p_synDecl _ _ (XLHsQTyVars x) _ = noExtCon x

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -69,7 +69,7 @@ p_familyResultSigL l =
         breakpoint
         located k p_hsType
       TyVarSig NoExtField bndr -> Just $ do
-        txt "="
+        equals
         breakpoint
         located bndr p_hsTyVarBndr
       XFamilyResultSig x ->
@@ -101,7 +101,7 @@ p_tyFamInstEqn HsIB {hsib_body = FamEqn {..}} = do
         (p_rdrName feqn_tycon)
         (located' p_hsType . typeArgToType <$> feqn_pats)
     space
-    txt "="
+    equals
     breakpoint
     inci (located feqn_rhs p_hsType)
 p_tyFamInstEqn HsIB {hsib_body = XFamEqn x} = noExtCon x


### PR DESCRIPTION
Close #340.

This resolves a class of idempotence issues when the equality sign happens to be inserted between an element and its comment that follows on the same line. I had to special-case equality sign for this, because all alternative approaches (changing comment association logic or trying to find a more general rule) did not work or fixed this issue yet made other things worse.

There is nothing special about the equality sign per se, but it (always?) starts definitions which have their own `Located` wrappers and it is those spans interfere with the logic of comment association (they are detected as AST elements between the “host” element and its comment) on subsequent
passes. This results in non-idempotent formatting.

The solution is OKish in that it fixes 99% of problems that one will encounter in practice, but I see how an input can be crafted to show that there is still an issue with idempotence.