### PR TITLE
format `do` commands like `do` blocks in expression contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Infix arrow command formations are formatted like usual operators.
   This fixes [Issue 748](https://github.com/tweag/ormolu/issues/748).
 
+* `do` arrow commands are formatted more flexibly. Fixes [Issue
+  753](https://github.com/tweag/ormolu/issues/753).
+
 ## Ormolu 0.2.0.0
 
 * Now standalone kind signatures are grouped with type synonyms. [Issue

--- a/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
@@ -60,3 +60,6 @@ foo
                   + x
                   * y -- Just do the calculation
               )
+
+traverseA_ f = proc (e, (xs, s)) ->
+  (| foldlA' (\() x -> do (e, (x, s)) >- f; () >- returnA) |) () xs

--- a/data/examples/declaration/value/function/arrow/proc-do-complex.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex.hs
@@ -47,3 +47,6 @@ foo
           returnA -< (i +
                       x *
                       y) -- Just do the calculation
+
+traverseA_ f = proc (e, (xs, s)) ->
+  (| foldlA' (\() x -> do { (e, (x, s)) >- f; () >- returnA }) |) () xs

--- a/data/examples/declaration/value/function/arrow/proc-do-simple1-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-simple1-out.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE Arrows #-}
 
-bar f = proc a -> do
-  b <- f -< a
+bar f = proc a -> do b <- f -< a
 
 barbar f g = proc a -> do
   b <- f -< a

--- a/data/examples/declaration/value/function/arrow/proc-do-simple2-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-simple2-out.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE Arrows #-}
 
-foo f = proc a -> do
-  f -< a
+foo f = proc a -> do f -< a
 
 bazbaz f g h = proc (a, b, c) -> do
   x <-
@@ -20,3 +19,5 @@ bazbaz f g h = proc (a, b, c) -> do
   returnA
     -<
       (x, y, z)
+
+bar f = proc x -> do { f -< x } <+> do f -< x

--- a/data/examples/declaration/value/function/arrow/proc-do-simple2.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-simple2.hs
@@ -18,3 +18,5 @@ bazbaz f g h = proc (a, b, c) ->
        )
      returnA -<
        (x, y, z)
+
+bar f = proc x -> do {f -< x} <+> do f -< x


### PR DESCRIPTION
Closes #753 

As we no longer always insert `newline`s after the "do" in `do` commands, we also have to ensure that the left hand side has braces if necessary.