### PR TITLE
Cache operator fixity maps

### DIFF
--- a/ormolu-live/src/Main.hs
+++ b/ormolu-live/src/Main.hs
@@ -246,4 +246,4 @@ extractOrmoluException = \case
 -- | The default fixity map, using the default value for the popularity
 -- ratio threshold, and an empty list of dependencies.
 defaultFixityMap :: LazyFixityMap
-defaultFixityMap = buildFixityMap mempty defaultStrategyThreshold
+defaultFixityMap = buildFixityMap defaultStrategyThreshold mempty

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -105,7 +105,8 @@ library
         Cabal >=3.6 && <3.7,
         aeson >=1.0 && <3.0,
         template-haskell,
-        th-lift-instances >=0.1 && <0.2
+        th-lift-instances >=0.1 && <0.2,
+        MemoTrie >=0.6 && <0.7
 
     mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
 

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -65,7 +65,7 @@ ormolu ::
 ormolu cfgWithIndices path str = do
   let totalLines = length (lines str)
       cfg = regionIndicesToDeltas totalLines <$> cfgWithIndices
-      fixityMap = buildFixityMap (cfgDependencies cfg) defaultStrategyThreshold
+      fixityMap = buildFixityMap defaultStrategyThreshold (cfgDependencies cfg)
   (warnings, result0) <-
     parseModule' cfg fixityMap OrmoluParsingFailed path str
   when (cfgDebug cfg) $ do

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -38,7 +38,7 @@ spec = do
       ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
     it "extracts correct dependencies from ormolu.cabal (src/Ormolu/Config.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "src/Ormolu/Config.hs"
-      ciDependencies `shouldBe` Set.fromList ["Cabal", "Diff", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc-lib-parser", "mtl", "syb", "template-haskell", "text", "th-lift-instances"]
+      ciDependencies `shouldBe` Set.fromList ["Cabal", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc-lib-parser", "mtl", "syb", "template-haskell", "text", "th-lift-instances"]
     it "extracts correct dependencies from ormolu.cabal (tests/Ormolu/PrinterSpec.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "tests/Ormolu/PrinterSpec.hs"
       ciDependencies `shouldBe` Set.fromList ["base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "ormolu", "path", "path-io", "temporary", "text"]

--- a/tests/Ormolu/HackageInfoSpec.hs
+++ b/tests/Ormolu/HackageInfoSpec.hs
@@ -31,8 +31,8 @@ checkFixityMap
           packageToOps
           packageToPopularity
           bootPackages
-          (Set.fromList dependencies)
           threshold
+          (Set.fromList dependencies)
 
 -- | Build a fixity map from a custom package database, and then check the
 -- fixity of the specified subset of operators.
@@ -69,8 +69,8 @@ checkFixityMap'
           lPackageToOps'
           lPackageToPopularity'
           (Set.fromList highPrioPackages)
-          (Set.fromList dependencies)
           threshold
+          (Set.fromList dependencies)
       lPackageToOps' =
         Map.map Map.fromList $
           Map.fromList lPackageToOps


### PR DESCRIPTION
We cache the fixity map (depending on the package set). This speeds up scenarios when ormolu formats many files in the same package context, especially when they use non-standard operators (where #847 doesn't help).

## Timings

Test suite: from 2.0998s to 1.0540s

`nix-build -A hackageTests`: from 2m14,382s to 1m41,690s

### Formatting the same file multiple times

Test.hs:
```haskell
1++++++1
```

`ormolu` is 0.4.0.0, `./ormolu-pre` is before this PR and `./ormolu` is with this PR.

Formatting Test.hs once: No change as expected
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `ormolu -e Test.hs ` | 5.8 ± 0.6 | 5.1 | 8.5 | 1.00 |
| `./ormolu-pre Test.hs ` | 72.5 ± 1.6 | 70.3 | 81.5 | 12.56 ± 1.31 |
| `./ormolu Test.hs ` | 72.6 ± 1.0 | 71.1 | 75.2 | 12.57 ± 1.29 |

Formatting Test.hs 10x and 100x: big speedups

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `ormolu -e Test.hs ... ` | 21.1 ± 1.2 | 19.6 | 24.0 | 1.00 |
| `./ormolu-pre Test.hs ... ` | 411.7 ± 8.1 | 403.9 | 430.5 | 19.52 ± 1.15 |
| `./ormolu Test.hs ... ` | 80.9 ± 0.8 | 79.3 | 83.5 | 3.84 ± 0.22 |

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `ormolu -e Test.hs ... ` | 159.3 ± 3.5 | 155.6 | 169.3 | 1.00 |
| `./ormolu-pre Test.hs ... ` | 3995.6 ± 96.0 | 3822.2 | 4158.4 | 25.08 ± 0.81 |
| `./ormolu Test.hs ... ` | 210.6 ± 2.6 | 206.3 | 214.9 | 1.32 ± 0.03 |
