### PR TITLE
support TypeApplications in data/type family instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 * CTYPE pragmas are now preserved. [Issue 689](
   https://github.com/tweag/ormolu/issues/689).
 
+* `TypeApplications` in data/type family instances are now supported. [Issue
+  698](https://github.com/tweag/ormolu/issues/698).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/type-families/closed-type-family/type-arguments-out.hs
+++ b/data/examples/declaration/type-families/closed-type-family/type-arguments-out.hs
@@ -1,0 +1,4 @@
+type PickType :: forall k. Nat -> k
+type family PickType n where
+  PickType @Type 1 = Bool
+  PickType @(Type -> Type) 2 = Maybe

--- a/data/examples/declaration/type-families/closed-type-family/type-arguments.hs
+++ b/data/examples/declaration/type-families/closed-type-family/type-arguments.hs
@@ -1,0 +1,4 @@
+type PickType :: forall k. Nat -> k
+type family PickType n where
+  PickType @Type 1 = Bool
+  PickType @(Type -> Type) 2 = Maybe

--- a/data/examples/declaration/type-families/data-family/type-arguments-out.hs
+++ b/data/examples/declaration/type-families/data-family/type-arguments-out.hs
@@ -1,0 +1,5 @@
+type PickType :: forall k. (k -> Type) -> Type
+data family PickType m
+
+data instance PickType @Nat M where
+  Foo :: PickType M

--- a/data/examples/declaration/type-families/data-family/type-arguments.hs
+++ b/data/examples/declaration/type-families/data-family/type-arguments.hs
@@ -1,0 +1,5 @@
+type PickType :: forall k. (k -> Type) -> Type
+data family PickType m
+
+data instance PickType @Nat M where
+  Foo :: PickType M

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -136,7 +136,7 @@ p_tyClDecl style = \case
     p_dataDecl
       Associated
       tcdLName
-      (tyVarsToTypes tcdTyVars)
+      (tyVarsToTyPats tcdTyVars)
       tcdFixity
       tcdDataDefn
   ClassDecl {..} ->

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -30,7 +30,7 @@ p_dataDecl ::
   -- | Type constructor
   Located RdrName ->
   -- | Type patterns
-  [LHsType GhcPs] ->
+  HsTyPats GhcPs ->
   -- | Lexical fixity
   LexicalFixity ->
   -- | Data definition
@@ -52,7 +52,7 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
         Just (Header h _) -> space *> p_sourceText h
       p_sourceText type_
       txt " #-}"
-  let constructorSpans = getLoc name : fmap getLoc tpats
+  let constructorSpans = getLoc name : fmap lhsTypeArgSrcSpan tpats
   switchLayout constructorSpans $ do
     breakpoint
     inci $
@@ -60,7 +60,7 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
         (isInfix fixity)
         True
         (p_rdrName name)
-        (located' p_hsType <$> tpats)
+        (p_lhsTypeArg <$> tpats)
   case dd_kindSig of
     Nothing -> return ()
     Just k -> do

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -27,7 +27,6 @@ import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration
 import Ormolu.Printer.Meat.Declaration.Data
 import Ormolu.Printer.Meat.Declaration.TypeFamily
 import Ormolu.Printer.Meat.Type
-import Ormolu.Utils
 
 p_standaloneDerivDecl :: DerivDecl GhcPs -> R ()
 p_standaloneDerivDecl DerivDecl {..} = do
@@ -102,7 +101,7 @@ p_tyFamInstDecl style TyFamInstDecl {..} = do
 
 p_dataFamInstDecl :: FamilyStyle -> DataFamInstDecl GhcPs -> R ()
 p_dataFamInstDecl style (DataFamInstDecl {dfid_eqn = HsIB {hsib_body = FamEqn {..}}}) =
-  p_dataDecl style feqn_tycon (map typeArgToType feqn_pats) feqn_fixity feqn_rhs
+  p_dataDecl style feqn_tycon feqn_pats feqn_fixity feqn_rhs
 
 match_overlap_mode :: Maybe (Located OverlapMode) -> R () -> R ()
 match_overlap_mode overlap_mode layoutStrategy =

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -19,7 +19,6 @@ import GHC.Types.SrcLoc
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Type
-import Ormolu.Utils
 
 p_famDecl :: FamilyStyle -> FamilyDecl GhcPs -> R ()
 p_famDecl style FamilyDecl {fdTyVars = HsQTvs {..}, ..} = do
@@ -90,13 +89,13 @@ p_tyFamInstEqn HsIB {hsib_body = FamEqn {..}} = do
       p_forallBndrs ForAllInvis p_hsTyVarBndr bndrs
       breakpoint
   inciIf (not $ null feqn_bndrs) $ do
-    let famLhsSpn = getLoc feqn_tycon : fmap (getLoc . typeArgToType) feqn_pats
+    let famLhsSpn = getLoc feqn_tycon : fmap lhsTypeArgSrcSpan feqn_pats
     switchLayout famLhsSpn $
       p_infixDefHelper
         (isInfix feqn_fixity)
         True
         (p_rdrName feqn_tycon)
-        (located' p_hsType . typeArgToType <$> feqn_pats)
+        (p_lhsTypeArg <$> feqn_pats)
     space
     equals
     breakpoint

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -10,7 +10,6 @@ module Ormolu.Utils
     notImplemented,
     showOutputable,
     splitDocString,
-    typeArgToType,
     unSrcSpan,
     incSpanLine,
     separatedByBlank,
@@ -99,13 +98,6 @@ splitDocString docStr =
            in if leadingSpace x
                 then dropSpace <$> xs
                 else xs
-
--- | Get 'LHsType' out of 'LHsTypeArg'.
-typeArgToType :: LHsTypeArg p -> LHsType p
-typeArgToType = \case
-  HsValArg tm -> tm
-  HsTypeArg _ ty -> ty
-  HsArgPar _ -> notImplemented "HsArgPar"
 
 -- | Get 'RealSrcSpan' out of 'SrcSpan' if the span is “helpful”.
 unSrcSpan :: SrcSpan -> Maybe RealSrcSpan


### PR DESCRIPTION
Closes #698

Previously, `LHsTypeArg` was converted to `LHsType` via `typeArgToType`, but this conversion loses information, namely whether something was a "value argument" (in this case the conversion is correct) or a "type argument" (in this case it is an argument of visible type application):

```haskell
type LHsTypeArg p = HsArg (LHsType p) (LHsKind p)

-- Arguments in an expression/type after splitting
data HsArg tm ty
  = HsValArg tm   -- Argument is an ordinary expression     (f arg)
  | HsTypeArg SrcSpan ty -- Argument is a visible type application (f @ty)
                         -- SrcSpan is location of the `@`
  | HsArgPar SrcSpan -- See Note [HsArgPar]
```