### PR TITLE
WIP: Migrate to ghc-lib-parser-9.0.1

### DIFF
--- a/data/examples/declaration/value/function/pattern/as-pattern.hs
+++ b/data/examples/declaration/value/function/pattern/as-pattern.hs
@@ -1,3 +1,3 @@
 main = case [1] of
-  xs @ (x:_) -> print (x, xs)
+  xs@(x:_) -> print (x, xs)
   xs@[] -> print xs

--- a/data/examples/declaration/value/function/pragmas-out.hs
+++ b/data/examples/declaration/value/function/pragmas-out.hs
@@ -3,9 +3,3 @@ sccfoo = {-# SCC foo #-} 1
 sccbar =
   {-# SCC "barbaz" #-}
   "hello"
-
-corefoo = {-# CORE "foo" #-} 1
-
-corebar =
-  {-# CORE "bar baz" #-}
-  "hello"

--- a/data/examples/declaration/value/function/pragmas.hs
+++ b/data/examples/declaration/value/function/pragmas.hs
@@ -1,7 +1,3 @@
 sccfoo = {-# SCC foo#-}  1
 sccbar = {-# SCC "barbaz"#-}
   "hello"
-
-corefoo = {-# CORE "foo"#-}  1
-corebar = {-# CORE "bar baz"#-}
-  "hello"

--- a/data/examples/import/misc-out.hs
+++ b/data/examples/import/misc-out.hs
@@ -1,5 +1,5 @@
 import A hiding
   ( foobarbazqux,
   )
-import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 import GHC.Types.Name hiding ()
+import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)

--- a/data/examples/import/misc-out.hs
+++ b/data/examples/import/misc-out.hs
@@ -2,4 +2,4 @@ import A hiding
   ( foobarbazqux,
   )
 import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
-import Name hiding ()
+import GHC.Types.Name hiding ()

--- a/data/examples/import/misc.hs
+++ b/data/examples/import/misc.hs
@@ -8,6 +8,6 @@ import A hiding
   , foobarbazqux
   )
 
-import Name hiding ()
+import GHC.Types.Name hiding ()
 
 import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -127,7 +127,7 @@ library
         containers >=0.5 && <0.7,
         dlist >=0.8 && <2.0,
         exceptions >=0.6 && <0.11,
-        ghc-lib-parser >=8.10 && <8.11,
+        ghc-lib-parser==9.0.1.20210324,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
         text >=0.2 && <1.3
@@ -152,7 +152,7 @@ executable ormolu
     build-depends:
         base >=4.12 && <5.0,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=8.10 && <8.11,
+        ghc-lib-parser==9.0.1.20210324,
         gitrev >=1.3 && <1.4,
         optparse-applicative >=0.14 && <0.17,
         ormolu -any,

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -127,7 +127,7 @@ library
         containers >=0.5 && <0.7,
         dlist >=0.8 && <2.0,
         exceptions >=0.6 && <0.11,
-        ghc-lib-parser==9.0.1.20210324,
+        ghc-lib-parser >=9.0.1 && <9.1,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
         text >=0.2 && <1.3
@@ -152,7 +152,7 @@ executable ormolu
     build-depends:
         base >=4.12 && <5.0,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser==9.0.1.20210324,
+        ghc-lib-parser >=9.0.1 && <9.1,
         gitrev >=1.3 && <1.4,
         optparse-applicative >=0.14 && <0.17,
         ormolu -any,

--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -3,10 +3,10 @@ module GHC
   )
 where
 
-import ApiAnnotation as X
-import BasicTypes as X
+import GHC.Parser.Annotation as X
+import GHC.Types.Basic as X
 import GHC.Hs as X
 import GHC.Hs.Instances as X ()
-import Module as X
-import RdrName as X
-import SrcLoc as X
+import GHC.Unit.Module as X
+import GHC.Types.Name.Reader as X
+import GHC.Types.SrcLoc as X

--- a/src/GHC/DynFlags.hs
+++ b/src/GHC/DynFlags.hs
@@ -7,11 +7,11 @@ module GHC.DynFlags
   )
 where
 
-import Config
-import DynFlags
-import Fingerprint
+import GHC.Settings.Config
+import GHC.Driver.Session
+import GHC.Utils.Fingerprint
 import GHC.Platform
-import ToolSettings
+import GHC.Settings
 
 fakeSettings :: Settings
 fakeSettings =
@@ -30,7 +30,14 @@ fakeSettings =
                 { platformMini_arch = ArchUnknown,
                   platformMini_os = OSUnknown
                 },
-            platformUnregisterised = True
+            platformUnregisterised = True,
+            platformByteOrder = undefined,
+            platformHasGnuNonexecStack = undefined,
+            platformHasIdentDirective = undefined,
+            platformHasSubsectionsViaSymbols = undefined,
+            platformIsCrossCompiling = undefined,
+            platformLeadingUnderscore = undefined,
+            platformTablesNextToCode = undefined
           },
       sPlatformMisc = PlatformMisc {},
       sPlatformConstants =

--- a/src/GHC/DynFlags.hs
+++ b/src/GHC/DynFlags.hs
@@ -30,14 +30,15 @@ fakeSettings =
                 { platformMini_arch = ArchUnknown,
                   platformMini_os = OSUnknown
                 },
+            -- not really
             platformUnregisterised = True,
-            platformByteOrder = undefined,
-            platformHasGnuNonexecStack = undefined,
-            platformHasIdentDirective = undefined,
-            platformHasSubsectionsViaSymbols = undefined,
-            platformIsCrossCompiling = undefined,
-            platformLeadingUnderscore = undefined,
-            platformTablesNextToCode = undefined
+            platformByteOrder = LittleEndian,
+            platformHasGnuNonexecStack = True,
+            platformHasIdentDirective = False,
+            platformHasSubsectionsViaSymbols = False,
+            platformIsCrossCompiling = False,
+            platformLeadingUnderscore = False,
+            platformTablesNextToCode = False
           },
       sPlatformMisc = PlatformMisc {},
       sPlatformConstants =

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -15,7 +15,7 @@ module Ormolu
   )
 where
 
-import qualified CmdLineParser as GHC
+import qualified GHC.Driver.CmdLine as GHC
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO (..))
@@ -30,7 +30,7 @@ import Ormolu.Parser
 import Ormolu.Parser.Result
 import Ormolu.Printer
 import Ormolu.Utils (showOutputable)
