### PR TITLE
Format deriving clauses with Haddocks idempotently

### DIFF
--- a/data/examples/declaration/deriving/haddocks-out.hs
+++ b/data/examples/declaration/deriving/haddocks-out.hs
@@ -1,0 +1,11 @@
+data A = A
+  deriving
+    ( -- | B
+      Eq
+    )
+
+data B = B
+  deriving
+    ( -- | test
+      Eq
+    )

--- a/data/examples/declaration/deriving/haddocks.hs
+++ b/data/examples/declaration/deriving/haddocks.hs
@@ -1,0 +1,6 @@
+data A = A
+  -- | B
+  deriving (Eq)
+
+data B = B
+  deriving ({- | test -} Eq)

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -28,6 +28,7 @@ module Ormolu.Printer.Combinators
     located',
     realLocated,
     switchLayout,
+    enterLayout,
     Layout (..),
     vlayout,
     getLayout,


### PR DESCRIPTION
Closes #752 

There might be other constructs that are written in a single line by the user, but contain Haddock comments, such that they will have to printed using the multiline layout.