### PR TITLE
nix: allow to pass the system attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-{ pkgs ? (import ./nix/nixpkgs)
+{ pkgs ? (import ./nix/nixpkgs { inherit system; })
+, system ? builtins.currentSystem
 , ormoluCompiler ? "ghc883" # the shell doesn't work with ghc8101 yet
 }:
 

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,3 +1,4 @@
+{ system ? builtins.currentSystem }:
 let
   rev = "807ca93fadd5197c2260490de0c76e500562dc05";
   sha256 = "10yq8bnls77fh3pk5chkkb1sv5lbdgyk1rr2v9xn71rr1k2x563p";
@@ -5,5 +6,8 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;
   };
-  pkgs = import nixpkgs { config.allowUnfree = true; };
+  pkgs = import nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+  };
 in pkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,5 @@
-{ pkgs ? (import ./nix/nixpkgs) }:
+{ pkgs ? (import ./nix/nixpkgs { inherit system; })
+, system ? builtins.currentSystem
+}:
 
 (import ./default.nix { inherit pkgs; }).dev.ormoluShell


### PR DESCRIPTION
This allows to build ormolu for another system as the machine's,
combined with Nix remote builders. It is also useful in a context of a
pure evaluation (like Flakes).