### PR TITLE
[wip] Sort constraints

### DIFF
--- a/data/examples/declaration/class/dependency-super-classes-out.hs
+++ b/data/examples/declaration/class/dependency-super-classes-out.hs
@@ -9,8 +9,8 @@ class (MonadReader r s, MonadWriter w m) => MonadState s m | m -> s where
 
 -- | 'MonadParsec'
 class
-  ( Stream s, -- Token streams
-    MonadPlus m -- Potential for failure
+  ( MonadPlus m, -- Potential for failure
+    Stream s -- Token streams
   ) =>
   MonadParsec e s m
     | m -> e s

--- a/data/examples/declaration/data/gadt/multiline-out.hs
+++ b/data/examples/declaration/data/gadt/multiline-out.hs
@@ -7,7 +7,7 @@ data Foo a where
   -- | 'Foo' is wonderful.
   Foo ::
     forall a b.
-    (Show a, Eq b) => -- foo
+    (Eq b, Show a) => -- foo
     -- bar
     a ->
     b ->

--- a/data/examples/declaration/data/gadt/simple-out.hs
+++ b/data/examples/declaration/data/gadt/simple-out.hs
@@ -5,7 +5,7 @@ module Main where
 -- | Here goes a comment.
 data Foo a where
   -- | 'Foo' is wonderful.
-  Foo :: forall a b. (Show a, Eq b) => a -> b -> Foo 'Int
+  Foo :: forall a b. (Eq b, Show a) => a -> b -> Foo 'Int
   Bar ::
     Int ->
     Text ->

--- a/data/examples/declaration/signature/specialize/specialize-instance-out.hs
+++ b/data/examples/declaration/signature/specialize/specialize-instance-out.hs
@@ -6,7 +6,7 @@ instance (Eq a) => Eq (Foo a) where
   {-# SPECIALIZE instance Eq (Foo [(Int, Bar)]) #-}
   (==) (Foo a) (Foo b) = (==) a b
 
-instance (Num r, V.Vector v r, Factored m r) => Num (VT v m r) where
+instance (Factored m r, Num r, V.Vector v r) => Num (VT v m r) where
   {-# SPECIALIZE instance
     ( Factored m Int => Num (VT U.Vector m Int)
     )

--- a/data/examples/declaration/value/function/fancy-forall-0-out.hs
+++ b/data/examples/declaration/value/function/fancy-forall-0-out.hs
@@ -1,10 +1,10 @@
 wrapError ::
   forall outertag innertag t outer inner m a.
   ( forall x. Coercible (t m x) (m x),
+    HasCatch outertag outer m,
     forall m'.
     HasCatch outertag outer m' =>
-    HasCatch innertag inner (t m'),
-    HasCatch outertag outer m
+    HasCatch innertag inner (t m')
   ) =>
   (forall m'. HasCatch innertag inner m' => m' a) ->
   m a

--- a/data/examples/declaration/value/function/fancy-forall-1-out.hs
+++ b/data/examples/declaration/value/function/fancy-forall-1-out.hs
@@ -1,10 +1,10 @@
 magnify ::
   forall outertag innertag t outer inner m a.
   ( forall x. Coercible (t m x) (m x),
+    HasReader outertag outer m,
     forall m'.
     HasReader outertag outer m' =>
-    HasReader innertag inner (t m'),
-    HasReader outertag outer m
+    HasReader innertag inner (t m')
   ) =>
   (forall m'. HasReader innertag inner m' => m' a) ->
   m a

--- a/data/examples/other/constraint-sorting-out.hs
+++ b/data/examples/other/constraint-sorting-out.hs
@@ -1,0 +1,2 @@
+foo :: (Bar A a, Baz (a), forall a b. Baz b) => a -> b
+foo a = undefined

--- a/data/examples/other/constraint-sorting.hs
+++ b/data/examples/other/constraint-sorting.hs
@@ -1,0 +1,2 @@
+foo :: (forall a b. Baz b, Baz (a), Bar A a) => a -> b
+foo a = undefined

--- a/data/examples/other/cpp/separation-1a-out.hs
+++ b/data/examples/other/cpp/separation-1a-out.hs
@@ -1,5 +1,5 @@
 decompressingPipe ::
-  (PrimMonad m, MonadThrow m, MonadResource m) =>
+  (MonadResource m, MonadThrow m, PrimMonad m) =>
   CompressionMethod ->
   ConduitT ByteString ByteString m ()
 decompressingPipe Store = C.awaitForever C.yield

--- a/data/examples/other/cpp/separation-1b-out.hs
+++ b/data/examples/other/cpp/separation-1b-out.hs
@@ -1,5 +1,5 @@
 decompressingPipe ::
-  (PrimMonad m, MonadThrow m, MonadResource m) =>
+  (MonadResource m, MonadThrow m, PrimMonad m) =>
   CompressionMethod ->
   ConduitT ByteString ByteString m ()
 decompressingPipe Store = C.awaitForever C.yield

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -68,6 +68,7 @@ library
     exposed-modules:
         Ormolu
         Ormolu.Config
+        Ormolu.Constraints
         Ormolu.Diff
         Ormolu.Exception
         Ormolu.Imports

--- a/src/Ormolu/Constraints.hs
+++ b/src/Ormolu/Constraints.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Ormolu.Constraints
+  ( sortConstraints,
+  )
+where
+
+import Data.Char
+import Data.Generics (Data, Typeable, cast, gmapQ)
+import Data.List (sortOn)
+import Outputable
+import GHC
+
+sortConstraints :: [LHsType GhcPs] -> [LHsType GhcPs]
+sortConstraints = sortOn oFromL
+
+oFromL :: LHsType GhcPs -> OrdWrapper
+oFromL = O . unLoc
+
+newtype OrdWrapper = O (HsType GhcPs)
+  deriving (Typeable, Data)
+
+instance Eq OrdWrapper where
+  (O a) == (O b) = compare (O a) (O b) == EQ
+
+getIdentifiers :: Data d => d -> [RdrName]
+getIdentifiers a = case cast a of
+  Just name -> [name]
+  Nothing -> mconcat $ case cast a :: Maybe (HsType GhcPs) of
+    Just (HsForAllTy _ _ _ body) -> gmapQ getIdentifiers body
+    _ -> gmapQ getIdentifiers a
+
+showRdrName :: RdrName -> String
+showRdrName = showSDocUnsafe . ppr
+
+getIdentStrings :: Data d => d -> [String]
+getIdentStrings = fmap (fmap toLower) . fmap showRdrName . getIdentifiers
+
+instance Ord (OrdWrapper) where
+  compare a b = compare (getIdentStrings a) (getIdentStrings b)

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -18,6 +18,7 @@ where
 import Data.Data (Data)
 import GHC hiding (isPromoted)
 import Ormolu.Printer.Combinators
+import Ormolu.Constraints (sortConstraints)
 import Ormolu.Printer.Meat.Common
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsSplice, p_stringLit)
 import Ormolu.Printer.Operators
@@ -188,7 +189,7 @@ hasDocStrings = \case
   _ -> False
 
 p_hsContext :: HsContext GhcPs -> R ()
-p_hsContext = \case
+p_hsContext ctx = case sortConstraints ctx of
   [] -> txt "()"
   [x] -> located x p_hsType
   xs -> parens N $ sep commaDel (sitcc . located' p_hsType) xs


### PR DESCRIPTION
Want to get some initial feedback on this.

Sometimes, you just need a lot of constraints, so having them sorted improves the reader's constraint lookup time.

The constraints are sorted by their embedded identifiers, case insensitively, and excluding built-in syntax like `(,)`, `[,]`, `forall`.

There's currently two [tests](https://github.com/tweag/ormolu/blob/033bb16032f1a056652883a67a2666daf745c2b0/data/examples/declaration/class/super-classes-out.hs) [failing](https://github.com/tweag/ormolu/blob/033bb16032f1a056652883a67a2666daf745c2b0/data/examples/declaration/class/dependency-super-classes-out.hs), where the formatter isn't reordering comments placed after constraints (it kind of screws up the formatting):

```haskell
( -- Foo?
  Bar a, -- Bar?
  Baz a, -- Baz
  Foo a
) =>
```