### PR TITLE
Cache `.cabal` file parsing and processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * Comments in closed type family declarations are now indented correctly.
   [Issue 913](https://github.com/tweag/ormolu/issues/913).
 
+* Cache `.cabal` file parsing and processing when given multiple input files in
+  the same project. This results in dramatic speedups on projects which have
+  both huge `.cabal` files and a large number of individual modules. [Issue
+  897](https://github.com/tweag/ormolu/issues/897).
+
 ## Ormolu 0.5.0.0
 
 * Changed the way operator fixities and precedences are inferred.


### PR DESCRIPTION
Closes #897 

I tested this by creating a cabal project with 10000 trivial modules (just `module A42 where`), all listed in the `.cabal` file. Formatting 1000 of those modules takes

 - ~100s before this PR
 - 8s with this PR
 - 150ms with `--no-cabal`

Eventlog profiling yields that the big majority of the remaining 8s is spent in `findCabalFile`, which seems reasonable as it uses `listDirectory` to find a `.cabal` file, and the directory contains 10000 files. We could make it smarter by taking all input files into account at once, but I think this really is an edge case of this particular test setup, so I didn't go ahead with it.

In general, we now use `NOINLINE` `IORef`s for caching in two places -- if it ever turns out to be necessary, we could take the more principled but invasive approach of calculating such shared data upfront instead of maintaining ad-hoc caches. But I don't think we have to do that now.