-import qualified SrcLoc as GHC
+import qualified GHC.Types.SrcLoc as GHC
 
 -- | Format a 'String', return formatted version as 'Text'.
 --

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -15,7 +15,7 @@ module Ormolu.Config
 where
 
 import Ormolu.Terminal (ColorMode (..))
-import qualified SrcLoc as GHC
+import qualified GHC.Types.SrcLoc as GHC
 
 -- | Ormolu configuration.
 data Config region = Config

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 
 -- | This module allows us to diff two 'ParseResult's.
 module Ormolu.Diff.ParseResult
@@ -55,7 +56,7 @@ diffParseResult
 -- | Compare two values for equality disregarding differences in 'SrcSpan's
 -- and the ordering of import lists.
 matchIgnoringSrcSpans :: Data a => a -> a -> ParseResultDiff
-matchIgnoringSrcSpans = genericQuery
+matchIgnoringSrcSpans dt = genericQuery dt
   where
     genericQuery :: GenericQ (GenericQ ParseResultDiff)
     genericQuery x y

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -2,7 +2,12 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
+
+-- TODO(berberman): why we need quick look to typecheck this file?
+#if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 {-# LANGUAGE ImpredicativeTypes #-}
+#endif
 
 -- | This module allows us to diff two 'ParseResult's.
 module Ormolu.Diff.ParseResult

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -14,7 +14,7 @@ import Data.Function (on)
 import Data.List (foldl', nubBy, sortBy, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import FastString (FastString)
+import GHC.Data.FastString (FastString)
 import GHC hiding (GhcPs, IE)
 import GHC.Hs.Extension
 import GHC.Hs.ImpExp (IE (..))
@@ -62,7 +62,7 @@ data ImportId = ImportId
   { importIsPrelude :: Bool,
     importIdName :: ModuleName,
     importPkgQual :: Maybe FastString,
-    importSource :: Bool,
+    importSource :: IsBootInterface,
     importSafe :: Bool,
     importQualified :: Bool,
     importImplicit :: Bool,

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -147,8 +147,9 @@ manualExts =
     TemplateHaskellQuotes, -- enables TH subset of quasi-quotes, this
     -- apparently interferes with QuasiQuotes in
     -- weird ways
-    ImportQualifiedPost -- affects how Ormolu renders imports, so the
+    ImportQualifiedPost, -- affects how Ormolu renders imports, so the
     -- decision of enabling this style is left to the user
+    LexicalNegation -- affects how minus sign is parsed
   ]
 
 -- | Run a 'GHC.P' computation.

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -9,23 +9,23 @@ module Ormolu.Parser
   )
 where
 
