### PR TITLE
Fix the false positive about AST differences

### DIFF
--- a/data/examples/other/multiple-blank-line-comment-out.hs
+++ b/data/examples/other/multiple-blank-line-comment-out.hs
@@ -1,0 +1,9 @@
+module A where
+
+a =
+  b
+    [ f
+    {-,
+
+                                       -}
+    ]

--- a/data/examples/other/multiple-blank-line-comment.hs
+++ b/data/examples/other/multiple-blank-line-comment.hs
@@ -1,0 +1,10 @@
+module A where
+
+a =
+  b
+    [ f
+ {-,
+
+
+                                    -}
+    ]


### PR DESCRIPTION
Close #518.

Comments that have more than one consecutive blank line will be rendered
with just a single blank line due to how our rendering engine works. I think
that the engine work correctly in this case and we want to generally
normalize blank lines. So what should be fixed is just the check. For that
we remove extra consecutive blank lines when we construct `Comment` values.