### PR TITLE
Indent closing arrow-banana in do block (fixes #739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 
 * Now `--mode check` fails on missing trailing blank lines.
 
+* Fixed indentation of arrow forms in do blocks. [Issue
+  739](https://github.com/tweag/ormolu/issues/739).
+
 ## Ormolu 0.1.4.1
 
 * Added command line option `--color` to control how diffs are printed.

--- a/data/examples/declaration/value/function/arrow/proc-form-do-indent-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-form-do-indent-out.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE Arrows #-}
+
+foo x = proc (y, z) -> do
+  (|
+    bar
+      (bindA -< y)
+    |)
+
+foo1 x = proc (y, z) -> do
+  (|
+    bar
+      (bindA -< y)
+    |) z

--- a/data/examples/declaration/value/function/arrow/proc-form-do-indent.hs
+++ b/data/examples/declaration/value/function/arrow/proc-form-do-indent.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE Arrows #-}
+
+foo x = proc (y, z) -> do
+  (|
+    bar
+      (bindA -< y)
+    |)
+
+foo1 x = proc (y, z) -> do
+  (|
+    bar
+      (bindA -< y)
+    |) z

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -226,8 +226,8 @@ backticks m = do
   txt "`"
 
 -- | Surround given entity by banana brackets (i.e., from arrow notation.)
-banana :: R () -> R ()
-banana = brackets_ True "(|" "|)" N
+banana :: BracketStyle -> R () -> R ()
+banana = brackets_ True "(|" "|)"
 
 -- | Surround given entity by curly braces @{@ and  @}@.
 braces :: BracketStyle -> R () -> R ()


### PR DESCRIPTION
Close #739

This is mostly applying mental pattern matching, seeing how indentation is handled for parentheses in regular do blocks.

This may well miss some other cases that should be `BracketStyle`-aware, but it does fix the two instances I ran across.