### PR TITLE
update CI for release binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         if: runner.os != 'Linux'
         with:
-          ghc-version: '8.10.1'
+          ghc-version: '8.10.2'
           cabal-version: '3.2'
       - name: Build Linux binary
         if: runner.os == 'Linux'
         run: |
           docker run \
             -v $(pwd):/mnt -w /mnt \
-            utdemir/ghc-musl:v14-ghc8101 \
+            utdemir/ghc-musl:v16-ghc8102 \
             bash .github/workflows/build.sh
       - name: Build ${{ runner.os }} binary
         if: runner.os != 'Linux'


### PR DESCRIPTION
[`actions/setup-haskell`](https://github.com/actions/setup-haskell) is deprecated, but [`haskell/actions/setup`](https://github.com/haskell/actions/tree/main/setup) is a drop-in replacement.

Also, updating to 8.10.2.

See [here](https://github.com/amesgen/ormolu/actions/runs/418860529) for a run in my fork.