### PR TITLE
allow CLI GHC options to be overriden by file local options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
      1
   ```
 
+* GHC options passed in via the CLI can now be overridden in local files.
+  Previously, if an extension was disabled via the CLI, it could not be
+  re-enabled per file.
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -171,6 +171,7 @@ test-suite tests
     hs-source-dirs:   tests
     other-modules:
         Ormolu.Diff.TextSpec
+        Ormolu.Parser.OptionsSpec
         Ormolu.Parser.PragmaSpec
         Ormolu.PrinterSpec
 

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -204,9 +204,9 @@ parsePragmasIntoDynFlags ::
   IO (Either String ([GHC.Warn], DynFlags))
 parsePragmasIntoDynFlags flags extraOpts filepath str =
   catchErrors $ do
-    let opts = GHC.getOptions flags (GHC.stringToStringBuffer str) filepath
+    let fileOpts = GHC.getOptions flags (GHC.stringToStringBuffer str) filepath
     (flags', leftovers, warnings) <-
-      parseDynamicFilePragma flags (opts <> extraOpts)
+      parseDynamicFilePragma flags (extraOpts <> fileOpts)
     case NE.nonEmpty leftovers of
       Nothing -> return ()
       Just unrecognizedOpts ->

--- a/tests/Ormolu/Parser/OptionsSpec.hs
+++ b/tests/Ormolu/Parser/OptionsSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Ormolu.Parser.OptionsSpec (spec) where
+
+import qualified Data.Text as T
+import Ormolu
+import Test.Hspec
+
+spec :: Spec
+spec = describe "GHC options in source files take priority" $ do
+  it "default extensions can be disabled locally" $ do
+    let src =
+          unlines
+            [ "{-# LANGUAGE NoBlockArguments #-}",
+              "",
+              "test = test do test"
+            ]
+    fixedPoint [] src `shouldThrow` \case
+      OrmoluParsingFailed {} -> True
+      _ -> False
+  it "extensions disabled via CLI can be enabled locally" $ do
+    let src =
+          unlines
+            [ "{-# LANGUAGE BlockArguments #-}",
+              "",
+              "test = test do test"
+            ]
+    fixedPoint ["-XNoBlockArguments"] src
+  where
+    fixedPoint opts input = do
+      output <- ormolu defaultConfig {cfgDynOptions = DynOption <$> opts} "<input>" input
+      T.unpack output `shouldBe` input


### PR DESCRIPTION
Closes #651 

The first of the two new tests also passes without this patch, but it ensures that we maintain the ability to disable extensions per file.