### PR TITLE
Normalize multi-line Haddock comments to use multi-line comment syntax

### DIFF
--- a/data/examples/module-header/leading-empty-line-out.hs
+++ b/data/examples/module-header/leading-empty-line-out.hs
@@ -1,11 +1,12 @@
--- |
--- Module      :  Text.Megaparsec
--- Copyright   :  © 2015–2019 Megaparsec contributors
---                © 2007 Paolo Martini
---                © 1999–2001 Daan Leijen
--- License     :  FreeBSD
---
--- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
--- Stability   :  experimental
--- Portability :  portable
+{- |
+Module      :  Text.Megaparsec
+Copyright   :  © 2015–2019 Megaparsec contributors
+               © 2007 Paolo Martini
+               © 1999–2001 Daan Leijen
+License     :  FreeBSD
+
+Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+Stability   :  experimental
+Portability :  portable
+-}
 module Main where

--- a/data/examples/module-header/named-section-out.hs
+++ b/data/examples/module-header/named-section-out.hs
@@ -9,5 +9,4 @@ module Magic
 where
 
 -- $explanation
---
 -- Here it goes.

--- a/data/examples/other/comment-style-transform-out.hs
+++ b/data/examples/other/comment-style-transform-out.hs
@@ -1,17 +1,18 @@
--- |
--- Module:      Data.Aeson.TH
--- Copyright:   (c) 2011-2016 Bryan O'Sullivan
---              (c) 2011 MailRank, Inc.
--- License:     BSD3
--- Stability:   experimental
--- Portability: portable
+{- |
+Module:      Data.Aeson.TH
+Copyright:   (c) 2011-2016 Bryan O'Sullivan
+             (c) 2011 MailRank, Inc.
+License:     BSD3
+Stability:   experimental
+Portability: portable
+-}
 module Main where
 
--- |
---
--- Here is a snippet:
---
--- @
--- x = y + 2
--- @
+{- |
+Here is a snippet:
+
+@
+x = y + 2
+@
+-}
 x = y + 2

--- a/data/examples/other/haddock-sections-out.hs
+++ b/data/examples/other/haddock-sections-out.hs
@@ -1,7 +1,7 @@
--- $weird #anchor#
+-- $weird
+-- #anchor#
 --
 -- Section 1
 
 -- $normal
---
 -- Section 2

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -32,16 +32,18 @@ import Ormolu.Printer
 import Ormolu.Utils (showOutputable)
 import qualified SrcLoc as GHC
 
--- | Format a 'String', return formatted version as 'Text'.
---
--- The function
---
---     * Takes 'String' because that's what GHC parser accepts.
---     * Needs 'IO' because some functions from GHC that are necessary to
---       setup parsing context require 'IO'. There should be no visible
---       side-effects though.
---     * Takes file name just to use it in parse error messages.
---     * Throws 'OrmoluException'.
+{- |
+Format a 'String', return formatted version as 'Text'.
+
+The function
+
+    * Takes 'String' because that's what GHC parser accepts.
+    * Needs 'IO' because some functions from GHC that are necessary to
+      setup parsing context require 'IO'. There should be no visible
+      side-effects though.
+    * Takes file name just to use it in parse error messages.
+    * Throws 'OrmoluException'.
+-}
 ormolu ::
   MonadIO m =>
   -- | Ormolu configuration
@@ -89,11 +91,13 @@ ormolu cfgWithIndices path str = do
                 throwIO (OrmoluNonIdempotentOutput diff)
   return txt
 
--- | Load a file and format it. The file stays intact and the rendered
--- version is returned as 'Text'.
---
--- > ormoluFile cfg path =
--- >   liftIO (readFile path) >>= ormolu cfg path
+{- |
+Load a file and format it. The file stays intact and the rendered
+version is returned as 'Text'.
+
+> ormoluFile cfg path =
+>   liftIO (readFile path) >>= ormolu cfg path
+-}
 ormoluFile ::
   MonadIO m =>
   -- | Ormolu configuration
@@ -105,10 +109,12 @@ ormoluFile ::
 ormoluFile cfg path =
   liftIO (readFile path) >>= ormolu cfg path
 
--- | Read input from stdin and format it.
---
--- > ormoluStdin cfg =
--- >   liftIO (hGetContents stdin) >>= ormolu cfg "<stdin>"
+{- |
+Read input from stdin and format it.
+
+> ormoluStdin cfg =
+>   liftIO (hGetContents stdin) >>= ormolu cfg "<stdin>"
+-}
 ormoluStdin ::
   MonadIO m =>
   -- | Ormolu configuration

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -43,8 +43,10 @@ data RegionIndices = RegionIndices
   }
   deriving (Eq, Show)
 
