### PR TITLE
Avoid inserting a redundant space in front of ticked types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Added support for monad comprehensions. [Issue
   665](https://github.com/tweag/ormolu/issues/658).
 
+* Fixed a bug when a space was inserted in front of promoted types even when
+  it wasn't strictly necessary. [Issue
+  668](https://github.com/tweag/ormolu/issues/688).
+
 ## Ormolu 0.1.3.1
 
 * Fixed a problem with multiline record updates using the record dot

--- a/data/examples/declaration/type/promotion-0-out.hs
+++ b/data/examples/declaration/type/promotion-0-out.hs
@@ -1,0 +1,9 @@
+type Foo = Cluster '[ 'NodeCore, 'NodeRelay', 'NodeEdge]
+
+type Query = Query '[] '[] DB '[ 'NotNull 'PGint4] (RowPG RawElementData)
+
+data T = T' | T'T
+
+type S0 = ' T'
+
+type S1 = ' T'T

--- a/data/examples/declaration/type/promotion-0.hs
+++ b/data/examples/declaration/type/promotion-0.hs
@@ -1,0 +1,9 @@
+type Foo = Cluster '[ 'NodeCore, 'NodeRelay', 'NodeEdge ]
+
+type Query = Query '[] '[] DB '[ 'NotNull 'PGint4] (RowPG RawElementData)
+
+data T = T' | T'T
+
+type S0 = ' T'
+
+type S1 = ' T'T

--- a/data/examples/declaration/type/promotion-1-out.hs
+++ b/data/examples/declaration/type/promotion-1-out.hs
@@ -1,13 +1,3 @@
-type Foo = Cluster '[ 'NodeCore, 'NodeRelay', 'NodeEdge]
-
-type Query = Query '[] '[] DB '[ 'NotNull 'PGint4] (RowPG RawElementData)
-
-data T = T' | T'T
-
-type S0 = ' T'
-
-type S1 = ' T'T
-
 type S2 = Proxy ('[ '[], '[]])
 
 type S4 = Proxy ('( 'Just, ' T'T))
@@ -19,3 +9,7 @@ type S6 = Proxy ('( '(), '()))
 type S7 = Proxy ('( 'a, 'b))
 
 type S8 = Proxy ('[Int, Bool])
+
+type E = TypeError ('Text "Some text")
+
+type G = '[ '( 'Just, 'Bool)]

--- a/data/examples/declaration/type/promotion-1.hs
+++ b/data/examples/declaration/type/promotion-1.hs
@@ -1,16 +1,9 @@
-type Foo = Cluster '[ 'NodeCore, 'NodeRelay', 'NodeEdge ]
-
-type Query = Query '[] '[] DB '[ 'NotNull 'PGint4] (RowPG RawElementData)
-
-data T = T' | T'T
-
-type S0 = ' T'
-
-type S1 = ' T'T
-
 type S2 = Proxy ( '[ '[], '[] ])
 type S4 = Proxy ( '( 'Just, ' T'T))
 type S5 = Proxy ( '[ 'Just, ' TT'T])
 type S6 = Proxy ( '( '(), '() ))
 type S7 = Proxy ( '( 'a, 'b ))
 type S8 = Proxy ( '[ Int, Bool ])
+
+type E = TypeError ('Text "Some text")
+type G = '[ '( 'Just, 'Bool) ]

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -52,7 +52,6 @@ p_hsType' multilineArgs docStyle = \case
   HsTyVar NoExtField p n -> do
     case p of
       IsPromoted -> do
-        space
         txt "'"
         case showOutputable (unLoc n) of
           _ : '\'' : _ -> space
@@ -170,6 +169,7 @@ p_hsType' multilineArgs docStyle = \case
   XHsType (NHsCoreTy t) -> atom t
   where
     isPromoted = \case
+      HsAppTy _ (L _ f) _ -> isPromoted f
       HsTyVar _ IsPromoted _ -> True
       HsExplicitTupleTy {} -> True
       HsExplicitListTy {} -> True


### PR DESCRIPTION
Close #668.

In certain cases spaces in this position are unnecessary. Here we try to
make the algorithm smarter so that it doesn't always insert spaces.