### PR TITLE
Support left-to-right arrow application (fixes #737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 * Minus signs in literal patterns are now preserved in all cases. [Issue
   733](https://github.com/tweag/ormolu/issues/733).
 
+* Added support for left-to-right arrow application. [Issue
+  737](https://github.com/tweag/ormolu/issues/737).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/value/function/arrow/proc-applications-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications-out.hs
@@ -2,6 +2,8 @@
 
 foo x = proc a -> a -< x
 
+foolr x = proc a -> x >- a
+
 bar f x =
   proc
     ( y,
@@ -17,3 +19,5 @@ bar f x =
         )
 
 baz x = proc a -> a -<< x
+
+bazlr x = proc a -> x >>- a

--- a/data/examples/declaration/value/function/arrow/proc-applications.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications.hs
@@ -2,6 +2,8 @@
 
 foo x = proc a -> a -< x
 
+foolr x = proc a -> x >- a
+
 bar f x =
     proc (
         y,
@@ -15,3 +17,5 @@ bar f x =
     )
 
 baz x = proc a -> a -<< x
+
+bazlr x = proc a -> x >>- a

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -315,15 +315,18 @@ p_grhs' placer render style (GRHS NoExtField guards body) =
 
 p_hsCmd :: HsCmd GhcPs -> R ()
 p_hsCmd = \case
-  HsCmdArrApp NoExtField body input arrType _ -> do
-    located body p_hsExpr
+  HsCmdArrApp NoExtField body input arrType rightToLeft -> do
+    let (l, r) = if rightToLeft then (body, input) else (input, body)
+    located l p_hsExpr
     breakpoint
     inci $ do
-      case arrType of
-        HsFirstOrderApp -> txt "-<"
-        HsHigherOrderApp -> txt "-<<"
+      case (arrType, rightToLeft) of
+        (HsFirstOrderApp, True) -> txt "-<"
+        (HsHigherOrderApp, True) -> txt "-<<"
+        (HsFirstOrderApp, False) -> txt ">-"
+        (HsHigherOrderApp, False) -> txt ">>-"
       placeHanging (exprPlacement (unLoc input)) $
-        located input p_hsExpr
+        located r p_hsExpr
   HsCmdArrForm NoExtField form Prefix _ cmds -> banana $ do
     located form p_hsExpr
     unless (null cmds) $ do


### PR DESCRIPTION
Close #737

Compare https://hackage.haskell.org/package/ghc-8.10.2/docs/src/GHC.Hs.Expr.html#HsCmdArrApp