### PR TITLE
fix formatting of infix arrow command formations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 * `TypeApplications` in data/type family instances are now supported. [Issue
   698](https://github.com/tweag/ormolu/issues/698).
 
+* Formatting infix arrow command formations now preserves the AST. [Issue
+  718](https://github.com/tweag/ormolu/issues/718).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/value/function/arrow/proc-forms2-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-forms2-out.hs
@@ -20,3 +20,22 @@ bar3 f g h x =
           -<
             y z . (y x)
       )
+
+bar4 = proc x ->
+  case x of
+    Just f -> f -< ()
+    Nothing -> x -< ()
+  <+> do
+    g -< x
+
+expr' = proc x ->
+  do
+    returnA -< x
+  <+> do
+    symbol Plus -< ()
+    y <- term -< ()
+    expr' -< x + y
+  <+> do
+    symbol Minus -< ()
+    y <- term -< ()
+    expr' -< x - y

--- a/data/examples/declaration/value/function/arrow/proc-forms2.hs
+++ b/data/examples/declaration/value/function/arrow/proc-forms2.hs
@@ -17,3 +17,20 @@ bar3 f g h x =
   |||
     ((h g  .  h f)
       -<y z  .  (y x))
+
+bar4 = proc x -> case x of
+    Just f -> f -< ()
+    Nothing -> x -< ()
+ <+> do
+         g -< x
+
+expr' = proc x -> do
+                returnA -< x
+        <+> do
+                symbol Plus -< ()
+                y <- term -< ()
+                expr' -< x + y
+        <+> do
+                symbol Minus -< ()
+                y <- term -< ()
+                expr' -< x - y

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -328,7 +328,9 @@ p_hsCmd = \case
       inci (sequence_ (intersperse breakpoint (located' p_hsCmdTop <$> cmds)))
   HsCmdArrForm NoExtField form Infix _ [left, right] -> do
     located left p_hsCmdTop
-    space
+    case unLoc left of
+      HsCmdTop NoExtField (L _ HsCmdPar {}) -> space
+      _ -> breakpoint
     located form p_hsExpr
     placeHanging (cmdTopPlacement (unLoc right)) $
       located right p_hsCmdTop


### PR DESCRIPTION
Closes #718

Previously, we inserted a space before the infix operator in all scenarios, which breaks if the first operand is e.g. a `do` block or a case switch. To preserve the existing behavior, we now only insert a space (instead of a breakpoint) if the first argument is parenthesized.