### PR TITLE
Remove duplicate LIE's from import lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Duplicate imports in a single import list are now eliminated.
+
 ## Ormolu 0.1.0.0
 
 * Fixed rendering of type signatures concerning several identifiers. [Issue

--- a/data/examples/import/misc-out.hs
+++ b/data/examples/import/misc-out.hs
@@ -1,11 +1,5 @@
 import A hiding
   ( foobarbazqux,
-    foobarbazqux,
-    foobarbazqux,
-    foobarbazqux,
-    foobarbazqux,
-    foobarbazqux,
-    foobarbazqux,
   )
 import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 import Name hiding ()

--- a/data/examples/import/simple-out.hs
+++ b/data/examples/import/simple-out.hs
@@ -4,3 +4,5 @@ import qualified Data.Text as T
 import qualified Data.Text (a, b, c)
 import Data.Text (a, b, c)
 import Data.Text hiding (a, b, c)
+import Data.Text (a, b, c)
+import Data.Text hiding (a, b, c)

--- a/data/examples/import/simple.hs
+++ b/data/examples/import/simple.hs
@@ -4,3 +4,5 @@ import qualified Data.Text as T
 import qualified Data.Text (a, c, b)
 import Data.Text (a, b, c)
 import Data.Text hiding (c, b, a)
+import Data.Text (a, b, c, b, a)
+import Data.Text hiding (c, b, a, b, c)


### PR DESCRIPTION
Sanitizes import lists
```haskell
import Data.Text (a, a)
import Data.Text hiding (a, a)
```
to
```haskell
import Data.Text (a)
import Data.Text hiding (a)
```
This seems sensible to me, although `data/examples/import/misc-out.hs` suggests that the original behavior is as intended?