### PR TITLE
Fix stack for ormolu-live + extract-hackage-info

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.28
+resolver: lts-19.2
 
 packages:
 - '.'


### PR DESCRIPTION
Sorry, forgot to try a `stack build`. Turns out `ormolu-live` and `extract-hackage-info` need newer versions of libraries than lts 18 provides.

Alternatively, we could keep it at lts-18 and add everything as extra-deps, but this seemed simpler, even if lts-19 is still rather new.