### PR TITLE
Release binaries: store targets of symlinks

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Prepare upload
         run: |
           cd result/bin
-          7z a ${{ github.workspace }}/ormolu.zip .
+          7z a -l ${{ github.workspace }}/ormolu.zip .
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously, `ormolu-Windows.zip` would contain symlinks to `/nix/store`. See [new](https://github.com/amesgen/ormolu/releases/tag/test-haskell.nix-5) vs [old](https://github.com/amesgen/ormolu/releases/tag/test-haskell.nix-latest).