### PR TITLE
Ormolu Live: Propagate fixity map cache at startup

### DIFF
--- a/ormolu-live/ormolu-live.cabal
+++ b/ormolu-live/ormolu-live.cabal
@@ -7,7 +7,7 @@ maintainer: Alexander Esgen <alexander.esgen@tweag.io>
 executable ormolu-live
   ghc-options: -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -fno-warn-name-shadowing -Wmissing-deriving-strategies -Wunused-packages
   ghcjs-options: -dedupe
-  default-extensions: BlockArguments CPP DeriveGeneric DerivingStrategies LambdaCase NamedFieldPuns OverloadedLabels OverloadedStrings RecordWildCards TemplateHaskell TypeApplications ViewPatterns
+  default-extensions: BlockArguments CPP DeriveGeneric DerivingStrategies FlexibleContexts LambdaCase NamedFieldPuns OverloadedLabels OverloadedStrings RecordWildCards TemplateHaskell TypeApplications ViewPatterns
   main-is: Main.hs
   build-depends:
       base


### PR DESCRIPTION
Previously, as soon as there was any operator in the input, it would become horribly slow. With #848, it is only slow for the first time an operator is entered, and fast afterwards. With this PR, we now do this at startup/loading time (which is already so long that an extra 300ms is probably worth the snapiness afterwards).