--- | Region selection as the length of the literal prefix and the literal
--- suffix.
+{- |
+Region selection as the length of the literal prefix and the literal
+suffix.
+-}
 data RegionDeltas = RegionDeltas
   { -- | Prefix length in number of lines
     regionPrefixLength :: !Int,

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -52,8 +52,10 @@ diffParseResult
         hs0 {hsmodImports = normalizeImports (hsmodImports hs0)}
         hs1 {hsmodImports = normalizeImports (hsmodImports hs1)}
 
--- | Compare two values for equality disregarding differences in 'SrcSpan's
--- and the ordering of import lists.
+{- |
+Compare two values for equality disregarding differences in 'SrcSpan's
+and the ordering of import lists.
+-}
 matchIgnoringSrcSpans :: Data a => a -> a -> ParseResultDiff
 matchIgnoringSrcSpans = genericQuery
   where

--- a/src/Ormolu/Diff/Text.hs
+++ b/src/Ormolu/Diff/Text.hs
@@ -68,8 +68,10 @@ diffText a b path =
       D.First _ -> False
       D.Second _ -> False
 
--- | Print the given 'TextDiff' as a 'Term' action. This function tries to
--- mimic the style of @git diff@.
+{- |
+Print the given 'TextDiff' as a 'Term' action. This function tries to
+mimic the style of @git diff@.
+-}
 printTextDiff :: TextDiff -> Term ()
 printTextDiff (TextDiff path xs) = do
   (bold . putS) path

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -81,8 +81,10 @@ printOrmoluException = \case
     (putS . unwords . NE.toList) opts
     newline
 
--- | Inside this wrapper 'OrmoluException' will be caught and displayed
--- nicely.
+{- |
+Inside this wrapper 'OrmoluException' will be caught and displayed
+nicely.
+-}
 withPrettyOrmoluExceptions ::
   -- | Color mode
   ColorMode ->

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -37,8 +37,10 @@ normalizeImports =
           }
     g _ = notImplemented "XImportDecl"
 
--- | Combine two import declarations. It should be assumed that 'ImportId's
--- are equal.
+{- |
+Combine two import declarations. It should be assumed that 'ImportId's
+are equal.
+-}
 combineImports ::
   LImportDecl GhcPs ->
   LImportDecl GhcPs ->
@@ -55,9 +57,11 @@ combineImports (L lx ImportDecl {..}) (L _ y) =
       }
 combineImports _ _ = notImplemented "XImportDecl"
 
--- | Import id, a collection of all things that justify having a separate
--- import entry. This is used for merging of imports. If two imports have
--- the same 'ImportId' they can be merged.
+{- |
+Import id, a collection of all things that justify having a separate
+import entry. This is used for merging of imports. If two imports have
+the same 'ImportId' they can be merged.
+-}
 data ImportId = ImportId
   { importIsPrelude :: Bool,
     importIdName :: ModuleName,
@@ -149,8 +153,10 @@ normalizeLies = sortOn (getIewn . unLoc) . M.elems . foldl' combine M.empty
                in Just (f <$> old)
        in M.alter alter wname m
 
--- | A wrapper for @'IEWrappedName' 'RdrName'@ that allows us to define an
--- 'Ord' instance for it.
+{- |
+A wrapper for @'IEWrappedName' 'RdrName'@ that allows us to define an
+'Ord' instance for it.
+-}
 newtype IEWrappedNameOrd = IEWrappedNameOrd (IEWrappedName RdrName)
   deriving (Eq)
 

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -116,16 +116,20 @@ parseModule Config {..} path rawInput = liftIO $ do
                       }
   return (warnings, r)
 
--- | Enable all language extensions that we think should be enabled by
--- default for ease of use.
+{- |
+Enable all language extensions that we think should be enabled by
+default for ease of use.
+-}
 setDefaultExts :: DynFlags -> DynFlags
 setDefaultExts flags = L.foldl' xopt_set flags autoExts
   where
     autoExts = allExts L.\\ manualExts
     allExts = [minBound .. maxBound]
 
