### PR TITLE
Fix Ormolu Live by rebuilding all GHCJS dependencies by upgrading haskell.nix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,6 @@ steps:
       if [[ $BUILDKITE_BRANCH == "master" ]]; then
         ormolu-live/deploy.sh
       else
-        nix-build -A ormoluLive.ormoluLive --arg ormoluLiveLink false
+        nix-build -A ormoluLive.ormoluLive --arg ormoluLiveLink false -j 1
       fi
     timeout: 100

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -4,13 +4,6 @@ let
   inherit (haskellNix) nixpkgsArgs;
   overlays = nixpkgsArgs.overlays ++ [
     (self: super: {
-      closurecompiler = super.closurecompiler.overrideAttrs (old: rec {
-        version = "20211107";
-        src = super.fetchurl {
-          url = "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v${version}/closure-compiler-v${version}.jar";
-          sha256 = "733f00f0a1651c9d5409d9162e6f94f0a3e61463628925d3d6ef66be60ec14a6";
-        };
-      });
       macdylibbundler = super.macdylibbundler.overrideAttrs (old: {
         version = "custom";
         src = super.fetchFromGitHub {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "499ab5b07582568d3b9ca821ee97622a03ab38c6",
-        "sha256": "116bb82fjn4qzqpaljqiriac1xgkhjpv96hh3hrjgz83xaihy8mm",
+        "rev": "64cd5f70ce0d619390039a1a3d57c442552b0924",
+        "sha256": "14v09rh7apjs5r6px7h0dglrz56mzj0zp9hq8ji8y4s2422k1h0l",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/499ab5b07582568d3b9ca821ee97622a03ab38c6.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/64cd5f70ce0d619390039a1a3d57c442552b0924.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/ormolu-live/deploy.sh
+++ b/ormolu-live/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail
-ORMOLU_LIVE=$(nix-build -A ormoluLive.website)
+ORMOLU_LIVE=$(nix-build -A ormoluLive.website -j 1)
 netlify deploy --alias=$(git log -1 --format="%H") -d $ORMOLU_LIVE
 netlify deploy --prod -d $ORMOLU_LIVE


### PR DESCRIPTION
It turns out that closure compiler is not at fault for Ormolu Live not working, so #834 did not matter. Locally, Ormolu Live works perfectly fine, and even disabling closure compiler on CI does not fix the issue, so my best guess is that some dependency got corrupted and cached. This PR simply bumps haskell.nix which includes (probably unrelated) changes of GHCJS which results in all dependencies being rebuilt. With this, the Ormolu Live built on CI now works again: https://8afdf0d5bb5e7d9b24e2811df9c96b94b388cc44--ormolu-live.netlify.app/ (note that this is a version without closure compiler, so it takes ages to load).

Also, I set `-j`/`--max-jobs` to `1` as excessive parallelism is sometimes involved in such issues. It won't matter for usual CI run times as rebuilding all GHCJS dependencies should happen fairly rarely.