### PR TITLE
fix formatting of applied multi line constructs in do blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@
 * Surround code in brackets with spaces if it contains a `StarIsType` `*` to
   prevent unparseable output. [Issue 704](https://github.com/tweag/ormolu/issues/704).
 
+* Formatting applied multiline constructs in do blocks now preserves the AST.
+  [Issue 707](https://github.com/tweag/ormolu/issues/707).
+
+  This will sometimes result in odd indentations, e.g. this snippet is a
+  fixed point:
+  ```haskell
+  foo = do
+    do
+      (+1)
+     1
+  ```
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/value/function/application-1-out.hs
+++ b/data/examples/declaration/value/function/application-1-out.hs
@@ -2,18 +2,18 @@ main =
   do
     x
     y
-  z
+   z
 
 main =
   case foo of
     x -> a
-  foo
-  a
-  b
+   foo
+   a
+   b
 
 main =
   do
     if x then y else z
-  foo
-  a
-  b
+   foo
+   a
+   b

--- a/data/examples/declaration/value/function/application-2-out.hs
+++ b/data/examples/declaration/value/function/application-2-out.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+foo = do
+  $( bar
+   )
+    baz
+
+foo = do
+  $$( bar
+    )
+    baz
+
+foo = do
+  do (+ 1)
+    2
+
+foo = do
+  do
+    (+ 1)
+   2
+
+foo = do
+  case () of () -> (+ 1)
+    2
+
+foo = do
+  case () of
+    () -> (+ 1)
+   2
+
+foo = do
+  \case 2 -> 3
+    2
+
+foo = do
+  \case
+    2 -> 3
+   2

--- a/data/examples/declaration/value/function/application-2.hs
+++ b/data/examples/declaration/value/function/application-2.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+foo = do
+  $( bar
+   ) baz
+
+foo = do
+  $$( bar
+    ) baz
+
+foo = do
+  do (+1)
+   2
+
+foo = do
+  do
+    (+1)
+   2
+
+foo = do
+  case () of () -> (+1)
+   2
+
+foo = do
+  case () of
+    () -> (+1)
+   2
+
+foo = do
+  \case 2 -> 3
+   2
+
+foo = do
+  \case
+    2 -> 3
+   2

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -23,6 +23,7 @@ module Ormolu.Printer.Combinators
     newline,
     inci,
     inciIf,
+    inciHalf,
     located,
     located',
     realLocated,

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -20,6 +20,7 @@ module Ormolu.Printer.Internal
     newline,
     useRecordDot,
     inci,
+    inciHalf,
     sitcc,
     Layout (..),
     enterLayout,
@@ -381,18 +382,26 @@ newlineRaw = R . modify $ \sc ->
 useRecordDot :: R Bool
 useRecordDot = R (asks rcUseRecDot)
 
+inciBy :: Int -> R () -> R ()
+inciBy step (R m) = R (local modRC m)
+  where
+    modRC rc =
+      rc
+        { rcIndent = rcIndent rc + step
+        }
+
 -- | Increase indentation level by one indentation step for the inner
 -- computation. 'inci' should be used when a part of code must be more
 -- indented relative to the parts outside of 'inci' in order for the output
 -- to be valid Haskell. When layout is single-line there is no obvious
 -- effect, but with multi-line layout correct indentation levels matter.
 inci :: R () -> R ()
-inci (R m) = R (local modRC m)
-  where
-    modRC rc =
-      rc
-        { rcIndent = rcIndent rc + indentStep
-        }
+inci = inciBy indentStep
+
+-- | In rare cases, we have to indent by a positive amount smaller
+-- than 'indentStep'.
+inciHalf :: R () -> R ()
+inciHalf = inciBy $ (indentStep `div` 2) `max` 1
 
 -- | Set indentation level for the inner computation equal to current
 -- column. This makes sure that the entire inner block is uniformly


### PR DESCRIPTION
Closes #707 

If we choose to merge this as is, I will create a style tracking issue for the 1 space indentation via `inciHalf`.

I *think*  that `do`, `case of` and `\case` are all constructs where we have to indent the argument by less than `indentStep`, but it might turn out that there are more.