--- | Extensions that are not enabled automatically and should be activated
--- by user.
+{- |
+Extensions that are not enabled automatically and should be activated
+by user.
+-}
 manualExts :: [Extension]
 manualExts =
   [ Arrows, -- steals proc

--- a/src/Ormolu/Parser/CommentStream.hs
+++ b/src/Ormolu/Parser/CommentStream.hs
@@ -34,14 +34,18 @@ import SrcLoc
 ----------------------------------------------------------------------------
 -- Comment stream
 
--- | A stream of 'RealLocated' 'Comment's in ascending order with respect to
--- beginning of corresponding spans.
+{- |
+A stream of 'RealLocated' 'Comment's in ascending order with respect to
+beginning of corresponding spans.
+-}
 newtype CommentStream = CommentStream [RealLocated Comment]
   deriving (Eq, Data, Semigroup, Monoid)
 
--- | Create 'CommentStream' from 'GHC.PState'. The pragmas and shebangs are
--- removed from the 'CommentStream'. Shebangs are only extracted from the
--- comments that come from the first argument.
+{- |
+Create 'CommentStream' from 'GHC.PState'. The pragmas and shebangs are
+removed from the 'CommentStream'. Shebangs are only extracted from the
+comments that come from the first argument.
+-}
 mkCommentStream ::
   -- | Original input
   String ->
@@ -84,16 +88,20 @@ showCommentStream (CommentStream xs) =
 ----------------------------------------------------------------------------
 -- Comment
 
--- | A wrapper for a single comment. The 'Bool' indicates whether there were
--- atoms before beginning of the comment in the original input. The
--- 'NonEmpty' list inside contains lines of multiline comment @{- … -}@ or
--- just single item\/line otherwise.
+{- |
+A wrapper for a single comment. The 'Bool' indicates whether there were
+atoms before beginning of the comment in the original input. The
+'NonEmpty' list inside contains lines of multiline comment or
+just single item\/line otherwise.
+-}
 data Comment = Comment Bool (NonEmpty String)
   deriving (Eq, Show, Data)
 
--- | Normalize comment string. Sometimes one multi-line comment is turned
--- into several lines for subsequent outputting with correct indentation for
--- each line.
+{- |
+Normalize comment string. Sometimes one multi-line comment is turned
+into several lines for subsequent outputting with correct indentation for
+each line.
+-}
 mkComment ::
   -- | Lines of original input with their indices
   [(Int, String)] ->
@@ -136,8 +144,10 @@ mkComment ls (L l s) = (ls', comment)
 unComment :: Comment -> NonEmpty String
 unComment (Comment _ xs) = xs
 
--- | Check whether the 'Comment' had some non-whitespace atoms in front of
--- it in the original input.
+{- |
+Check whether the 'Comment' had some non-whitespace atoms in front of
+it in the original input.
+-}
 hasAtomsBefore :: Comment -> Bool
 hasAtomsBefore (Comment atomsBefore _) = atomsBefore
 

--- a/src/Ormolu/Parser/Pragma.hs
+++ b/src/Ormolu/Parser/Pragma.hs
@@ -28,8 +28,10 @@ data Pragma
     PragmaOptionsHaddock String
   deriving (Show, Eq)
 
--- | Extract a pragma from a comment if possible, or return 'Nothing'
--- otherwise.
+{- |
+Extract a pragma from a comment if possible, or return 'Nothing'
+otherwise.
+-}
 parsePragma ::
   -- | Comment to try to parse
   String ->
@@ -48,8 +50,10 @@ parsePragma input = do
     trimSpaces :: String -> String
     trimSpaces = L.dropWhileEnd isSpace . dropWhile isSpace
 
--- | Assuming the input consists of a series of tokens from a language
--- pragma, return the set of enabled extensions.
+{- |
+Assuming the input consists of a series of tokens from a language
+pragma, return the set of enabled extensions.
+-}
 parseExtensions :: String -> Maybe [String]
 parseExtensions str = tokenize str >>= go
   where

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Printing combinators. The definitions here are presented in such an
--- order so you can just go through the Haddocks and by the end of the file
--- you should have a pretty good idea how to program rendering logic.
+{- |
+Printing combinators. The definitions here are presented in such an
+order so you can just go through the Haddocks and by the end of the file
+you should have a pretty good idea how to program rendering logic.
+-}
 module Ormolu.Printer.Combinators
   ( -- * The 'R' monad
     R,
@@ -84,11 +86,13 @@ inciIf ::
   R ()
 inciIf b m = if b then inci m else m
 
--- | Enter a 'Located' entity. This combinator handles outputting comments
--- and sets layout (single-line vs multi-line) for the inner computation.
--- Roughly, the rule for using 'located' is that every time there is a
--- 'Located' wrapper, it should be “discharged” with a corresponding
--- 'located' invocation.
+{- |
+Enter a 'Located' entity. This combinator handles outputting comments
+and sets layout (single-line vs multi-line) for the inner computation.
+Roughly, the rule for using 'located' is that every time there is a
+'Located' wrapper, it should be “discharged” with a corresponding
+'located' invocation.
+-}
 located ::
   -- | Thing to enter
   Located a ->
@@ -111,12 +115,14 @@ located' ::
   R ()
 located' = flip located
 
--- | Set layout according to combination of given 'SrcSpan's for a given.
--- Use this only when you need to set layout based on e.g. combined span of
--- several elements when there is no corresponding 'Located' wrapper
--- provided by GHC AST. It is relatively rare that this one is needed.
---
--- Given empty list this function will set layout to single line.
+{- |
+Set layout according to combination of given 'SrcSpan's for a given.
+Use this only when you need to set layout based on e.g. combined span of
+several elements when there is no corresponding 'Located' wrapper
+provided by GHC AST. It is relatively rare that this one is needed.
+
+Given empty list this function will set layout to single line.
+-}
 switchLayout ::
   -- | Span that controls layout
   [SrcSpan] ->
@@ -134,17 +140,21 @@ spansLayout = \case
       then SingleLine
       else MultiLine
 
--- | Insert a space if enclosing layout is single-line, or newline if it's
--- multiline.
---
--- > breakpoint = vlayout space newline
+{- |
+Insert a space if enclosing layout is single-line, or newline if it's
+multiline.
+
+> breakpoint = vlayout space newline
+-}
 breakpoint :: R ()
 breakpoint = vlayout space newline
 
--- | Similar to 'breakpoint' but outputs nothing in case of single-line
--- layout.
---
--- > breakpoint' = vlayout (return ()) newline
+{- |
+Similar to 'breakpoint' but outputs nothing in case of single-line
+layout.
+
+> breakpoint' = vlayout (return ()) newline
+-}
 breakpoint' :: R ()
 breakpoint' = vlayout (return ()) newline
 
@@ -162,15 +172,17 @@ sep ::
   R ()
 sep s f xs = sequence_ (intersperse s (f <$> xs))
 
--- | Render a collection of elements layout-sensitively using given printer,
--- inserting semicolons if necessary and respecting 'useBraces' and
--- 'dontUseBraces' combinators.
---
--- > useBraces $ sepSemi txt ["foo", "bar"]
--- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
---
--- > dontUseBraces $ sepSemi txt ["foo", "bar"]
--- >   == vlayout (txt "foo; bar") (txt "foo\nbar")
+{- |
+Render a collection of elements layout-sensitively using given printer,
+inserting semicolons if necessary and respecting 'useBraces' and
+'dontUseBraces' combinators.
+
+> useBraces $ sepSemi txt ["foo", "bar"]
+>   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
+
+> dontUseBraces $ sepSemi txt ["foo", "bar"]
+>   == vlayout (txt "foo; bar") (txt "foo\nbar")
+-}
 sepSemi ::
   -- | How to render an element
   (a -> R ()) ->
@@ -221,10 +233,12 @@ banana = brackets_ True "(|" "|)" N
 braces :: BracketStyle -> R () -> R ()
 braces = brackets_ False "{" "}"
 
--- | Surround record update fields which use RecordDot plugin entity by
--- curly braces @{@ and @}@.
---
--- @since 0.1.3.1
+{- |
+Surround record update fields which use RecordDot plugin entity by
+curly braces @{@ and @}@.
+
+@since 0.1.3.1
+-}
 recordDotBraces :: R () -> R ()
 recordDotBraces m = sitcc (vlayout singleLine multiLine)
   where

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Helpers for formatting of comments. This is low-level code, use
--- "Ormolu.Printer.Combinators" unless you know what you are doing.
+{- |
+Helpers for formatting of comments. This is low-level code, use
+"Ormolu.Printer.Combinators" unless you know what you are doing.
+-}
 module Ormolu.Printer.Comments
   ( spitPrecedingComments,
     spitFollowingComments,
@@ -78,8 +80,10 @@ spitPrecedingComment ref = do
       then space
       else newline
 
--- | Output a comment that follows element at given location immediately on
--- the same line, if there is any.
+{- |
+Output a comment that follows element at given location immediately on
+the same line, if there is any.
+-}
 spitFollowingComment ::
   -- | AST element to attach comments to
   RealSrcSpan ->
@@ -131,8 +135,10 @@ handleCommentSeries f = go False
         then return gotSome
         else go True
 
--- | Try to pop a comment using given predicate and if there is a comment
--- matching the predicate, print it out.
+{- |
+Try to pop a comment using given predicate and if there is a comment
+matching the predicate, print it out.
+-}
 withPoppedComment ::
   -- | Comment predicate
   (RealLocated Comment -> Bool) ->
@@ -146,8 +152,10 @@ withPoppedComment p f = do
     Nothing -> return True
     Just (L l comment) -> False <$ f l comment
 
--- | Determine if we need to insert a newline between current comment and
--- last printed comment.
+{- |
+Determine if we need to insert a newline between current comment and
+last printed comment.
+-}
 needsNewlineBefore ::
   -- | Current comment span
   RealSrcSpan ->
@@ -269,9 +277,11 @@ spitCommentNow spn comment = do
     $ comment
   setSpanMark (CommentSpan spn)
 
--- | Output a 'Comment' at the end of correct line or after it depending on
--- 'CommentPosition'. Used for comments that may potentially follow on the
--- same line as something we just rendered, but not immediately after it.
+{- |
+Output a 'Comment' at the end of correct line or after it depending on
+'CommentPosition'. Used for comments that may potentially follow on the
+same line as something we just rendered, but not immediately after it.
+-}
 spitCommentPending :: CommentPosition -> RealSrcSpan -> Comment -> R ()
 spitCommentPending position spn comment = do
   let wrapper = case position of

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -524,12 +524,15 @@ spanMarkSpan = \case
 data HaddockStyle
   = -- | @-- |@
     Pipe
+  | -- | @{- |@
+    Multiline
   | -- | @-- ^@
     Caret
   | -- | @-- *@
     Asterisk Int
   | -- | @-- $@
     Named String
+  deriving Eq
 
 -- | Set span of last output comment.
 setSpanMark ::

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -89,10 +89,12 @@ p_rdrName l@(L spn _) = located l $ \x -> do
     then m'
     else parensWrapper m'
 
--- | Whether given name should not have parentheses around it. This is used
--- to detect e.g. tuples for which annotations will indicate parentheses,
--- but the parentheses are already part of the symbol, so no extra layer of
--- parentheses should be added. It also detects the [] literal.
+{- |
+Whether given name should not have parentheses around it. This is used
+to detect e.g. tuples for which annotations will indicate parentheses,
+but the parentheses are already part of the symbol, so no extra layer of
+parentheses should be added. It also detects the [] literal.
+-}
 doesNotNeedExtraParens :: RdrName -> Bool
 doesNotNeedExtraParens = \case
   Exact name ->
@@ -180,8 +182,8 @@ p_hsDocString hstyle needsNewline canBeMultiLine (L l str) = do
   forM_ (zip docLines (True : repeat False)) $ \(x, isFirst) -> do
     -- Per-line leading comment characters
     if isFirst
-      -- Special characters for the first line, which typically includes the comment start marker.
-      then case hstyleNorm of
+      then -- Special characters for the first line, which typically includes the comment start marker.
+      case hstyleNorm of
         Pipe -> txt "-- |" >> space
         -- Print the multline comment start marker on its own line. No need to have a prefix for the upcoming
         -- doc line.

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -45,11 +45,13 @@ data UserGrouping
 p_hsDecls :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
 p_hsDecls = p_hsDecls' Disregard
 
--- | Like 'p_hsDecls' but respects user choices regarding grouping. If the
--- user omits newlines between declarations, we also omit them in most
--- cases, except when said declarations have associated Haddocks.
---
--- Does some normalization (compress subsequent newlines into a single one)
+{- |
+Like 'p_hsDecls' but respects user choices regarding grouping. If the
+user omits newlines between declarations, we also omit them in most
+cases, except when said declarations have associated Haddocks.
+
+Does some normalization (compress subsequent newlines into a single one)
+-}
 p_hsDeclsRespectGrouping :: FamilyStyle -> [LHsDecl GhcPs] -> R ()
 p_hsDeclsRespectGrouping = p_hsDecls' Respect
 

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -116,10 +116,10 @@ p_hsDecl style = \case
   SpliceD NoExtField x -> p_spliceDecl x
   DocD NoExtField docDecl ->
     case docDecl of
-      DocCommentNext str -> p_hsDocString Pipe False (noLoc str)
-      DocCommentPrev str -> p_hsDocString Caret False (noLoc str)
-      DocCommentNamed name str -> p_hsDocString (Named name) False (noLoc str)
-      DocGroup n str -> p_hsDocString (Asterisk n) False (noLoc str)
+      DocCommentNext str -> p_hsDocString Pipe False True (noLoc str)
+      DocCommentPrev str -> p_hsDocString Caret False False (noLoc str)
+      DocCommentNamed name str -> p_hsDocString (Named name) False False (noLoc str)
+      DocGroup n str -> p_hsDocString (Asterisk n) False False (noLoc str)
   RoleAnnotD NoExtField x -> p_roleAnnot x
   KindSigD NoExtField s -> p_standaloneKindSig s
   XHsDecl x -> noExtCon x

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -91,7 +91,7 @@ p_conDecl ::
   R ()
 p_conDecl singleConstRec = \case
   ConDeclGADT {..} -> do
-    mapM_ (p_hsDocString Pipe True) con_doc
+    mapM_ (p_hsDocString Pipe True False) con_doc
     let conDeclSpn =
           fmap getLoc con_names
             <> [getLoc con_forall]
@@ -134,7 +134,7 @@ p_conDecl singleConstRec = \case
           InfixCon _ _ -> notImplemented "InfixCon"
         p_hsType (unLoc con_res_ty)
   ConDeclH98 {..} -> do
-    mapM_ (p_hsDocString Pipe True) con_doc
+    mapM_ (p_hsDocString Pipe True False) con_doc
     let conDeclWithContextSpn =
           [getLoc con_forall]
             <> fmap getLoc con_ex_tvs

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -26,8 +26,10 @@ p_foreignDecl = \case
     p_foreignTypeSig fd
   XForeignDecl x -> noExtCon x
 
--- | Printer for the last part of an import\/export, which is function name
--- and type signature.
+{- |
+Printer for the last part of an import\/export, which is function name
+and type signature.
+-}
 p_foreignTypeSig :: ForeignDecl GhcPs -> R ()
 p_foreignTypeSig fd = do
   breakpoint
@@ -40,18 +42,20 @@ p_foreignTypeSig fd = do
       p_rdrName (fd_name fd)
       p_typeAscription (HsWC NoExtField (fd_sig_ty fd))
 
--- | Printer for 'ForeignImport'.
---
--- These have the form:
---
--- > foreign import callingConvention [safety] [identifier]
---
--- We need to check whether the safety has a good source, span, as it
--- defaults to 'PlaySafe' if you don't have anything in the source.
---
--- We also layout the identifier using the 'SourceText', because printing
--- with the other two fields of 'CImport' is very complicated. See the
--- 'Outputable' instance of 'ForeignImport' for details.
+{- |
+Printer for 'ForeignImport'.
+
+These have the form:
+
+> foreign import callingConvention [safety] [identifier]
+
+We need to check whether the safety has a good source, span, as it
+defaults to 'PlaySafe' if you don't have anything in the source.
+
+We also layout the identifier using the 'SourceText', because printing
+with the other two fields of 'CImport' is very complicated. See the
+'Outputable' instance of 'ForeignImport' for details.
+-}
 p_foreignImport :: ForeignImport -> R ()
 p_foreignImport (CImport cCallConv safety _ _ sourceText) = do
   txt "foreign import"

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -50,8 +50,10 @@ data GroupStyle
   = EqualSign
   | RightArrow
 
--- | Expression placement. This marks the places where expressions that
--- implement handing forms may use them.
+{- |
+Expression placement. This marks the places where expressions that
+implement handing forms may use them.
+-}
 data Placement
   = -- | Multi-line layout should cause
     -- insertion of a newline and indentation
@@ -117,12 +119,14 @@ p_matchGroup' placer render style MG {..} = do
     p_Match (XMatch x) = noExtCon x
 p_matchGroup' _ _ _ (XMatchGroup x) = noExtCon x
 
--- | Function id obtained through pattern matching on 'FunBind' should not
--- be used to print the actual equations because the different ‘RdrNames’
--- used in the equations may have different “decorations” (such as backticks
--- and paretheses) associated with them. It is necessary to use per-equation
--- names obtained from 'm_ctxt' of 'Match'. This function replaces function
--- name inside of 'Function' accordingly.
+{- |
+Function id obtained through pattern matching on 'FunBind' should not
+be used to print the actual equations because the different ‘RdrNames’
+used in the equations may have different “decorations” (such as backticks
+and paretheses) associated with them. It is necessary to use per-equation
+names obtained from 'm_ctxt' of 'Match'. This function replaces function
+name inside of 'Function' accordingly.
+-}
 adjustMatchGroupStyle ::
   Match GhcPs body ->
   MatchGroupStyle ->
@@ -353,8 +357,10 @@ p_hsCmdTop = \case
   HsCmdTop NoExtField cmd -> located cmd p_hsCmd
   XCmdTop x -> noExtCon x
 
--- | Render an expression preserving blank lines between such consecutive
--- expressions found in the original source code.
+{- |
+Render an expression preserving blank lines between such consecutive
+expressions found in the original source code.
+-}
 withSpacing ::
   -- | Rendering function
   (a -> R ()) ->
@@ -1167,15 +1173,19 @@ p_stringLit src =
 ----------------------------------------------------------------------------
 -- Helpers
 
--- | Return the wrapping function controlling the use of braces according to
--- the current layout.
+{- |
+Return the wrapping function controlling the use of braces according to
+the current layout.
+-}
 layoutToBraces :: Layout -> R () -> R ()
 layoutToBraces = \case
   SingleLine -> useBraces
   MultiLine -> id
 
--- | Append each element in both lists with semigroups. If one list is shorter
--- than the other, return the rest of the longer list unchanged.
+{- |
+Append each element in both lists with semigroups. If one list is shorter
+than the other, return the rest of the longer list unchanged.
+-}
 liftAppend :: Semigroup a => [a] -> [a] -> [a]
 liftAppend [] [] = []
 liftAppend [] (y : ys) = y : ys
@@ -1187,9 +1197,11 @@ getGRHSSpan (GRHS NoExtField guards body) =
   combineSrcSpans' $ getLoc body :| map getLoc guards
 getGRHSSpan (XGRHS x) = noExtCon x
 
--- | Place a thing that may have a hanging form. This function handles how
--- to separate it from preceding expressions and whether to bump indentation
--- depending on what sort of expression we have.
+{- |
+Place a thing that may have a hanging form. This function handles how
+to separate it from preceding expressions and whether to bump indentation
+depending on what sort of expression we have.
+-}
 placeHanging :: Placement -> R () -> R ()
 placeHanging placement m =
   case placement of
@@ -1200,8 +1212,10 @@ placeHanging placement m =
       breakpoint
       inci m
 
--- | Check if given block contains single expression which has a hanging
--- form.
+{- |
+Check if given block contains single expression which has a hanging
+form.
+-}
 blockPlacement ::
   (body -> Placement) ->
   [LGRHS GhcPs (Located body)] ->

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -109,9 +109,9 @@ p_lie encLayout relativePos = \case
       FirstPos -> return ()
       MiddlePos -> newline
       LastPos -> newline
-    p_hsDocString (Asterisk n) False (noLoc str)
+    p_hsDocString (Asterisk n) False False (noLoc str)
   IEDoc NoExtField str ->
-    p_hsDocString Pipe False (noLoc str)
+    p_hsDocString Pipe False False (noLoc str)
   IEDocNamed NoExtField str -> p_hsDocName str
   XIE x -> noExtCon x
   where

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -54,7 +54,7 @@ p_hsModule mstackHeader shebangs pragmas qualifiedPost HsModule {..} = do
       Nothing -> return ()
       Just hsmodName' -> do
         located hsmodName' $ \name -> do
-          forM_ hsmodHaddockModHeader (p_hsDocString Pipe True)
+          forM_ hsmodHaddockModHeader (p_hsDocString Pipe True True)
           p_hsmodName name
         breakpoint
         forM_ hsmodDeprecMessage $ \w -> do

--- a/src/Ormolu/Printer/Meat/Pragma.hs
+++ b/src/Ormolu/Printer/Meat/Pragma.hs
@@ -26,17 +26,19 @@ data PragmaTy
   | OptionsHaddock
   deriving (Eq, Ord)
 
--- | Language pragma classification.
---
--- The order in which language pragmas are put in the input sometimes
--- matters. This is because some language extensions can enable other
--- extensions, yet the extensions coming later in the list have the ability
--- to change it. So here we classify all extensions by assigning one of the
--- four groups to them. Then we only sort inside of the groups.
---
--- 'Ord' instance of this data type is what affects the sorting.
---
--- See also: <https://github.com/tweag/ormolu/issues/404>
+{- |
+Language pragma classification.
+
+The order in which language pragmas are put in the input sometimes
+matters. This is because some language extensions can enable other
+extensions, yet the extensions coming later in the list have the ability
+to change it. So here we classify all extensions by assigning one of the
+four groups to them. Then we only sort inside of the groups.
+
+'Ord' instance of this data type is what affects the sorting.
+
+See also: <https://github.com/tweag/ormolu/issues/404>
+-}
 data LanguagePragmaClass
   = -- | All other extensions
     Normal

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -125,12 +125,12 @@ p_hsType' multilineArgs docStyle = \case
   HsDocTy NoExtField t str ->
     case docStyle of
       PipeStyle -> do
-        p_hsDocString Pipe True str
+        p_hsDocString Pipe True False str
         located t p_hsType
       CaretStyle -> do
         located t p_hsType
         newline
-        p_hsDocString Caret False str
+        p_hsDocString Caret False False str
   HsBangTy NoExtField (HsSrcBang _ u s) t -> do
     case u of
       SrcUnpack -> txt "{-# UNPACK #-}" >> space
@@ -226,7 +226,7 @@ p_conDeclFields xs =
 
 p_conDeclField :: ConDeclField GhcPs -> R ()
 p_conDeclField ConDeclField {..} = do
-  mapM_ (p_hsDocString Pipe True) cd_fld_doc
+  mapM_ (p_hsDocString Pipe True False) cd_fld_doc
   sitcc $
     sep
       commaDel

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -180,8 +180,10 @@ p_hsType' multilineArgs docStyle = \case
         else breakpoint
     p_hsTypeR = p_hsType' multilineArgs docStyle
 
--- | Return 'True' if at least one argument in 'HsType' has a doc string
--- attached to it.
+{- |
+Return 'True' if at least one argument in 'HsType' has a doc string
+attached to it.
+-}
 hasDocStrings :: HsType GhcPs -> Bool
 hasDocStrings = \case
   HsDocTy {} -> True

--- a/src/Ormolu/Printer/Operators.hs
+++ b/src/Ormolu/Printer/Operators.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
--- | This module helps handle operator chains composed of different
--- operators that may have different precedence and fixities.
+{- |
+This module helps handle operator chains composed of different
+operators that may have different precedence and fixities.
+-}
 module Ormolu.Printer.Operators
   ( OpTree (..),
     opTreeLoc,
@@ -19,9 +21,11 @@ import GHC
 import OccName (occNameString)
 import Ormolu.Utils (unSrcSpan)
 
--- | Intermediate representation of operator trees. It has two type
--- parameters: @ty@ is the type of sub-expressions, while @op@ is the type
--- of operators.
+{- |
+Intermediate representation of operator trees. It has two type
+parameters: @ty@ is the type of sub-expressions, while @op@ is the type
+of operators.
+-}
 data OpTree ty op
   = OpNode ty
   | OpBranch
@@ -34,10 +38,12 @@ opTreeLoc :: OpTree (Located a) b -> SrcSpan
 opTreeLoc (OpNode (L l _)) = l
 opTreeLoc (OpBranch l _ r) = combineSrcSpans (opTreeLoc l) (opTreeLoc r)
 
--- | Re-associate an 'OpTree' taking into account automagically inferred
--- relative precedence of operators. Users are expected to first construct
--- an initial 'OpTree', then re-associate it using this function before
--- printing.
+{- |
+Re-associate an 'OpTree' taking into account automagically inferred
+relative precedence of operators. Users are expected to first construct
+an initial 'OpTree', then re-associate it using this function before
+printing.
+-}
 reassociateOpTree ::
   -- | How to get name of an operator
   (op -> Maybe RdrName) ->
@@ -166,8 +172,10 @@ buildFixityMap getOpName opTree =
 ----------------------------------------------------------------------------
 -- Helpers
 
--- | Convert an 'OpTree' to with all operators having the same fixity and
--- associativity (left infix).
+{- |
+Convert an 'OpTree' to with all operators having the same fixity and
+associativity (left infix).
+-}
 normalizeOpTree :: OpTree ty op -> OpTree ty op
 normalizeOpTree (OpNode n) =
   OpNode n

--- a/src/Ormolu/Printer/SpanStream.hs
+++ b/src/Ormolu/Printer/SpanStream.hs
@@ -16,14 +16,18 @@ import Data.List (sortOn)
 import Data.Typeable (cast)
 import SrcLoc
 
--- | A stream of 'RealSrcSpan's in ascending order. This allows us to tell
--- e.g. whether there is another \"located\" element of AST between current
--- element and comment we're considering for printing.
+{- |
+A stream of 'RealSrcSpan's in ascending order. This allows us to tell
+e.g. whether there is another \"located\" element of AST between current
+element and comment we're considering for printing.
+-}
 newtype SpanStream = SpanStream [RealSrcSpan]
   deriving (Eq, Show, Data, Semigroup, Monoid)
 
--- | Create 'SpanStream' from a data structure containing \"located\"
--- elements.
+{- |
+Create 'SpanStream' from a data structure containing \"located\"
+elements.
+-}
 mkSpanStream ::
   Data a =>
   -- | Data structure to inspect (AST)

--- a/src/Ormolu/Processing/Cpp.hs
+++ b/src/Ormolu/Processing/Cpp.hs
@@ -57,8 +57,10 @@ processLine line state
 maskLine :: String -> String
 maskLine x = maskPrefix ++ x
 
--- | If the given line is masked, unmask it. Otherwise return the line
--- unchanged.
+{- |
+If the given line is masked, unmask it. Otherwise return the line
+unchanged.
+-}
 unmaskLine :: Text -> Text
 unmaskLine x =
   case T.stripPrefix maskPrefix (T.stripStart x) of

--- a/src/Ormolu/Processing/Preprocess.hs
+++ b/src/Ormolu/Processing/Preprocess.hs
@@ -19,9 +19,11 @@ import Ormolu.Processing.Common
 import qualified Ormolu.Processing.Cpp as Cpp
 import SrcLoc
 
--- | Transform given input possibly returning comments extracted from it.
--- This handles LINE pragmas, CPP, shebangs, and the magic comments for
--- enabling\/disabling of Ormolu.
+{- |
+Transform given input possibly returning comments extracted from it.
+This handles LINE pragmas, CPP, shebangs, and the magic comments for
+enabling\/disabling of Ormolu.
+-}
 preprocess ::
   -- | File name, just to use in the spans
   FilePath ->
@@ -103,8 +105,10 @@ processLine _ _ ormoluState cppState line =
   let (line', cppState') = Cpp.processLine line cppState
    in (line', ormoluState, cppState', Nothing)
 
--- | Take a line pragma and output its replacement (where line pragma is
--- replaced with spaces) and the contents of the pragma itself.
+{- |
+Take a line pragma and output its replacement (where line pragma is
+replaced with spaces) and the contents of the pragma itself.
+-}
 getPragma ::
   -- | Pragma line to analyze
   String ->

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -62,8 +62,10 @@ notImplemented msg = error $ "not implemented yet: " ++ msg
 showOutputable :: GHC.Outputable o => o -> String
 showOutputable = GHC.showSDoc baseDynFlags . GHC.ppr
 
--- | Split and normalize a doc string. The result is a list of lines that
--- make up the comment.
+{- |
+Split and normalize a doc string. The result is a list of lines that
+make up the comment.
+-}
 splitDocString :: HsDocString -> [Text]
 splitDocString docStr =
   case r of
@@ -72,7 +74,9 @@ splitDocString docStr =
   where
     r =
       fmap escapeLeadingDollar
+        -- Drop the leading padding space, if there is one
         . dropPaddingSpace
+        -- Drop both leading and trailing blank lines
         . dropWhile T.null
         . dropWhileEnd T.null
         . fmap (T.stripEnd . T.pack)
@@ -90,15 +94,17 @@ splitDocString docStr =
     -- it out again. So we strip it here. We decide whether or not to try and do
     -- this based on whether the *first* line has a leading space.
     dropPaddingSpace [] = []
-    dropPaddingSpace ls@(x : _) | leadingSpace x = dropSpace <$> ls
-                                | otherwise = ls
-       where leadingSpace txt = case T.uncons txt of
-                Just (' ', _) -> True
-                _ -> False
-             dropSpace txt =
-               if leadingSpace txt
-                 then T.drop 1 txt
-                 else txt
+    dropPaddingSpace ls@(x : _)
+      | leadingSpace x = dropSpace <$> ls
+      | otherwise = ls
+      where
+        leadingSpace txt = case T.uncons txt of
+          Just (' ', _) -> True
+          _ -> False
+        dropSpace txt =
+          if leadingSpace txt
+            then T.drop 1 txt
+            else txt
 
 -- | Get 'LHsType' out of 'LHsTypeArg'.
 typeArgToType :: LHsTypeArg p -> LHsType p
@@ -144,8 +150,10 @@ onTheSameLine :: SrcSpan -> SrcSpan -> Bool
 onTheSameLine a b =
   isOneLineSpan (mkSrcSpan (srcSpanEnd a) (srcSpanStart b))
 
--- | Remove indentation from a given 'String'. Return the input with
--- indentation removed and the detected indentation level.
+{- |
+Remove indentation from a given 'String'. Return the input with
+indentation removed and the detected indentation level.
+-}
 removeIndentation :: String -> (String, Int)
 removeIndentation (lines -> xs) = (unlines (drop n <$> xs), n)
   where

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -45,8 +45,10 @@ locateExamples :: IO [Path Rel File]
 locateExamples =
   filter isInput . snd <$> listDirRecurRel examplesDir
 
--- | Does given path look like input path (as opposed to expected output
--- path)?
+{- |
+Does given path look like input path (as opposed to expected output
+path)?
+-}
 isInput :: Path Rel File -> Bool
 isInput path =
   let s = fromRelFile path
@@ -59,8 +61,10 @@ deriveOutput path =
   parseRelFile $
     F.addExtension (F.dropExtensions (fromRelFile path) ++ "-out") "hs"
 
--- | A version of 'shouldBe' that is specialized to comparing 'Text' values.
--- It also prints multi-line snippets in a more readable form.
+{- |
+A version of 'shouldBe' that is specialized to comparing 'Text' values.
+It also prints multi-line snippets in a more readable form.
+-}
 shouldMatch :: Bool -> Text -> Text -> Expectation
 shouldMatch idempotenceTest actual expected =
   when (actual /= expected) . expectationFailure $
@@ -79,8 +83,10 @@ shouldMatch idempotenceTest actual expected =
 examplesDir :: Path Rel Dir
 examplesDir = $(mkRelDir "data/examples")
 
--- | Inside this wrapper 'OrmoluException' will be caught and displayed
--- nicely using 'displayException'.
+{- |
+Inside this wrapper 'OrmoluException' will be caught and displayed
+nicely using 'displayException'.
+-}
 withNiceExceptions ::
   -- | Action that may throw the exception
   Expectation ->


### PR DESCRIPTION
I still care about https://github.com/tweag/ormolu/issues/641, and I thought it might be more likely to go somewhere with a patch.

The first commit has the meat, the second reformats ormolu with the new ormolu.

--------------

This prints pipe-style, multi-line Haddock comments using multi-line
comment syntax where that is accepted.

Note that it is not accepted everywhere. For example, you cannot use it on
constructor definitions, so e.g. `operators.hs` remains unchanged.

The decision about whether to break after a comment and what styles are
acceptable is a bit obscure. I think an datatype enumerating all the
places a Haddock coment can occur would be helpful, but I didn't want to
bloat this PR too much, so I just added another boolean argument for
now.

Along the way, I tweaked the handling of doc comment content to always
strip leading blank lines (it already always stripped trailing blank
lines, and sometimes stripped leading ones). This makes it simpler
to ensure idempotence.

Fixes #641.