-import Bag (bagToList)
-import qualified CmdLineParser as GHC
+import GHC.Data.Bag (bagToList)
+import qualified GHC.Driver.CmdLine as GHC
 import Control.Exception
 import Control.Monad.IO.Class
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import Data.Ord (Down (Down))
 import qualified Data.Text as T
-import DynFlags as GHC
-import ErrUtils (Severity (..), errMsgSeverity, errMsgSpan)
-import qualified FastString as GHC
+import GHC.Driver.Session as GHC
+import GHC.Utils.Error (Severity (..), errMsgSeverity, errMsgSpan)
+import qualified GHC.Data.FastString as GHC
 import GHC hiding (IE, UnicodeSyntax)
 import GHC.DynFlags (baseDynFlags)
 import GHC.LanguageExtensions.Type (Extension (..))
-import qualified HeaderInfo as GHC
-import qualified HscTypes as GHC
-import qualified Lexer as GHC
+import qualified GHC.Parser.Header as GHC
+import qualified GHC.Driver.Types as GHC
+import qualified GHC.Parser.Lexer as GHC
 import Ormolu.Config
 import Ormolu.Exception
 import Ormolu.Parser.Anns
@@ -33,9 +33,9 @@ import Ormolu.Parser.CommentStream
 import Ormolu.Parser.Result
 import Ormolu.Processing.Preprocess (preprocess)
 import Ormolu.Utils (incSpanLine, removeIndentation)
-import qualified Panic as GHC
-import qualified Parser as GHC
-import qualified StringBuffer as GHC
+import qualified GHC.Utils.Panic as GHC
+import qualified GHC.Parser as GHC
+import qualified GHC.Data.StringBuffer as GHC
 
 -- | Parse a complete module from string.
 parseModule ::

--- a/src/Ormolu/Parser/Anns.hs
+++ b/src/Ormolu/Parser/Anns.hs
@@ -9,10 +9,9 @@ where
 
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import Data.Maybe (mapMaybe)
 import qualified GHC
-import qualified Lexer as GHC
-import SrcLoc
+import qualified GHC.Parser.Lexer as GHC
+import GHC.Types.SrcLoc
 
 -- | Ormolu-specific representation of GHC annotations.
 newtype Anns = Anns (Map RealSrcSpan [GHC.AnnKeywordId])
@@ -28,12 +27,9 @@ mkAnns ::
   Anns
 mkAnns pstate =
   Anns $
-    M.fromListWith (++) (mapMaybe f (GHC.annotations pstate))
+    M.fromListWith (++) (f <$> (GHC.annotations pstate))
   where
-    f ((spn, kid), _) =
-      case spn of
-        RealSrcSpan rspn -> Just (rspn, [kid])
-        UnhelpfulSpan _ -> Nothing
+    f ((spn, kid), _) = (spn, [kid])
 
 -- | Lookup 'GHC.AnnKeywordId's corresponding to a given 'SrcSpan'.
 lookupAnns ::
@@ -42,5 +38,5 @@ lookupAnns ::
   -- | Collection of annotations
   Anns ->
   [GHC.AnnKeywordId]
-lookupAnns (RealSrcSpan rspn) (Anns m) = M.findWithDefault [] rspn m
+lookupAnns (RealSrcSpan rspn _) (Anns m) = M.findWithDefault [] rspn m
 lookupAnns (UnhelpfulSpan _) _ = []

--- a/src/Ormolu/Parser/Pragma.hs
+++ b/src/Ormolu/Parser/Pragma.hs
@@ -11,12 +11,12 @@ where
 import Control.Monad
 import Data.Char (isSpace, toLower)
 import qualified Data.List as L
-import qualified EnumSet as ES
-import FastString (mkFastString, unpackFS)
-import qualified Lexer as L
-import Module (ComponentId (..), newSimpleUnitId)
-import SrcLoc
-import StringBuffer
+import qualified GHC.Data.EnumSet as ES
+import GHC.Data.FastString (mkFastString, unpackFS)
+import qualified GHC.Parser.Lexer as L
+import GHC.Types.SrcLoc
+import GHC.Data.StringBuffer
+import GHC.Unit.Module (stringToUnitId)
 
 -- | Ormolu's representation of pragmas.
 data Pragma
@@ -72,7 +72,7 @@ tokenize input =
       L.mkParserFlags'
         ES.empty
         ES.empty
-        (newSimpleUnitId (ComponentId (mkFastString "")))
+        (stringToUnitId "")
         True
         True
         True

