### PR TITLE
Rename Ormolu.Fixity.Types to Ormolu.Fixity.Internal

### DIFF
--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -74,7 +74,7 @@ library
         Ormolu.Printer.Meat.Type
         Ormolu.Printer.Operators
         Ormolu.Fixity
-        Ormolu.Fixity.Types
+        Ormolu.Fixity.Internal
         Ormolu.Printer.SpanStream
         Ormolu.Processing.Common
         Ormolu.Processing.Cpp

--- a/src/Ormolu/Fixity.hs
+++ b/src/Ormolu/Fixity.hs
@@ -32,7 +32,7 @@ import Data.MemoTrie (HasTrie, memo)
 import Data.Semigroup (sconcat)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Ormolu.Fixity.Types
+import Ormolu.Fixity.Internal
 #if FIXITY_TH
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Language.Haskell.TH.Syntax as TH

--- a/src/Ormolu/Fixity/Internal.hs
+++ b/src/Ormolu/Fixity/Internal.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Ormolu.Fixity.Types
+module Ormolu.Fixity.Internal
   ( FixityDirection (..),
     FixityInfo (..),
     defaultFixityInfo,

--- a/tests/Ormolu/OpTreeSpec.hs
+++ b/tests/Ormolu/OpTreeSpec.hs
@@ -5,7 +5,7 @@ import Data.Maybe (fromJust)
 import GHC.Types.Name (mkOccName, varName)
 import GHC.Types.Name.Reader (mkRdrUnqual)
 import Ormolu.Fixity
-import Ormolu.Fixity.Types (LazyFixityMap (..))
+import Ormolu.Fixity.Internal (LazyFixityMap (..))
 import Ormolu.Printer.Operators
 import Test.Hspec
 


### PR DESCRIPTION
I think `Internal` makes it more obvious that the module is not part of the
public API (e.g. the data constructor of `LazyFixityMap` should normally
stay hidden).