### PR TITLE
preserve CTYPE pragmas in data declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
    * Due to a change in Haddock parsing, empty Haddock comments on function
      arguments now get deleted.
 
+* CTYPE pragmas are now preserved. [Issue 689](
+  https://github.com/tweag/ormolu/issues/689).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/data/ctype-out.hs
+++ b/data/examples/declaration/data/ctype-out.hs
@@ -1,0 +1,1 @@
+data {-# CTYPE "unistd.h" "useconds_t" #-} T

--- a/data/examples/declaration/data/ctype.hs
+++ b/data/examples/declaration/data/ctype.hs
@@ -1,0 +1,1 @@
+data    {-# CTYPE "unistd.h" "useconds_t" #-} T

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -12,6 +12,7 @@ module Ormolu.Printer.Meat.Common
     p_infixDefHelper,
     p_hsDocString,
     p_hsDocName,
+    p_sourceText,
   )
 where
 
@@ -21,6 +22,7 @@ import qualified Data.Text as T
 import GHC.Hs.Doc
 import GHC.Hs.ImpExp
 import GHC.Parser.Annotation
+import GHC.Types.Basic
 import GHC.Types.Name (nameStableString)
 import GHC.Types.Name.Occurrence (OccName (..))
 import GHC.Types.Name.Reader
@@ -188,3 +190,8 @@ p_hsDocString hstyle needsNewline (L l str) = do
 -- | Print anchor of named doc section.
 p_hsDocName :: String -> R ()
 p_hsDocName name = txt ("-- $" <> T.pack name)
+
+p_sourceText :: SourceText -> R ()
+p_sourceText = \case
+  NoSourceText -> pure ()
+  SourceText s -> space >> txt (T.pack s)

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -16,6 +16,7 @@ import GHC.Hs.Extension
 import GHC.Hs.Type
 import GHC.Parser.Annotation
 import GHC.Types.Basic
+import GHC.Types.ForeignCall
 import GHC.Types.Name.Reader
 import GHC.Types.SrcLoc
 import Ormolu.Printer.Combinators
@@ -42,6 +43,15 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
   txt $ case style of
     Associated -> mempty
     Free -> " instance"
+  case unLoc <$> dd_cType of
+    Nothing -> pure ()
+    Just (CType prag header (type_, _)) -> do
+      p_sourceText prag
+      case header of
+        Nothing -> pure ()
+        Just (Header h _) -> space *> p_sourceText h
+      p_sourceText type_
+      txt " #-}"
   let constructorSpans = getLoc name : fmap getLoc tpats
   switchLayout constructorSpans $ do
     breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -8,11 +8,9 @@ module Ormolu.Printer.Meat.Declaration.Foreign
 where
 
 import Control.Monad
-import Data.Text
 import GHC.Hs.Decls
 import GHC.Hs.Extension
 import GHC.Hs.Type
-import GHC.Types.Basic
 import GHC.Types.ForeignCall
 import GHC.Types.SrcLoc
 import Ormolu.Printer.Combinators
@@ -69,8 +67,3 @@ p_foreignExport (CExport (L loc (CExportStatic _ _ cCallConv)) sourceText) = do
   space
   located (L loc cCallConv) atom
   located sourceText p_sourceText
-
-p_sourceText :: SourceText -> R ()
-p_sourceText = \case
-  NoSourceText -> pure ()
-  SourceText s -> space >> txt (pack s)


### PR DESCRIPTION
Closes #689

This targets the ghc-9.0 branch right now, which will have to change as soon as #722 has been merged.

---

The `dd_cType` field of [`HsDataDefn`](https://hackage.haskell.org/package/ghc-lib-parser-9.0.1.20210324/docs/GHC-Hs-Decls.html#v:dd_cType) had been ignored previously, which means that `CTYPE` pragmas were simply dropped on formatting.

As an aside: The `dd_ctxt` is also ignored, but the corresponding extension ([`DatatypeContexts`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/exts/datatype_contexts.html#extension-DatatypeContexts)) is deprecated, so I don't know if it is even worth to respect it.  