### PR TITLE
Fix rendering of regular record updates with RDP enabled

### DIFF
--- a/data/examples/declaration/value/function/record/dot-multiline-out.hs
+++ b/data/examples/declaration/value/function/record/dot-multiline-out.hs
@@ -8,3 +8,8 @@ fooplus'''' f n =
   f{foo = n,
     bar = n
    }
+
+fooplus''''' f n =
+  f
+    { foo = n
+    }

--- a/data/examples/declaration/value/function/record/dot-multiline.hs
+++ b/data/examples/declaration/value/function/record/dot-multiline.hs
@@ -5,3 +5,6 @@ bar' = (Foo 1){bar = 2
 fooplus'''' f n = f{foo = n,
                     bar = n
                    }
+
+fooplus''''' f n = f
+                   { foo = n }

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -737,6 +737,7 @@ p_hsExpr' s = \case
     let isPluginForm =
           ((1 +) . srcSpanEndCol <$> mrs rupd_expr)
             == (srcSpanStartCol <$> mrs (head rupd_flds))
+            && onTheSameLine (getLoc rupd_expr) (getLoc $ head rupd_flds)
     unless (useRecordDot' && isPluginForm) breakpoint
     let updName f =
           (f :: HsRecUpdField GhcPs)


### PR DESCRIPTION
Closes #701.

This pull request solves the "second half" of the idempotency bug presented in #701, but there is a another bug (the "first half") for which I do not see an obvious solution. Since the other bug is not directly related to this, I've opened a separate Issue where I explain the problem in detail, see #705.

When Ormolu checks if a record update conforms to the RDP syntax (no space **before** the opening brace), it compares the column numbers of the relevant source spans but not the line numbers. This is why a regular record update of the form
```hs
{-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}

def 
  { g = 1 
  }
``` 
where the start / end columns of the expression `def`  and the field `g` are aligned in a specific way, "tricks" Ormolu into thinking that this is an RDP record update, even when it is clearly not. The formatting result looks like this:
```hs
{-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}

def{g = 1
   }
```
For the same reason the second code snippet from #701 gets formatted the way it is. Fortunately, the problem is simply solved by checking if the relevant source spans are on the same line.