### PR TITLE
Allow ormolu -m check for STDIN content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Allow check mode (`-m check`) when working with STDIN input ([Issue 634](
+  https://github.com/tweag/ormolu/issues/634)).
+
 ## Ormolu 0.3.0.1
 
 * Improvements to `.cabal` file handling:

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -97,9 +97,6 @@ ormolu cfgWithIndices path str = do
 
 -- | Load a file and format it. The file stays intact and the rendered
 -- version is returned as 'Text'.
---
--- > ormoluFile cfg path =
--- >   liftIO (readFile path) >>= ormolu cfg path
 ormoluFile ::
   MonadIO m =>
   -- | Ormolu configuration
@@ -112,9 +109,6 @@ ormoluFile cfg path =
   readFileUtf8 path >>= ormolu cfg path . T.unpack
 
 -- | Read input from stdin and format it.
---
--- > ormoluStdin cfg =
--- >   liftIO (hGetContents stdin) >>= ormolu cfg "<stdin>"
 ormoluStdin ::
   MonadIO m =>
   -- | Ormolu configuration
@@ -122,7 +116,7 @@ ormoluStdin ::
   -- | Resulting rendition
   m Text
 ormoluStdin cfg =
-  liftIO getContents >>= ormolu cfg "<stdin>"
+  getContentsUtf8 >>= ormolu cfg "<stdin>" . T.unpack
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/src/Ormolu/Utils/IO.hs
+++ b/src/Ormolu/Utils/IO.hs
@@ -3,11 +3,13 @@
 module Ormolu.Utils.IO
   ( writeFileUtf8,
     readFileUtf8,
+    getContentsUtf8,
   )
 where
 
 import Control.Exception (throwIO)
 import Control.Monad.IO.Class
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Data.Text (Text)
 import qualified Data.Text.Encoding as TE
@@ -20,4 +22,13 @@ writeFileUtf8 p = liftIO . B.writeFile p . TE.encodeUtf8
 -- | Read an entire file strictly into a 'Text' using UTF8 and
 -- ignoring native line ending conventions.
 readFileUtf8 :: MonadIO m => FilePath -> m Text
-readFileUtf8 p = liftIO $ either throwIO pure . TE.decodeUtf8' =<< B.readFile p
+readFileUtf8 p = liftIO (B.readFile p) >>= decodeUtf8
+
+-- | Read stdin as UTF8-encoded 'Text' value.
+getContentsUtf8 :: MonadIO m => m Text
+getContentsUtf8 = liftIO B.getContents >>= decodeUtf8
+
+-- | A helper function for decoding a strict 'ByteString' into 'Text'. It is
+-- strict and fails immediately if decoding encounters a problem.
+decodeUtf8 :: MonadIO m => ByteString -> m Text
+decodeUtf8 = liftIO . either throwIO pure . TE.decodeUtf8'


### PR DESCRIPTION
Closes #634 

+ Removes the `ormoluStdin` function
+ Generalizes the `ormoluFile` function, to work on either a real file path,
  or the special string `"<stdin>"`
+ Refactors the `formatOne` function (to avoid repetitions)

**Identified drawbacks**

+ Real file / STDIN switch is made with a comparison to a special string
  (`"<stdin>"`)
+ When using the `in-place` mode with STDIN input, the error message is
  shown only after that the STDIN content has been read