### PR TITLE
add workflow for release binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,39 @@
+name: Build binaries
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-haskell@v1
+        if: runner.os != 'Linux'
+        with:
+          ghc-version: '8.10.1'
+          cabal-version: '3.2'
+      - name: Build Linux binary
+        if: runner.os == 'Linux'
+        run: |
+          docker run \
+            -v $(pwd):/mnt -w /mnt \
+            utdemir/ghc-musl:v14-ghc8101 \
+            bash .github/workflows/build.sh
+      - name: Build ${{ runner.os }} binary
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          cabal build exe:ormolu
+          cp $(find dist-newstyle \( -name ormolu -o -name ormolu.exe \) -type f) ormolu
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ormolu
+          asset_name: ormolu-${{ runner.os }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,7 @@
+set -e
+
+cabal update
+cabal build exe:ormolu --enable-executable-static --ghc-options="-split-sections"
+
+cp $(find dist-newstyle -name ormolu -type f) .
+strip -s ormolu


### PR DESCRIPTION
Closes #543.

This PR will add binaries for Linux, macOS and Windows when a new release (corresponding to a tag) is created. See [here](https://github.com/amesgen/ormolu/releases/tag/test-release) for an example ([workflow run](https://github.com/amesgen/ormolu/actions/runs/239377467)).

On Linux, the excellent [ghc-musl](https://github.com/utdemir/ghc-musl) by @utdemir is used.

GHC 8.10.1 is used due to this bug on Windows on 8.10.2: https://gitlab.haskell.org/ghc/ghc/-/issues/18550