--- a/src/Ormolu/Parser/Result.hs
+++ b/src/Ormolu/Parser/Result.hs
@@ -17,7 +17,7 @@ import Ormolu.Parser.Shebang (Shebang)
 -- | A collection of data that represents a parsed module in Ormolu.
 data ParseResult = ParseResult
   { -- | 'ParsedSource' from GHC
-    prParsedSource :: HsModule GhcPs,
+    prParsedSource :: HsModule,
     -- | Ormolu-specfic representation of annotations
     prAnns :: Anns,
     -- | Stack header

--- a/src/Ormolu/Parser/Shebang.hs
+++ b/src/Ormolu/Parser/Shebang.hs
@@ -10,14 +10,14 @@ where
 
 import Data.Data (Data)
 import qualified Data.List as L
-import SrcLoc
+import GHC.Types.SrcLoc
 
 -- | A wrapper for a shebang.
-newtype Shebang = Shebang (Located String)
+newtype Shebang = Shebang (RealLocated String)
   deriving (Eq, Data)
 
 -- | Extract shebangs from the beginning of a comment stream.
-extractShebangs :: [Located String] -> ([Shebang], [Located String])
+extractShebangs :: [RealLocated String] -> ([Shebang], [RealLocated String])
 extractShebangs comments = (Shebang <$> shebangs, rest)
   where
     (shebangs, rest) = span (isShebang . unLoc) comments

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -70,7 +70,7 @@ import Data.List (intersperse)
 import Data.Text (Text)
 import Ormolu.Printer.Comments
 import Ormolu.Printer.Internal
-import SrcLoc
+import GHC.Types.SrcLoc
 
 ----------------------------------------------------------------------------
 -- Basic
@@ -96,10 +96,10 @@ located ::
   (a -> R ()) ->
   R ()
 located (L (UnhelpfulSpan _) a) f = f a
-located (L (RealSrcSpan l) a) f = do
+located (L (RealSrcSpan l _) a) f = do
   spitPrecedingComments l
   withEnclosingSpan l $
-    switchLayout [RealSrcSpan l] (f a)
+    switchLayout [RealSrcSpan l Nothing] (f a)
   spitFollowingComments l
 
 -- | A version of 'located' with arguments flipped.

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -24,6 +24,7 @@ module Ormolu.Printer.Combinators
     inciIf,
     located,
     located',
+    realLocated,
     switchLayout,
     Layout (..),
     vlayout,
@@ -96,7 +97,15 @@ located ::
   (a -> R ()) ->
   R ()
 located (L (UnhelpfulSpan _) a) f = f a
-located (L (RealSrcSpan l _) a) f = do
+located (L (RealSrcSpan l _) a) f = realLocated (L l a) f
+
+realLocated ::
+  -- | Thing to enter
+  RealLocated a ->
+  -- | How to render inner value
+  (a -> R ()) ->
+  R ()
+realLocated (L l a) f = do
   spitPrecedingComments l
   withEnclosingSpan l $
     switchLayout [RealSrcSpan l Nothing] (f a)

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -18,7 +18,7 @@ import Data.Maybe (listToMaybe)
 import qualified Data.Text as T
 import Ormolu.Parser.CommentStream
 import Ormolu.Printer.Internal
-import SrcLoc
+import GHC.Types.SrcLoc
 
 ----------------------------------------------------------------------------
 -- Top-level

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -67,7 +67,7 @@ import Ormolu.Parser.Anns
 import Ormolu.Parser.CommentStream
 import Ormolu.Printer.SpanStream
 import Ormolu.Utils (showOutputable)
-import Outputable (Outputable)
+import GHC.Utils.Outputable (Outputable)
 
 ----------------------------------------------------------------------------
 -- The 'R' monad

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -19,8 +19,8 @@ import Control.Monad
 import Data.List (isPrefixOf)
 import qualified Data.Text as T
 import GHC hiding (GhcPs, IE)
-import Name (nameStableString)
-import OccName (OccName (..))
+import GHC.Types.Name (nameStableString)
+import GHC.Types.Name.Occurrence (OccName (..))
 import Ormolu.Printer.Combinators
 import Ormolu.Utils
 
@@ -178,7 +178,7 @@ p_hsDocString hstyle needsNewline (L l str) = do
       -- attached to it and instead its location can be obtained from
       -- nearest enclosing span.
       getEnclosingSpan (const True) >>= mapM_ (setSpanMark . HaddockSpan hstyle)
-    RealSrcSpan spn -> setSpanMark (HaddockSpan hstyle spn)
+    RealSrcSpan spn _ -> setSpanMark (HaddockSpan hstyle spn)
 
 -- | Print anchor of named doc section.
 p_hsDocName :: String -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -15,7 +15,7 @@ import Data.List (sort)
 import Data.List.NonEmpty (NonEmpty (..), (<|))
 import qualified Data.List.NonEmpty as NE
 import GHC hiding (InlinePragma)
-import OccName (occNameFS)
+import GHC.Types.Name.Occurrence (occNameFS)
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration.Annotation

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -258,7 +258,7 @@ pattern AnnTypePragma n <- AnnD NoExtField (HsAnnotation NoExtField _ (TypeAnnPr
 pattern AnnValuePragma n <- AnnD NoExtField (HsAnnotation NoExtField _ (ValueAnnProvenance (L _ n)) _)
 pattern Pattern n <- ValD NoExtField (PatSynBind NoExtField (PSB _ (L _ n) _ _ _))
 pattern DataDeclaration n <- TyClD NoExtField (DataDecl NoExtField (L _ n) _ _ _)
-pattern ClassDeclaration n <- TyClD NoExtField (ClassDecl NoExtField _ (L _ n) _ _ _ _ _ _ _ _)
+pattern ClassDeclaration n <- TyClD NoExtField (ClassDecl _layoutInfo _ (L _ n) _ _ _ _ _ _ _ _)
 pattern KindSignature n <- KindSigD NoExtField (StandaloneKindSig NoExtField (L _ n) _)
 pattern FamilyDeclaration n <- TyClD NoExtField (FamDecl NoExtField (FamilyDecl NoExtField _ (L _ n) _ _ _ _))
 pattern TypeSynonym n <- TyClD NoExtField (SynDecl NoExtField (L _ n) _ _ _)
@@ -293,7 +293,7 @@ defSigRdrNames (SigD NoExtField (ClassOpSig NoExtField True ns _)) = Just $ map 
 defSigRdrNames _ = Nothing
 
 funRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
-funRdrNames (ValD NoExtField (FunBind NoExtField (L _ n) _ _ _)) = Just [n]
+funRdrNames (ValD NoExtField (FunBind NoExtField (L _ n) _ _)) = Just [n]
 funRdrNames (ValD NoExtField (PatBind NoExtField (L _ n) _ _)) = Just $ patBindNames n
 funRdrNames _ = Nothing
 
@@ -324,7 +324,7 @@ patBindNames (LitPat NoExtField _) = []
 patBindNames (SigPat _ (L _ p) _) = patBindNames p
 patBindNames (NPat NoExtField _ _ _) = []
 patBindNames (NPlusKPat NoExtField (L _ n) _ _ _ _) = [n]
-patBindNames (ConPatIn _ d) = concatMap (patBindNames . unLoc) (hsConPatArgs d)
-patBindNames ConPatOut {} = notImplemented "ConPatOut" -- created by renamer
-patBindNames (CoPat NoExtField _ p _) = patBindNames p
+patBindNames (ConPat _ _ d) = concatMap (patBindNames . unLoc) (hsConPatArgs d)
+-- patBindNames ConPatOut {} = notImplemented "ConPatOut" -- created by renamer
+-- patBindNames (CoPat NoExtField _ p _) = patBindNames p
 patBindNames (XPat x) = noExtCon x

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -8,16 +8,17 @@ module Ormolu.Printer.Meat.Declaration.Class
   )
 where
 
-import Class
+import GHC.Core.Class
 import Control.Arrow
 import Control.Monad
 import Data.Foldable
-import Data.List (sortOn)
+import Data.List (sortBy)
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration
 import Ormolu.Printer.Meat.Type
+import Data.Function (on)
 
 p_classDecl ::
   LHsContext GhcPs ->
@@ -49,7 +50,7 @@ p_classDecl ctx name HsQTvs {..} fixity fdeps csigs cdefs cats catdefs cdocs = d
         )
           <$> catdefs
       allDecls =
-        snd <$> sortOn fst (sigs <> vals <> tyFams <> tyFamDefs <> docs)
+        snd <$> sortBy (leftmost_smallest `on` fst) (sigs <> vals <> tyFams <> tyFamDefs <> docs)
   txt "class"
   switchLayout combinedSpans $ do
     breakpoint
@@ -60,7 +61,7 @@ p_classDecl ctx name HsQTvs {..} fixity fdeps csigs cdefs cats catdefs cdocs = d
           (isInfix fixity)
           True
           (p_rdrName name)
-          (located' p_hsTyVarBndr <$> hsq_explicit)
+          (located' p_hsTyVarBndr_vis <$> hsq_explicit)
       inci (p_classFundeps fdeps)
       unless (null allDecls) $ do
         breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -152,7 +152,7 @@ p_conDecl singleConstRec = \case
           getLoc con_name : conArgsSpans con_args
     switchLayout conDeclWithContextSpn $ do
       when (unLoc con_forall) $ do
-        p_forallBndrs $ HsForAllInvis noExtField con_ex_tvs
+        p_forallTelescope $ HsForAllInvis noExtField con_ex_tvs
         breakpoint
       forM_ con_mb_cxt p_lhsContext
       switchLayout conDeclSpn $ case con_args of

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -7,10 +7,10 @@ module Ormolu.Printer.Meat.Declaration.Foreign
   )
 where
 
-import BasicTypes
+import GHC.Types.Basic
 import Control.Monad
 import Data.Text
-import ForeignCall
+import GHC.Types.ForeignCall
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -11,11 +11,11 @@ module Ormolu.Printer.Meat.Declaration.Instance
   )
 where
 
-import BasicTypes
+import GHC.Types.Basic
 import Control.Arrow
 import Control.Monad
 import Data.Foldable
-import Data.List (sortOn)
+import Data.List (sortBy)
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
@@ -24,6 +24,7 @@ import Ormolu.Printer.Meat.Declaration.Data
 import Ormolu.Printer.Meat.Declaration.TypeFamily
 import Ormolu.Printer.Meat.Type
 import Ormolu.Utils
+import Data.Function (on)
 
 p_standaloneDerivDecl :: DerivDecl GhcPs -> R ()
 p_standaloneDerivDecl DerivDecl {..} = do
@@ -79,7 +80,7 @@ p_clsInstDecl = \case
               )
                 <$> cid_datafam_insts
             allDecls =
