### PR TITLE
Recursively format directory

### DIFF
--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -151,6 +151,7 @@ executable ormolu
     default-language: Haskell2010
     build-depends:
         base >=4.12 && <5.0,
+        directory >=1.3.0 && <1.4,
         filepath >=1.2 && <1.5,
         ghc-lib-parser >=8.10 && <8.11,
         gitrev >=1.3 && <1.4,


### PR DESCRIPTION
related to https://github.com/tweag/ormolu/issues/691

if the `FilePath` passed to `formatOne` is a file, format it like normal. 
if the `FilePath` passed to `formatOne` is a directory, walk that directory for Haskell source files, calling `formatOne` on each file.

not yet implemented: excluding directories. 
the first argument of `walkDir` allows you to exclude directories from being walked, but I'm not sure what the best way to do that is.
for instance, a user might want to exclude files/dirs in their gitignore or exclude directories via a glob