### PR TITLE
Sort imports by package qualifier if present (Fixes #905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Imports are now sorted by package qualifier, if one is present.
+  [Issue 905](https://github.com/tweag/ormolu/issues/905).
+
 ## Ormolu 0.5.0.1
 
 * Fixed a bug in the diff printing functionality. [Issue

--- a/data/examples/import/sorted-package-imports-out.hs
+++ b/data/examples/import/sorted-package-imports-out.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE PackageImports #-}
+
+import D
+import "a" Ab
+import "b" Aa
+import "b" Bb
+import "c" Ba

--- a/data/examples/import/sorted-package-imports.hs
+++ b/data/examples/import/sorted-package-imports.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE PackageImports #-}
+
+import "b" Aa
+import "a" Ab
+import "c" Ba
+import D
+import "b" Bb

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -64,8 +64,8 @@ combineImports (L lx ImportDecl {..}) (L _ y) =
 -- the same 'ImportId' they can be merged.
 data ImportId = ImportId
   { importIsPrelude :: Bool,
-    importIdName :: ModuleName,
     importPkgQual :: Maybe LexicalFastString,
+    importIdName :: ModuleName,
     importSource :: IsBootInterface,
     importSafe :: Bool,
     importQualified :: Bool,


### PR DESCRIPTION
This fixes #905 by sorting imports first by package qualifier,
if any are included, and then by module name. Imports without
package qualifiers are always sorted before those with.