### PR TITLE
Use custom macdylibbundler

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,7 +13,7 @@ jobs:
         include:
           - os: ubuntu-latest
             targetOs: Linux
-          - os: macOS-10.15
+          - os: macOS-latest
             targetOs: macOS
           - os: ubuntu-latest
             targetOs: Windows
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v15
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -11,6 +11,15 @@ let
           sha256 = "733f00f0a1651c9d5409d9162e6f94f0a3e61463628925d3d6ef66be60ec14a6";
         };
       });
+      macdylibbundler = super.macdylibbundler.overrideAttrs (old: {
+        version = "custom";
+        src = super.fetchFromGitHub {
+          owner = "amesgen";
+          repo = "macdylibbundler";
+          rev = "f98d06980e718947b1d4afed3586f475056563b6";
+          sha256 = "0qqgcp14vvr6r5yqj96hy3klc2dkcqyq909az30ql4y879r3xm62";
+        };
+      });
     })
   ];
 in


### PR DESCRIPTION
Closes #804

We use a custom version of macdylibbundler, namely [`ce13cb5`](https://github.com/amesgen/macdylibbundler/commit/ce13cb585ead5237813b85e68fe530f085fc0a9e) (which was the version before the nixpkgs bump via #779) with [`dd677ce`](https://github.com/auriamg/macdylibbundler/commit/dd677cec46b1eb8f096906d71c67572de491e8c2) for macOS 11 compat on top. Some later commit introduces an issue which prevents transitive dylib dependencies from being patched (see [here](https://github.com/amesgen/ormolu/actions/runs/1467718275)). If I had access to a macOS machine, it would be interesting to bisect to find out which exact commit introduces the issue.

Test run: https://github.com/amesgen/ormolu/actions/runs/1469420664 (runs on 10.15, but I also ensured that building on 11 works fine)
