### PR TITLE
Minimize binary sizes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,9 @@ let
     projectFileName = "cabal.project";
     compiler-nix-name = ormoluCompiler;
     modules = [({pkgs, ...}: {
+      dontStrip = false;
+      dontPatchELF = false;
+      enableDeadCodeElimination = true;
       packages.ormolu.components.exes.ormolu.build-tools =
         pkgs.lib.mkForce [ pkgs.buildPackages.buildPackages.gitReallyMinimal ];
       packages.ormolu.components.exes.ormolu.extraSrcFiles = [ ".git/**/*" ];


### PR DESCRIPTION
Closes #792. See [here](https://input-output-hk.github.io/haskell.nix/reference/modules/) for documentation about these options.

Test run:

https://github.com/amesgen/ormolu/releases/tag/smaller-binaries
https://github.com/amesgen/ormolu/actions/runs/1276056492

Results:

 - Linux: 25.9 MB → 20.1 MB
 - macOS: 35.6 MB → 25.7 MB
 - Windows: 81.5 MB → 54.7 MB

---

Credits for this suggestion go to @ilyakooo0!