### PR TITLE
Put operators after other names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   disabled part is still syntactically correct. [Issue
   601](https://github.com/tweag/ormolu/issues/601).
 
+* Improved sorting of operators in imports. [Issue
+  602](https://github.com/tweag/ormolu/issues/602).
+
 ## Ormolu 0.1.0.0
 
 * Fixed rendering of type signatures concerning several identifiers. [Issue

--- a/data/examples/import/explicit-imports-out.hs
+++ b/data/examples/import/explicit-imports-out.hs
@@ -1,12 +1,12 @@
 import qualified MegaModule as M
-  ( (<<<),
-    (>>>),
-    Either,
+  ( Either,
     Maybe (Just, Nothing),
     MaybeT (..),
-    Monad ((>>), (>>=), return),
+    Monad (return, (>>), (>>=)),
     MonadBaseControl,
     join,
     liftIO,
     void,
+    (<<<),
+    (>>>),
   )

--- a/data/examples/import/explicit-imports-with-comments-out.hs
+++ b/data/examples/import/explicit-imports-with-comments-out.hs
@@ -1,6 +1,7 @@
 import qualified MegaModule as M
   ( -- (1)
-    (<<<), -- (2)
-    (>>>),
+    -- (2)
     Either, -- (3)
+    (<<<),
+    (>>>),
   )

--- a/data/examples/import/nested-explicit-imports-out.hs
+++ b/data/examples/import/nested-explicit-imports-out.hs
@@ -1,10 +1,10 @@
 import qualified MegaModule as M
-  ( (<<<),
-    (>>>),
-    Either,
+  ( Either,
     Monad
-      ( (>>),
-        (>>=),
-        return
+      ( return,
+        (>>),
+        (>>=)
       ),
+    (<<<),
+    (>>>),
   )

--- a/data/examples/import/qualified-prelude-out.hs
+++ b/data/examples/import/qualified-prelude-out.hs
@@ -1,4 +1,4 @@
 module P where
 
 import qualified Prelude
-import Prelude hiding ((.), id)
+import Prelude hiding (id, (.))

--- a/data/examples/import/sorted-export-list-out.hs
+++ b/data/examples/import/sorted-export-list-out.hs
@@ -1,0 +1,1 @@
+import Linear.Vector (Additive (..), (*^), (^*))

--- a/data/examples/import/sorted-export-list.hs
+++ b/data/examples/import/sorted-export-list.hs
@@ -1,0 +1,1 @@
+import Linear.Vector (Additive (..), (*^), (^*))

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -12,7 +12,7 @@ module Ormolu.Printer.Meat.Declaration
 where
 
 import Data.List (sort)
-import Data.List.NonEmpty ((<|), NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty (..), (<|))
 import qualified Data.List.NonEmpty as NE
 import GHC hiding (InlinePragma)
 import OccName (occNameFS)

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -21,7 +21,7 @@ import Data.Char (isPunctuation, isSymbol)
 import Data.Data hiding (Infix, Prefix)
 import Data.Functor ((<&>))
 import Data.List (intersperse, sortOn)
-import Data.List.NonEmpty ((<|), NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty (..), (<|))
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import qualified Data.Text as Text


### PR DESCRIPTION
Close #602.

Previously `RdrName`s were sorted by simple comparison of their names. However, in ASCII not all “operator-like” symbols go after alpha-numeric characters. This resulted in this sort of output:

```haskell
import Linear.Vector ((*^), Additive (..), (^*))
```

The new ordering scheme allows us to separate operators and other names:

```haskell
import Linear.Vector (Additive (..), (*^), (^*))
```