### PR TITLE
Move script tag into the body

### DIFF
--- a/ormolu-live/www/index.html
+++ b/ormolu-live/www/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Ormolu Live</title>
-    <script src="all.min.js"></script>
   </head>
   <body>
+    <script src="all.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Closes #862 

I managed to reproduce the issue in Chrome (some caching stuff apparently prevented me from encountering it earlier) and ensured moving the script tag into the body (such that it is already part of the DOM when the script loads) fixes the issue (which is a best practice for exactly this reason).