### PR TITLE
surround code in brackets with spaces if it contains a `* ~ Type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 * Formatting infix arrow command formations now preserves the AST. [Issue
   718](https://github.com/tweag/ormolu/issues/718).
 
+* Surround code in brackets with spaces if it contains a `StarIsType` `*` to
+  prevent unparseable output. [Issue 704](https://github.com/tweag/ormolu/issues/704).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/splice/bracket-declaration-out.hs
+++ b/data/examples/declaration/splice/bracket-declaration-out.hs
@@ -24,3 +24,12 @@ $( singletons
          deriving (Eq, Ord, Enum, Bounded, Show)
        |]
  )
+
+foo = [d| type X = * |]
+
+foo =
+  [d|
+    type X = *
+
+    data A
+    |]

--- a/data/examples/declaration/splice/bracket-declaration.hs
+++ b/data/examples/declaration/splice/bracket-declaration.hs
@@ -20,3 +20,11 @@ $(singletons [d|
   data T = T
     deriving (Eq, Ord, Enum, Bounded, Show)
  |])
+
+
+foo = [d|type X = * |]
+
+foo = [d|
+  type X = *
+  data A
+        |]

--- a/data/examples/declaration/splice/bracket-out.hs
+++ b/data/examples/declaration/splice/bracket-out.hs
@@ -16,3 +16,7 @@ foo =
   [||
   foo bar
   ||]
+
+foo = [t| * |]
+
+foo = [t| a -> * -> a |]

--- a/data/examples/declaration/splice/bracket.hs
+++ b/data/examples/declaration/splice/bracket.hs
@@ -10,3 +10,7 @@ foo = [t|       Char |]
 
 foo = [|| foo bar
   ||]
+
+foo = [t| * |]
+
+foo = [t|a -> * -> a|]


### PR DESCRIPTION
Closes #704 

One could probably write a better detection algorithm whether the bracket code has the `*` actually at its end (and not somewhere in the middle), but I am not sure if this is worth it, especially as the `StarIsType` is scheduled to be removed (see [this GHC proposal](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0143-remove-star-kind.rst)) and `-Wstar-is-type` is already part of `-Wall` in GHC 9.0. 