-              snd <$> sortOn fst (sigs <> vals <> tyFamInsts <> dataFamInsts)
+              snd <$> sortBy (leftmost_smallest `on` fst) (sigs <> vals <> tyFamInsts <> dataFamInsts)
         located hsib_body $ \x -> do
           breakpoint
           inci $ do

--- a/src/Ormolu/Printer/Meat/Declaration/RoleAnnotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/RoleAnnotation.hs
@@ -8,7 +8,7 @@ module Ormolu.Printer.Meat.Declaration.RoleAnnotation
   )
 where
 
-import CoAxiom
+import GHC.Core.Coercion.Axiom
 import GHC
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -33,13 +33,13 @@ p_ruleDecl = \case
     case tyvars of
       Nothing -> return ()
       Just xs -> do
-        p_forallBndrs $ mkHsForAllInvisTele $ (fmap . fmap) (setHsTyVarBndrFlag SpecifiedSpec) xs
+        p_forallTelescope $ mkHsForAllInvisTele $ (fmap . fmap) (setHsTyVarBndrFlag SpecifiedSpec) xs
         space
     -- It appears that there is no way to tell if there was an empty forall
     -- in the input or no forall at all. We do not want to add redundant
     -- foralls, so let's just skip the empty ones.
     unless (null ruleBndrs) $
