### PR TITLE
 Avoid modifying correctly-formatted files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Ormolu no longer overwrites already formatted files. [PR
+  649](https://github.com/tweag/ormolu/pull/649).
+
 ## Ormolu 0.1.2.0
 
 * Fixed the bug when comments in different styles got glued together after


### PR DESCRIPTION
Currently, when running with `--mode=inplace`, Ormolu always overwrites the files, even when nothing has changed, updating the modified timestamp of the file. This encourages Stack to rebuild everything when only one file has changed.

A quick check to see if the file needs rewriting solves this problem.

I would prefer the API allowed me to only read the file once, but as the `--mode=check` logic also reads the file twice, I decided this wasn't the biggest sin for now.