### PR TITLE
improve detection of blank lines between spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
    * Due to a change in Haddock parsing, empty Haddock comments on function
      arguments now get deleted.
 
+* Unnecessary blank lines after comments are no longer inserted. [Issue
+  678](https://github.com/tweag/ormolu/issues/678).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/value/function/if-with-comment-out.hs
+++ b/data/examples/declaration/value/function/if-with-comment-out.hs
@@ -3,6 +3,12 @@ foo =
     then -- then comment
       undefined
     else -- else comment
-
     do
       undefined
+
+x =
+  if undefined
+    then -- then
+      ()
+    else -- else
+      ()

--- a/data/examples/declaration/value/function/if-with-comment.hs
+++ b/data/examples/declaration/value/function/if-with-comment.hs
@@ -6,3 +6,12 @@ foo =
     else
       do
         undefined
+
+x =
+  if undefined
+    -- then
+    then
+      ()
+    -- else
+    else
+      ()

--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,7 @@ let
     "pipes"
     "postgrest"
     "purescript"
+    "stack"
   ];
   ormolizedPackages = doCheck:
     pkgs.lib.mapAttrs (name: p: ormolize {

--- a/expected-failures/intero.txt
+++ b/expected-failures/intero.txt
@@ -1,5 +1,5 @@
 src/InteractiveUI.hs
-@@ -3746,6 +3746,7 @@
+@@ -3744,6 +3744,7 @@
                   stdout
                   ( text "Unable to list source for"
                       <+> ppr pan

--- a/expected-failures/leksah.txt
+++ b/expected-failures/leksah.txt
@@ -42,7 +42,7 @@ src/IDE/NotebookFlipper.hs
   AST of input and AST of formatted code differ.
   Please, consider reporting the bug.
 src/IDE/Pane/Modules.hs
-@@ -1182,9 +1182,9 @@
+@@ -1181,9 +1181,9 @@
         let modId = mdModuleId modDescr
             modName = modu modId
             mFilePath = mdMbSourcePath modDescr

--- a/expected-failures/stack.txt
+++ b/expected-failures/stack.txt
@@ -1,0 +1,18 @@
+src/Stack/Path.hs
+@@ -65,9 +65,9 @@
+              (set (globalOptsL . globalOptsBuildOptsMonoidL . buildOptsMonoidHaddockL) (Just x))
+              . withConfig YesReexec
+              . withDefaultEnvConfig -- FIXME this matches previous behavior, but doesn't make a lot of sense
+-     -- MSS 2019-03-17 Not a huge fan of rerunning withConfig and
+-     -- withDefaultEnvConfig each time, need to figure out what
+-     -- purpose is served and whether we can achieve it without two
+-     -- completely separate Config setups
++             -- MSS 2019-03-17 Not a huge fan of rerunning withConfig and
++             -- withDefaultEnvConfig each time, need to figure out what
++             -- purpose is served and whether we can achieve it without two
++             -- completely separate Config setups
+      runHaddock True $ printKeys with singlePath
+      runHaddock False $ printKeys without singlePath
+
+  Formatting is not idempotent.
+  Please, consider reporting the bug.

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -11,6 +11,8 @@ where
 
 import Control.Exception
 import Control.Monad.IO.Class
+import Data.Char (isSpace)
+import qualified Data.IntSet as IntSet
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import Data.Ord (Down (Down))
@@ -55,6 +57,9 @@ parseModule Config {..} path rawInput = liftIO $ do
   let (literalPrefix, indentedInput, literalSuffix, extraComments) =
         preprocess path rawInput cfgRegion
       (input, indent) = removeIndentation indentedInput
+      blankLines =
+        IntSet.fromList . fmap snd . filter (all isSpace . fst) $
+          lines input `zip` [1 ..]
   -- It's important that 'setDefaultExts' is done before
   -- 'parsePragmasIntoDynFlags', because otherwise we might enable an
   -- extension that was explicitly disabled in the file.
@@ -112,7 +117,8 @@ parseModule Config {..} path rawInput = liftIO $ do
                         prExtensions = GHC.extensionFlags dynFlags,
                         prLiteralPrefix = T.pack literalPrefix,
                         prLiteralSuffix = T.pack literalSuffix,
-                        prIndent = indent
+                        prIndent = indent,
+                        prBlankLines = blankLines
                       }
   return (warnings, r)
 

--- a/src/Ormolu/Parser/Result.hs
+++ b/src/Ormolu/Parser/Result.hs
@@ -7,6 +7,7 @@ module Ormolu.Parser.Result
   )
 where
 
+import Data.IntSet (IntSet)
 import Data.Text (Text)
 import GHC.Data.EnumSet (EnumSet)
 import GHC.Hs
@@ -40,7 +41,9 @@ data ParseResult = ParseResult
     -- | Literal suffix
     prLiteralSuffix :: Text,
     -- | Indentation level, can be non-zero in case of region formatting
-    prIndent :: Int
+    prIndent :: Int,
+    -- | Blank lines of the input
+    prBlankLines :: IntSet
   }
 
 -- | Pretty-print a 'ParseResult'.

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -36,3 +36,4 @@ printModule ParseResult {..} =
           prAnns
           prUseRecordDot
           prExtensions
+          prBlankLines

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -13,6 +13,7 @@ module Ormolu.Printer.Combinators
     getAnns,
     getEnclosingSpan,
     isExtensionEnabled,
+    isBlankLine,
 
     -- * Combinators
 

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -17,9 +17,11 @@ module Ormolu.Utils
     separatedByBlankNE,
     onTheSameLine,
     removeIndentation,
+    whenM,
   )
 where
 
+import Control.Monad
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -154,3 +156,8 @@ removeIndentation (lines -> xs) = (unlines (drop n <$> xs), n)
       if all isSpace y
         then 0
         else length (takeWhile isSpace y)
+
+whenM :: Monad m => m Bool -> m () -> m ()
+whenM cond body = do
+  b <- cond
+  when b body


### PR DESCRIPTION
Closes #678 

Previously, `needsNewlineBefore` only checked that the two spans are separated by at least one line, but did not account for the possibility of them being non-blank.

---

This fix creates an idempotency issue in stack. Minimized example:

```haskell
test = do
  let test =
        test . -- comment
          test
  -- comment
  test
```
to
```haskell
test = do
  let test =
        test
          . test -- comment
  -- comment
  test
```
to
```haskell
test = do
  let test =
        test
          . test -- comment
          -- comment
  test

```
Previously, the first snippet got formatted into
```haskell
test = do
  let test =
        test
          . test -- comment

  -- comment
  test
```

This seems to be rather orthogonal to this PR, so maybe it is a good idea to create a separate issue for this idempotency failure.