### PR TITLE
Support type applications in patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Fix formatting of `SCC` pragmas in `do` blocks. [Issue
   925](https://github.com/tweag/ormolu/issues/925).
 
+* Support type applications in patterns. [Issue
+  930](https://github.com/tweag/ormolu/issues/930).
+
 ## Ormolu 0.5.0.1
 
 * Fixed a bug in the diff printing functionality. [Issue

--- a/data/examples/declaration/value/function/type-applications-out.hs
+++ b/data/examples/declaration/value/function/type-applications-out.hs
@@ -14,3 +14,11 @@ goo =
     @(HASH TPraosStandardCrypto)
     @ByteString
     "And the lamb lies down on Broadway"
+
+test x = case x of
+  Foo @t -> show @t 0
+  Bar
+    @t
+    @u
+    v ->
+      ""

--- a/data/examples/declaration/value/function/type-applications.hs
+++ b/data/examples/declaration/value/function/type-applications.hs
@@ -11,3 +11,9 @@ goo = hash
   @(HASH TPraosStandardCrypto)
   @ByteString
   "And the lamb lies down on Broadway"
+
+test x = case x of
+  Foo  @t -> show @t 0
+  Bar
+   @t @u v
+    -> ""


### PR DESCRIPTION
Closes #930

In all other occurences of `PrefixCon` (in an expression context), `tys` is of type `[Void]`, which is probably why I thought that it is also not relevant in a pattern context :shrug: Also, it was not mentioned in the changelog of 9.2: https://gitlab.haskell.org/ghc/ghc/-/issues/22397