### PR TITLE
Add haskell-language-server to dev shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,7 +88,10 @@ in {
   inherit ormoluLib ormoluExe ormoluCompiler;
   dev = let shellFor = packages: hsPkgs.shellFor {
     inherit packages;
-    tools = { cabal = "latest"; };
+    tools = {
+      cabal = "latest";
+      haskell-language-server = "latest";
+    };
     withHoogle = false;
     exactDeps = false;
   }; in {


### PR DESCRIPTION
As I am now on NixOS, I started to actually use the nix shell. HLS is cached by the IOHK cache, so one does not have to compile HLS to get into the shell.