### PR TITLE
Build self-contained macOS binary

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,6 +2,9 @@ name: Build binaries
 on:
   release:
     types: [published]
+defaults:
+  run:
+    shell: bash
 jobs:
   build:
     strategy:
@@ -9,13 +12,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            attr: projectCross.musl64.hsPkgs.ormolu.components.exes.ormolu
             targetOs: Linux
           - os: macOS-latest
-            attr: ormoluExe
             targetOs: macOS
           - os: ubuntu-latest
-            attr: projectCross.mingwW64.hsPkgs.ormolu.components.exes.ormolu
             targetOs: Windows
     name: Build binary for ${{ matrix.targetOs }}
     runs-on: ${{ matrix.os }}
@@ -27,7 +27,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             substituters = https://cache.nixos.org https://hydra.iohk.io
       - name: Build binary
-        run: nix-build -A ${{ matrix.attr }}
+        run: nix-build -A binaries.${{ matrix.targetOS }}
       - name: Prepare upload
         run: |
           cd result/bin
@@ -40,3 +40,24 @@ jobs:
           asset_path: ormolu.zip
           asset_name: ormolu-${{ matrix.targetOs }}.zip
           asset_content_type: application/zip
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+    name: Test built binaries
+    runs-on: ${{ matrix.os }}
+    needs: build
+    steps:
+      - name: Download and extract binary
+        run: |
+          curl -sL https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/ormolu-${{ runner.os }}.zip > ormolu.zip
+          7z e ormolu.zip
+      - name: Basic functionality tests
+        run: |
+          ./ormolu --version
+          echo "data A = A" > test.hs
+          ./ormolu -m check test.hs

--- a/default.nix
+++ b/default.nix
@@ -63,7 +63,6 @@ let
             else null;
       }) ormolizablePackages;
 in {
-  projectCross = hsPkgs.projectCross;
   ormoluLib = ormolu.components.library;
   ormoluTests = ormolu.checks.tests;
   ormolu = ormoluExe; # for compatibility
@@ -175,5 +174,20 @@ in {
       mkdir "$out"
       find . -name '*.hs' -exec cp --parents {} $out \;
     '';
+  };
+  binaries = {
+    Linux = hsPkgs.projectCross.musl64.hsPkgs.ormolu.components.exes.ormolu;
+    macOS = pkgs.runCommand "ormolu-macOS" {
+      buildInputs = [ pkgs.macdylibbundler ];
+    } ''
+      mkdir -p $out/bin
+      cp ${ormoluExe}/bin/ormolu $out/bin/ormolu
+      chmod 755 $out/bin/ormolu
+      dylibbundler -b \
+        -x $out/bin/ormolu \
+        -d $out/bin \
+        -p '@executable_path'
+    '';
+    Windows = hsPkgs.projectCross.mingwW64.hsPkgs.ormolu.components.exes.ormolu;
   };
 }


### PR DESCRIPTION
I stumbled upon [this blogpost](https://www.joachim-breitner.de/blog/776-Distributing_Haskell_programs_in_a_multi-platform_zip_file), which mentions [macdylibbundler](https://github.com/auriamg/macdylibbundler), which is *exactly* what we are looking for. :tada:

Example run in my fork:

 - https://github.com/amesgen/ormolu/actions/runs/1267537364
 - https://github.com/amesgen/ormolu/releases/tag/test-macos-6

But this can also be tested in this repo by creating (and then deleting) a temporary (pre-)release.