### PR TITLE
improve handling of negative literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@
   Previously, if an extension was disabled via the CLI, it could not be
   re-enabled per file.
 
+* `LexicalNegation` is no longer enabled by default. Also, spaces after
+  negation via `-` are removed where possible. [Issue
+  694](https://github.com/tweag/ormolu/issues/694).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
   negation via `-` are removed where possible. [Issue
   694](https://github.com/tweag/ormolu/issues/694).
 
+* Minus signs in literal patterns are now preserved in all cases. [Issue
+  733](https://github.com/tweag/ormolu/issues/733).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/instance/newlines-between-methods-out.hs
+++ b/data/examples/declaration/instance/newlines-between-methods-out.hs
@@ -4,7 +4,7 @@ instance Num a => Num (Diff a) where
   D u dudx * D v dvdx = D (u * v) (u * dvdx + v * dudx)
 
   -- Comment before definition
-  negate (D u dudx) = D (- u) (- dudx)
+  negate (D u dudx) = D (-u) (-dudx)
   negate (Z u dudx) = undefined
 
   -- Comment after definition

--- a/data/examples/declaration/value/function/lexical-negation-out.hs
+++ b/data/examples/declaration/value/function/lexical-negation-out.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE LexicalNegation #-}
 
-foo :: Int
-foo = (-2)
+foo = -1
 
-bar :: Int
-bar = -2
+foo = -x
 
 weird :: (Int -> Int) -> Int -> Int
 weird x y = x -y

--- a/data/examples/declaration/value/function/lexical-negation.hs
+++ b/data/examples/declaration/value/function/lexical-negation.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE LexicalNegation #-}
 
-foo :: Int
-foo = (-2)
+foo = -1
 
-bar :: Int
-bar = -2
+foo = -x
 
 weird :: (Int -> Int) -> Int -> Int
 weird x y = x -y

--- a/data/examples/declaration/value/function/negation-out.hs
+++ b/data/examples/declaration/value/function/negation-out.hs
@@ -5,7 +5,12 @@ bar :: Int
 bar = -2
 
 baz :: Int
-baz = - 2
+baz = -2
+
+neg :: Int -> Int
+neg x = (-x)
+neg x = -x
+neg x = -x
 
 weird :: Int -> Int -> Int
 weird x y = x - y

--- a/data/examples/declaration/value/function/negation-out.hs
+++ b/data/examples/declaration/value/function/negation-out.hs
@@ -14,3 +14,7 @@ neg x = -x
 
 weird :: Int -> Int -> Int
 weird x y = x - y
+
+pat = \case -1 -> 1
+
+pat = \case -1 -> 1

--- a/data/examples/declaration/value/function/negation.hs
+++ b/data/examples/declaration/value/function/negation.hs
@@ -14,3 +14,7 @@ neg x = -x
 
 weird :: Int -> Int -> Int
 weird x y = x -y
+
+pat = \case -1 -> 1
+
+pat = \case - 1 -> 1

--- a/data/examples/declaration/value/function/negation.hs
+++ b/data/examples/declaration/value/function/negation.hs
@@ -7,5 +7,10 @@ bar = -2
 baz :: Int
 baz = - 2
 
+neg :: Int -> Int
+neg x = (- x)
+neg x = - x
+neg x = -x
+
 weird :: Int -> Int -> Int
 weird x y = x -y

--- a/data/examples/declaration/value/function/negative-literals-out.hs
+++ b/data/examples/declaration/value/function/negative-literals-out.hs
@@ -7,3 +7,7 @@ foo = -1
 foo = -x
 
 foo = -x
+
+pat = \case -1 -> 1
+
+pat = \case - 1 -> 1

--- a/data/examples/declaration/value/function/negative-literals-out.hs
+++ b/data/examples/declaration/value/function/negative-literals-out.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE NegativeLiterals #-}
+
+foo = - 1
+
+foo = -1
+
+foo = -x
+
+foo = -x

--- a/data/examples/declaration/value/function/negative-literals.hs
+++ b/data/examples/declaration/value/function/negative-literals.hs
@@ -7,3 +7,7 @@ foo = -1
 foo = - x
 
 foo = -x
+
+pat = \case -1 -> 1
+
+pat = \case - 1 -> 1

--- a/data/examples/declaration/value/function/negative-literals.hs
+++ b/data/examples/declaration/value/function/negative-literals.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE NegativeLiterals #-}
+
+foo = - 1
+
+foo = -1
+
+foo = - x
+
+foo = -x

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -148,7 +148,8 @@ manualExts =
     -- weird ways
     ImportQualifiedPost, -- affects how Ormolu renders imports, so the
     -- decision of enabling this style is left to the user
-    LexicalNegation, -- this breaks e.g. declaration/value/function/negation.hs
+    NegativeLiterals, -- with this, `- 1` and `-1` have differing AST
+    LexicalNegation, -- implies NegativeLiterals
     LinearTypes -- steals the (%) type operator in some cases
   ]
 

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Ormolu.Printer.Meat.Declaration.Value
   ( p_valDecl,
@@ -23,6 +24,7 @@ import Data.Generics.Schemes (everything)
 import Data.List (intersperse, sortBy)
 import Data.List.NonEmpty (NonEmpty (..), (<|))
 import qualified Data.List.NonEmpty as NE
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Data.Bag (bagToList)
@@ -1003,7 +1005,12 @@ p_pat = \case
     inci (located pat p_pat)
   SplicePat NoExtField splice -> p_hsSplice splice
   LitPat NoExtField p -> atom p
-  NPat NoExtField v _ _ -> located v (atom . ol_val)
+  NPat NoExtField v (isJust -> isNegated) NoExtField -> do
+    when isNegated $ do
+      txt "-"
+      negativeLiterals <- isExtensionEnabled NegativeLiterals
+      when negativeLiterals space
+    located v (atom . ol_val)
   NPlusKPat NoExtField n k _ _ _ -> sitcc $ do
     p_rdrName n
     breakpoint


### PR DESCRIPTION
Close #694 
Close #733

Note that CI would fail without the second commit, as the addition of `NegativeLiterals` to `manualExts` triggers #733 in a lot of places.
