### PR TITLE
Render empty case expressions with braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Opt-in support to respect default-extensions and default-language
   from .cabal files. [Issue 517](https://github.com/tweag/ormolu/issues/517).
 
+* Empty case expressions are now rendered with braces. [Issue
+  765](https://github.com/tweag/ormolu/issues/765).
+
 ## Ormolu 0.2.0.0
 
 * Now standalone kind signatures are grouped with type synonyms. [Issue

--- a/data/examples/declaration/value/function/case-empty-out.hs
+++ b/data/examples/declaration/value/function/case-empty-out.hs
@@ -1,0 +1,6 @@
+absurd x = case x of {}
+absurd = \case {}
+absurd x = case x of {}
+absurd = \case {}
+
+foo = case () of {} 1

--- a/data/examples/declaration/value/function/case-empty.hs
+++ b/data/examples/declaration/value/function/case-empty.hs
@@ -1,0 +1,6 @@
+absurd x = case x of
+absurd = \case
+absurd x = case x of {}
+absurd = \case {}
+
+foo = case () of {} 1

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -108,11 +108,13 @@ p_matchGroup' ::
   -- | Match group
   MatchGroup GhcPs (Located body) ->
   R ()
-p_matchGroup' placer render style MG {..} = do
+p_matchGroup' placer render style mg@MG {..} = do
   let ob = case style of
-        Case -> id
-        LambdaCase -> id
+        Case -> bracesIfEmpty
+        LambdaCase -> bracesIfEmpty
         _ -> dontUseBraces
+        where
+          bracesIfEmpty = if isEmptyMatchGroup mg then useBraces else id
   -- Since we are forcing braces on 'sepSemi' based on 'ob', we have to
   -- restore the brace state inside the sepsemi.
   ub <- bool dontUseBraces useBraces <$> canUseBraces


### PR DESCRIPTION
Closes #765

We could detect whether `{}` is present in the source file via `AnnOpen`/`AnnClose`, but I think it is actually nice to format empty case expressions with `{}` in all cases.