### PR TITLE
Remove `unix` dependency

### DIFF
--- a/extract-hackage-info/extract-hackage-info.cabal
+++ b/extract-hackage-info/extract-hackage-info.cabal
@@ -19,7 +19,6 @@ executable extract-hackage-info
         aeson >= 1.0 && <3.0,
         pcre2 >= 2.0 && < 3.0,
         directory >= 1.0 && < 2.0,
-        unix >= 2.0 && < 3.0,
         tagsoup >= 0.14 && < 0.15,
         text-format >= 0.3 && < 0.4,
         ghc-lib-parser >=9.2 && <9.3,

--- a/extract-hackage-info/src/Main.hs
+++ b/extract-hackage-info/src/Main.hs
@@ -35,9 +35,8 @@ import qualified Data.Text.Lazy as TL
 import GHC.Utils.Monad (mapMaybeM)
 import Options.Applicative
 import Ormolu.Fixity hiding (packageToOps, packageToPopularity)
-import System.Directory (listDirectory)
+import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (makeRelative, splitPath, (</>))
-import System.Posix.Files (getFileStatus, isDirectory)
 import Text.HTML.TagSoup (Tag (TagText), parseTags)
 import Text.HTML.TagSoup.Match (tagCloseLit, tagOpenLit)
 import Text.Regex.Pcre2 (capture, regex)
@@ -103,10 +102,9 @@ walkDir top exclude = do
   ds <- listDirectory top
   paths <- forM (filter (not . exclude) ds) $ \d -> do
     let path = top </> d
-    s <- getFileStatus path
-    if isDirectory s
-      then walkDir path exclude
-      else return [path]
+    doesDirectoryExist path >>= \case
+      True -> walkDir path exclude
+      False -> return [path]
   return (concat paths)
 
 getPackageName ::


### PR DESCRIPTION
This makes the build fail on Windows (noticed via `nix-build -A binaries.Windows`).