### PR TITLE
Add back sitcc to ExplicitTuple.p_arg

### DIFF
--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -705,9 +705,10 @@ p_hsExpr' s = \case
         isMissing = \case
           Missing _ -> True
           _ -> False
-        p_arg = \case
-          Present _ x -> located x p_hsExpr
-          Missing _ -> pure ()
+        p_arg =
+          sitcc . \case
+            Present _ x -> located x p_hsExpr
+            Missing _ -> pure ()
         parens' =
           case boxity of
             Boxed -> parens


### PR DESCRIPTION
`sitcc` was removed as part of the `ghc-lib-parser-9.2` upgrade (#779), but it looks like that was erroneous; the only change that needed to happen in `p_larg` was the removal of `located`. This causes problems in `fourmolu` with leading commas (see https://github.com/fourmolu/fourmolu/issues/148#issuecomment-1086988846), and this fixes it. I'm not quite sure how to come up with a failing test case for this in ormolu, but I'm fairly certain that the removal of `sitcc` is incorrect, and may cause other unexpected behaviors.