### PR TITLE
Fix typo in ormolu-live html script tag

### DIFF
--- a/ormolu-live/www/index.html
+++ b/ormolu-live/www/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Ormolu Live</title>
-    <scipt src="clipboard.min.js"></scipt>
+    <script src="clipboard.min.js"></script>
   </head>
   <body>
     <script src="all.min.js"></script>


### PR DESCRIPTION
In my last PR (#918) I accidentally mistyped `script` as `scipt` in ormolu-live's `index.html`. This fixes that.