### PR TITLE
Simplify p_conDecl GADT rendering by using p_hsType

### DIFF
--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -186,6 +186,8 @@ hasDocStrings :: HsType GhcPs -> Bool
 hasDocStrings = \case
   HsDocTy {} -> True
   HsFunTy _ (L _ x) (L _ y) -> hasDocStrings x || hasDocStrings y
+  HsForAllTy _ _ _ (L _ x) -> hasDocStrings x
+  HsQualTy _ _ (L _ x) -> hasDocStrings x
   _ -> False
 
 p_hsContext :: HsContext GhcPs -> R ()


### PR DESCRIPTION
Before this there was some logic replicated in p_hsType, what this
change does is instead of printing directly it constructs the
appropriate type and spans to pass to p_hsType