### PR TITLE
Add commit hash alias for Ormolu Live

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ to `false`.
 ### Ormolu Live
 
 On every new commit to `master`, [Ormolu Live](./ormolu-live) is deployed to
-https://ormolu-live.tweag.io.
+https://ormolu-live.tweag.io. Older versions are available at
+https://COMMITHASH--ormolu-live.netlify.app.
 
 ### Editor integration
 

--- a/ormolu-live/deploy.sh
+++ b/ormolu-live/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail
-[[ $BUILDKITE_BRANCH == "master" ]] && FLAGS="--prod" || true
-netlify deploy $FLAGS -d $(nix-build -A ormoluLive.website)
+ORMOLU_LIVE=$(nix-build -A ormoluLive.website)
+netlify deploy --alias=$(git log -1 --format="%H") -d $ORMOLU_LIVE
+netlify deploy --prod -d $ORMOLU_LIVE


### PR DESCRIPTION
Trivial workaround as `--prod` and `--alias` can not be combined.