### PR TITLE
Fix formatting of `SCC` pragmas in `do` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   the list of language pragmas. [Issue
   922](https://github.com/tweag/ormolu/issues/922).
 
+* Fix formatting of `SCC` pragmas in `do` blocks. [Issue
+  925](https://github.com/tweag/ormolu/issues/925).
+
 ## Ormolu 0.5.0.1
 
 * Fixed a bug in the diff printing functionality. [Issue

--- a/data/examples/declaration/value/function/pragmas-out.hs
+++ b/data/examples/declaration/value/function/pragmas-out.hs
@@ -4,6 +4,11 @@ sccbar =
   {-# SCC "barbaz" #-}
   "hello"
 
+foo = do
+  {-# SCC "foo" #-}
+    fmap succ $ do
+      {-# SCC "bar" #-} pure 1
+
 -- CORE pragma got removed in https://gitlab.haskell.org/ghc/ghc/-/commit/12f9035200424ec8104484f154a040d612fee99d
 
 corefoo = {-# CORE "foo"#-} 1

--- a/data/examples/declaration/value/function/pragmas.hs
+++ b/data/examples/declaration/value/function/pragmas.hs
@@ -2,6 +2,10 @@ sccfoo = {-# SCC foo#-}  1
 sccbar = {-# SCC "barbaz"#-}
   "hello"
 
+foo = do
+  {-# SCC "foo" #-} fmap succ $ do
+    {-# SCC "bar" #-} pure 1
+
 -- CORE pragma got removed in https://gitlab.haskell.org/ghc/ghc/-/commit/12f9035200424ec8104484f154a040d612fee99d
 
 corefoo = {-# CORE "foo"#-}  1

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -861,7 +861,8 @@ p_hsExpr' s = \case
       atom name
       txt " #-}"
       breakpoint
-      located x p_hsExpr
+      let inciIfS = case s of N -> id; S -> inci
+      inciIfS $ located x p_hsExpr
 
 p_patSynBind :: PatSynBind GhcPs GhcPs -> R ()
 p_patSynBind PSB {..} = do


### PR DESCRIPTION
Closes #925 

This fix (re/ab)uses the `s :: BracketStyle` argument to `p_hsExpr'` in order to decide whether we are in a `do` expression: even though this particular case has nothing to do with brackets, it points to the same underlying problem (some stuff has to be indented only in `do` blocks). This could be potentially confusing for future readers of this code, but the diff is really small, so the effect is not huge in any case.

A slightly more principled fix could look like this: Introduce
```haskell
data InDoBlock = InDoBlock | NotInDoBlock
```
and change `p_hsExpr'`'s signature to
```haskell
p_hsExpr' :: InDoBlock -> HsExpr GhcPs -> R ()
```
as well as provide a function `InDoBlock -> BracketStyle`.