### PR TITLE
Include git info in executable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,9 +7,15 @@ let
     src = pkgs.haskell-nix.haskellLib.cleanGit {
       name = "ormolu";
       src = ./.;
+      keepGitDir = true;
     };
     projectFileName = "cabal.project";
     compiler-nix-name = ormoluCompiler;
+    modules = [({pkgs, ...}: {
+      packages.ormolu.components.exes.ormolu.build-tools =
+        pkgs.lib.mkForce [ pkgs.buildPackages.buildPackages.gitReallyMinimal ];
+      packages.ormolu.components.exes.ormolu.extraSrcFiles = [ ".git/**/*" ];
+    })];
   };
   ormolu = hsPkgs.ormolu;
   ormoluExe = ormolu.components.exes.ormolu;


### PR DESCRIPTION
Closes #342 

Adapted from https://github.com/input-output-hk/haskell.nix/issues/1111.

It does not work with cross compilation to Windows. I tried to debug using [githash](https://hackage.haskell.org/package/githash-0.1.6.1/docs/GitHash.html#v:tGitInfoCwdTry) (which allows to display error messages why git info inclusion failed), and it can't find the `git` executable. Right now, Template Haskell + cross compilation is mostly dark magic for me, so I am not sure how to investigate further.