### PR TITLE
Fix type synonyms with comment before `=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   escaped with a backslash `\`. [Issue
   816](https://github.com/tweag/ormolu/issues/816).
 
+* Type synonyms and families are now formatted correctly when the equals sign
+  is preceded by a comment. [Issue 829](
+  https://github.com/tweag/ormolu/issues/829).
+
 ## Ormolu 0.4.0.0
 
 * When a guard is located on its own line, the body associated with this

--- a/data/examples/declaration/type-families/closed-type-family/multi-line-out.hs
+++ b/data/examples/declaration/type-families/closed-type-family/multi-line-out.hs
@@ -23,3 +23,8 @@ type family
   F Bool =
     Char
   F a = String
+
+type family F a where
+  F a -- foo
+    =
+    a

--- a/data/examples/declaration/type-families/closed-type-family/multi-line.hs
+++ b/data/examples/declaration/type-families/closed-type-family/multi-line.hs
@@ -12,3 +12,7 @@ type family F a
   F Bool =
            Char
   F a    = String
+
+type family F a where
+  F a -- foo
+    = a

--- a/data/examples/declaration/type-synonyms/multi-line-out.hs
+++ b/data/examples/declaration/type-synonyms/multi-line-out.hs
@@ -16,3 +16,7 @@ type API =
   "route1" :> ApiRoute1
     :<|> "route2" :> ApiRoute2 -- comment here
     :<|> OmitDocs :> "i" :> ASomething API
+
+type A -- foo
+  =
+  B

--- a/data/examples/declaration/type-synonyms/multi-line.hs
+++ b/data/examples/declaration/type-synonyms/multi-line.hs
@@ -15,3 +15,6 @@ type API
   = "route1" :> ApiRoute1
       :<|> "route2" :> ApiRoute2 -- comment here
       :<|> OmitDocs :> "i" :> ASomething API
+
+type A -- foo
+  = B

--- a/src/Ormolu/Printer/Meat/Declaration/Type.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Type.hs
@@ -36,9 +36,10 @@ p_synDecl name fixity HsQTvs {..} t = do
       True
       (p_rdrName name)
       (map (located' p_hsTyVarBndr) hsq_explicit)
-  space
-  equals
-  if hasDocStrings (unLoc t)
-    then newline
-    else breakpoint
-  inci (located t p_hsType)
+  inci $ do
+    space
+    equals
+    if hasDocStrings (unLoc t)
+      then newline
+      else breakpoint
+    located t p_hsType

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -99,10 +99,11 @@ p_tyFamInstEqn FamEqn {..} = do
         True
         (p_rdrName feqn_tycon)
         (p_lhsTypeArg <$> feqn_pats)
-    space
-    equals
-    breakpoint
-    inci (located feqn_rhs p_hsType)
+    inci $ do
+      space
+      equals
+      breakpoint
+      located feqn_rhs p_hsType
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Closes #829