### PR TITLE
Cabal file lookup: fix handling of `hs-source-dirs: .`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Indent closing bracket for list comprehensions in `do` blocks.
   [Issue 893](https://github.com/tweag/ormolu/issues/893).
 
+* Fix `hs-source-dirs: .` resulting in failing to find a `.cabal` file for a
+  Haskell source file. [Issue 909](https://github.com/tweag/ormolu/issues/909).
+
 ## Ormolu 0.5.0.0
 
 * Changed the way operator fixities and precedences are inferred.

--- a/data/cabal-tests/Bar.hs
+++ b/data/cabal-tests/Bar.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+import Data.List qualified as List

--- a/data/cabal-tests/Foo.hs
+++ b/data/cabal-tests/Foo.hs
@@ -1,0 +1,3 @@
+module Foo where
+
+import Data.List qualified as List

--- a/data/cabal-tests/test.cabal
+++ b/data/cabal-tests/test.cabal
@@ -1,0 +1,13 @@
+cabal-version: 2.4
+name: test
+version: 0
+
+library
+  exposed-modules: Foo
+  hs-source-dirs: .
+  default-extensions: ImportQualifiedPost
+
+executable app
+  main-is: Main
+  other-modules: Bar
+  default-extensions: ImportQualifiedPost

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -14,6 +14,7 @@ build-type:         Simple
 extra-source-files:
     data/**/*.hs
     data/**/*.txt
+    data/**/*.cabal
     extract-hackage-info/hackage-info.json
 
 extra-doc-files:

--- a/src/Ormolu/Utils/Cabal.hs
+++ b/src/Ormolu/Utils/Cabal.hs
@@ -168,7 +168,7 @@ getExtensionAndDepsMap cabalFile GenericPackageDescription {..} =
 
     extractFromBuildInfo extraModules BuildInfo {..} = (,(exts, deps)) $ do
       m <- extraModules ++ (ModuleName.toFilePath <$> otherModules)
-      (takeDirectory cabalFile </>) <$> prependSrcDirs (dropExtensions m)
+      normalise . (takeDirectory cabalFile </>) <$> prependSrcDirs (dropExtensions m)
       where
         prependSrcDirs f
           | null hsSourceDirs = [f]

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -42,3 +42,13 @@ spec = do
     it "extracts correct dependencies from ormolu.cabal (tests/Ormolu/PrinterSpec.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "tests/Ormolu/PrinterSpec.hs"
       ciDependencies `shouldBe` Set.fromList ["QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
+
+    it "handles `hs-source-dirs: .`" $ do
+      CabalInfo {..} <- parseTestCabalInfo "Foo.hs"
+      ciDynOpts `shouldContain` [DynOption "-XImportQualifiedPost"]
+    it "handles empty hs-source-dirs" $ do
+      CabalInfo {..} <- parseTestCabalInfo "Bar.hs"
+      ciDynOpts `shouldContain` [DynOption "-XImportQualifiedPost"]
+  where
+    parseTestCabalInfo f =
+      parseCabalInfo "data/cabal-tests/test.cabal" ("data/cabal-tests" </> f)


### PR DESCRIPTION
Closes #909

Also added regression tests for this and the empty/missing `hs-source-dirs` bug I fixed in #783. 