-      p_forallBndrs ForallInvis p_ruleBndr ruleBndrs
+      p_forallBndrs False p_ruleBndr ruleBndrs
     breakpoint
     inci $ do
       located lhs p_hsExpr
@@ -58,5 +58,5 @@ p_ruleBndr = \case
   RuleBndr NoExtField x -> p_rdrName x
   RuleBndrSig NoExtField x hswc -> parens N $ do
     p_rdrName x
-    p_typeAscription hswc
+    p_typeAscription $ hspsToHswc hswc
   XRuleBndr x -> noExtCon x

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -14,6 +14,7 @@ import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration.Signature
 import Ormolu.Printer.Meat.Declaration.Value
 import Ormolu.Printer.Meat.Type
+import GHC.Types.Var (Specificity(SpecifiedSpec))
 
 p_ruleDecls :: RuleDecls GhcPs -> R ()
 p_ruleDecls = \case
@@ -32,7 +33,7 @@ p_ruleDecl = \case
     case tyvars of
       Nothing -> return ()
       Just xs -> do
-        p_forallBndrs ForallInvis p_hsTyVarBndr xs
+        p_forallBndrs $ mkHsForAllInvisTele $ (fmap . fmap) (setHsTyVarBndrFlag SpecifiedSpec) xs
         space
     -- It appears that there is no way to tell if there was an empty forall
     -- in the input or no forall at all. We do not want to add redundant

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -6,7 +6,7 @@ module Ormolu.Printer.Meat.Declaration.Rule
   )
 where
 
