### PR TITLE
[Ormolu-Live] Add line numbers to editor (Fixes #908)

### DIFF
--- a/ormolu-live/src/Main.hs
+++ b/ormolu-live/src/Main.hs
@@ -96,6 +96,7 @@ viewModel model@Model {..} =
   div_
     []
     [ link_ [rel_ "stylesheet", href_ "bulma.min.css"],
+      link_ [rel_ "stylesheet", href_ "editor.css"],
       script_ [] "new ClipboardJS('.copy-output');",
       section_ [class_ "section"] . pure . div_ [class_ "container is-fluid"] $
         [ h1_ [class_ "title"] [text "Ormolu Live"],
@@ -132,9 +133,15 @@ viewModel model@Model {..} =
             [class_ "columns"]
             [ div_
                 [class_ "column is-half is-flex"]
-                [ textarea_
-                    [class_ "textarea is-family-code", onInput SetInput, rows_ "20", autofocus_ True]
-                    [text input]
+                [ div_
+                    [class_ "editor"]
+                    [ div_
+                        [class_ "line-numbers"]
+                        (replicate (editorLineNumbers . fromMisoString $ input) (span_ [] [])),
+                      textarea_
+                        [class_ "is-family-code", onInput SetInput, rows_ "20", autofocus_ True]
+                        [text input]
+                    ]
                 ],
               div_
                 [id_ "output", class_ "column is-half is-flex card is-shadowless is-radiusless"]
@@ -252,6 +259,8 @@ viewModel model@Model {..} =
               . Dump.showAstData Dump.NoBlankSrcSpan Dump.NoBlankEpAnnotations
               $ prParsedSource
           O.RawSnippet r -> r
+
+    editorLineNumbers text = 1 + T.count "\n" text
 
 extractOrmoluException :: SomeException -> Either String O.OrmoluException
 extractOrmoluException = \case

--- a/ormolu-live/www/editor.css
+++ b/ormolu-live/www/editor.css
@@ -1,0 +1,38 @@
+.editor {
+    width: 100%;
+    display: inline-flex;
+    gap: 10px;
+    font-family: monospace;
+    line-height: 21px;
+    background: #282a3a;
+    border-radius: 2px;
+    padding: 20px 10px;
+}
+
+.editor > textarea {
+    flex-grow: 1;
+    line-height: 21px;
+    font-size: 14px;
+    overflow-y: hidden;
+    padding: 0;
+    border: 0;
+    background: #282a3a;
+    color: #FFF;
+    outline: none;
+    resize: none;
+}
+
+.line-numbers {
+    width: 20px;
+    text-align: right;
+}
+
+.line-numbers span {
+    counter-increment: linenumber;
+}
+
+.line-numbers span::before {
+    content: counter(linenumber);
+    display: block;
+    color: #506882;
+}


### PR DESCRIPTION
This uses a (mostly) pure-CSS solution (inspired by [this post](https://www.webtips.dev/add-line-numbers-to-html-textarea)) to add line numbers to the text editor in Ormolu Live. It calculates the desired line number count from the input, and then creates an equivalent number of `span` elements. A CSS counter is then incremented for each span, and the content is set to the counter's value.

As part of this I had to stop letting Bulma style the editor, so I took the opportunity to give it a dark background & white text, which I think looks pretty nice. I'm also happy to try and find something closer to the original style if anyone has particularly strong feelings about it. 

I initially looked at bringing in a dependency for this, but every one I found creates its own `textarea` rather than using the one provided, which means it'd be a huge pain to wire the browser input events back up to the `SetInput` action. Doing it this way has some drawbacks (primarily that the editor's `textarea` can no longer scroll separately from the rest of the page, as otherwise the line numbers would get out of sync) but is significantly simpler overall than the alternatives. 

Merging this will close #908.

### How it looks

![ormolu-line-numbers](https://user-images.githubusercontent.com/13350302/185360212-3b8ececd-0066-433c-a35a-cd54034b2e94.gif)

