### PR TITLE
Semi-preserve invalid Haddock comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   if all guards together occupy more than one line. The body of each guard
   is also indented one level deeper in that case. [Issue
   712](https://github.com/tweag/ormolu/issues/712).
+* Invalid Haddock comments are no longer silently deleted, but rather converted
+  into regular comments. [Issue 474](https://github.com/tweag/ormolu/issues/474).
 
 ## Ormolu 0.3.0.1
 

--- a/data/examples/other/invalid-haddock-out.hs
+++ b/data/examples/other/invalid-haddock-out.hs
@@ -1,0 +1,17 @@
+test = undefined
+  where
+    a ::
+      -- foo
+      Int ->
+      -- misplaced
+      Int
+    a = undefined
+
+test = undefined
+  where
+    -- Comment
+    a = undefined
+
+    -- A multiline
+    -- comment
+    b = b

--- a/data/examples/other/invalid-haddock-weird-out.hs
+++ b/data/examples/other/invalid-haddock-weird-out.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+foo = foo -- # ${

--- a/data/examples/other/invalid-haddock-weird.hs
+++ b/data/examples/other/invalid-haddock-weird.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+foo = foo -- |# ${

--- a/data/examples/other/invalid-haddock.hs
+++ b/data/examples/other/invalid-haddock.hs
@@ -1,0 +1,17 @@
+test = undefined
+  where
+    a ::
+      -- ** foo
+      Int ->
+      -- | misplaced
+      Int
+    a = undefined
+
+test = undefined
+  where
+    -- | Comment
+    a = undefined
+
+    -- | A multiline
+    -- comment
+    b = b

--- a/expected-failures/intero.txt
+++ b/expected-failures/intero.txt
@@ -1,6 +1,6 @@
 Found .cabal file intero.cabal, but it did not mention Setup.hs
 src/InteractiveUI.hs
-@@ -3746,6 +3746,7 @@
+@@ -3747,6 +3747,7 @@
                   stdout
                   ( text "Unable to list source for"
                       <+> ppr pan

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -116,7 +116,7 @@ parseModuleSnippet Config {..} dynFlags path rawInput = liftIO $ do
             Just err -> Left err
             Nothing ->
               let (stackHeader, pragmas, comments) =
-                    mkCommentStream input pstate
+                    mkCommentStream input pstate hsModule
                in Right
                     ParseResult
                       { prParsedSource = hsModule,


### PR DESCRIPTION
Closes #474

Overview:

 - `comment_q` and `annotation_comments` contain all comments, i.e. regular Haddock comments (which are also present in the AST via `HsDocString`), invalid Haddock comments (which are not present in the AST) and regular, non-Haddock comments.
 - We now print the invalid Haddock comments as regular comments, where we have to be careful:
    - Multiline invalid Haddock comments are not parsed as multiple single-line comments (in contrast to regular comments). This requires some changes in `mkComment` and AST diffing.
    - We have to insert a space after the hyphens if the comment does not start with a space to prevent a weird issue (see `invalid-haddock-weird.hs`).