-import BasicTypes
+import GHC.Types.Basic
 import Control.Monad (unless)
 import GHC
 import Ormolu.Printer.Combinators

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -11,8 +11,8 @@ module Ormolu.Printer.Meat.Declaration.Signature
   )
 where
 
-import BasicTypes
-import BooleanFormula
+import GHC.Types.Basic
+import GHC.Data.BooleanFormula
 import Control.Monad
 import GHC
 import Ormolu.Printer.Combinators

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -156,6 +156,7 @@ p_activation :: Activation -> R ()
 p_activation = \case
   NeverActive -> return ()
   AlwaysActive -> return ()
+  FinalActive -> return ()
   ActiveBefore _ n -> do
     txt "[~"
     atom n

--- a/src/Ormolu/Printer/Meat/Declaration/Type.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Type.hs
@@ -30,7 +30,7 @@ p_synDecl name fixity HsQTvs {..} t = do
       (case fixity of Infix -> True; _ -> False)
       True
       (p_rdrName name)
-      (map (located' p_hsTyVarBndr) hsq_explicit)
+      (map (located' p_hsTyVarBndr_vis) hsq_explicit)
   space
   equals
   if hasDocStrings (unLoc t)

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -92,7 +92,7 @@ p_tyFamInstEqn HsIB {hsib_body = FamEqn {..}} = do
     Nothing -> return ()
     Just bndrs -> do
       -- An invisible forall here, with all variables in 'SpecifiedSpec'
-      p_forallBndrs (HsForAllInvis noExtField (fmap (fmap (setHsTyVarBndrFlag SpecifiedSpec)) bndrs))
+      p_forallBndrs (mkHsForAllInvisTele (fmap (fmap (setHsTyVarBndrFlag SpecifiedSpec)) bndrs))
       breakpoint
   inciIf (not $ null feqn_bndrs) $ do
     let famLhsSpn = getLoc feqn_tycon : fmap (getLoc . typeArgToType) feqn_pats

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -92,7 +92,7 @@ p_tyFamInstEqn HsIB {hsib_body = FamEqn {..}} = do
     Nothing -> return ()
     Just bndrs -> do
       -- An invisible forall here, with all variables in 'SpecifiedSpec'
-      p_forallBndrs (mkHsForAllInvisTele (fmap (fmap (setHsTyVarBndrFlag SpecifiedSpec)) bndrs))
+      p_forallTelescope (mkHsForAllInvisTele (fmap (fmap (setHsTyVarBndrFlag SpecifiedSpec)) bndrs))
       breakpoint
   inciIf (not $ null feqn_bndrs) $ do
     let famLhsSpn = getLoc feqn_tycon : fmap (getLoc . typeArgToType) feqn_pats

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1005,7 +1005,7 @@ p_pat = \case
   SigPat NoExtField pat hswc -> do
     located pat p_pat
     p_typeAscription hswc
-  CoPat {} -> notImplemented "CoPat" -- apparently created at some later stage
+  -- CoPat {} -> notImplemented "CoPat" -- apparently created at some later stage
   XPat x -> noExtCon x
 
 p_pat_hsRecField :: HsRecField' (FieldOcc GhcPs) (LPat GhcPs) -> R ()
@@ -1046,7 +1046,7 @@ p_hsSplice = \case
     atom str
     txt "|]"
   HsSpliced {} -> notImplemented "HsSpliced"
-  HsSplicedT {} -> notImplemented "HsSplicedT"
+  -- HsSplicedT {} -> notImplemented "HsSplicedT"
   XSplice x -> noExtCon x
 
 p_hsSpliceTH ::

--- a/src/Ormolu/Printer/Meat/Declaration/Warning.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Warning.hs
@@ -7,7 +7,7 @@ module Ormolu.Printer.Meat.Declaration.Warning
   )
 where
 
-import BasicTypes
+import GHC.Types.Basic
 import Data.Foldable
 import Data.Text (Text)
 import GHC

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -32,7 +32,7 @@ p_hsmodImport :: Bool -> ImportDecl GhcPs -> R ()
 p_hsmodImport useQualifiedPost ImportDecl {..} = do
   txt "import"
   space
-  when ideclSource (txt "{-# SOURCE #-}")
+  when (ideclSource == IsBoot) (txt "{-# SOURCE #-}")
   space
   when ideclSafe (txt "safe")
   space

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -34,14 +34,14 @@ p_hsModule ::
   -- | Whether to use postfix qualified imports
   Bool ->
   -- | AST to print
-  HsModule GhcPs ->
+  HsModule ->
   R ()
 p_hsModule mstackHeader shebangs pragmas qualifiedPost HsModule {..} = do
   let deprecSpan = maybe [] (\(L s _) -> [s]) hsmodDeprecMessage
       exportSpans = maybe [] (\(L s _) -> [s]) hsmodExports
   switchLayout (deprecSpan <> exportSpans) $ do
     forM_ shebangs $ \(Shebang x) ->
-      located x $ \shebang -> do
+      realLocated x $ \shebang -> do
         txt (T.pack shebang)
         newline
     forM_ mstackHeader $ \(L spn comment) -> do

--- a/src/Ormolu/Printer/Meat/Pragma.hs
+++ b/src/Ormolu/Printer/Meat/Pragma.hs
@@ -17,7 +17,7 @@ import Ormolu.Parser.CommentStream
 import Ormolu.Parser.Pragma (Pragma (..))
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Comments
-import SrcLoc
+import GHC.Types.SrcLoc
 
 -- | Pragma classification.
 data PragmaTy

--- a/src/Ormolu/Printer/Operators.hs
+++ b/src/Ormolu/Printer/Operators.hs
@@ -16,7 +16,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import GHC
-import OccName (occNameString)
+import GHC.Types.Name.Occurrence (occNameString)
 import Ormolu.Utils (unSrcSpan)
 
 -- | Intermediate representation of operator trees. It has two type

--- a/src/Ormolu/Printer/SpanStream.hs
+++ b/src/Ormolu/Printer/SpanStream.hs
@@ -14,7 +14,7 @@ import Data.Data (Data)
 import Data.Generics (everything, ext2Q)
 import Data.List (sortOn)
 import Data.Typeable (cast)
-import SrcLoc
+import GHC.Types.SrcLoc
 
 -- | A stream of 'RealSrcSpan's in ascending order. This allows us to tell
 -- e.g. whether there is another \"located\" element of AST between current
@@ -43,4 +43,4 @@ mkSpanStream a =
       case cast mspn :: Maybe SrcSpan of
         Nothing -> mempty
         Just (UnhelpfulSpan _) -> mempty
-        Just (RealSrcSpan spn) -> D.singleton spn
+        Just (RealSrcSpan spn _) -> D.singleton spn

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -29,7 +29,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import GHC
 import GHC.DynFlags (baseDynFlags)
-import qualified Outputable as GHC
+import qualified GHC.Utils.Outputable as GHC
 
 -- | Relative positions in a list.
 data RelativePos
@@ -109,13 +109,13 @@ typeArgToType = \case
 -- | Get 'RealSrcSpan' out of 'SrcSpan' if the span is “helpful”.
 unSrcSpan :: SrcSpan -> Maybe RealSrcSpan
 unSrcSpan = \case
-  RealSrcSpan r -> Just r
+  RealSrcSpan r _ -> Just r
   UnhelpfulSpan _ -> Nothing
 
 -- | Increment line number in a 'SrcSpan'.
 incSpanLine :: Int -> SrcSpan -> SrcSpan
 incSpanLine i = \case
-  RealSrcSpan s ->
+  RealSrcSpan s _ ->
     let start = realSrcSpanStart s
         end = realSrcSpanEnd s
         incLine x =
@@ -123,7 +123,7 @@ incSpanLine i = \case
               line = srcLocLine x
               col = srcLocCol x
            in mkRealSrcLoc file (line + i) col
-     in RealSrcSpan (mkRealSrcSpan (incLine start) (incLine end))
+     in RealSrcSpan (mkRealSrcSpan (incLine start) (incLine end)) Nothing
   UnhelpfulSpan x -> UnhelpfulSpan x
 
 -- | Do two declarations have a blank between them?


### PR DESCRIPTION
Close #688.

This PR is very unpolished, though currently it builds, and all tests can pass with `cfgUnsafe = True`. Since I'm not very familiar with the changes in ASTs since GHC 9.0, basically I write these code following the hints from the powerful type system and intuition. It would be great if someone could help :)

### TODO
- [ ] Figure out why we need `ImpredicativeTypes` to typecheck `Ormolu.Diff.ParseResult` in GHC 9 (perhaps something related to simplified subsumption?)
- [ ] Make tests pass with `cfgUnsafe = False`
- [ ] Add tests for new syntax in GHC 9
- [ ] Cleanup code and squash commits

I also have a question that is there any use case of [`BufSpan`](https://hackage.haskell.org/package/ghc-lib-parser-9.0.1.20210324/docs/GHC-Types-SrcLoc.html#t:BufSpan)s in ormolu? They are now ignored.
