### PR TITLE
Use located in GADT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Handle `UnicodeSyntax` variants more consistently. [Issue
   934](https://github.com/tweag/ormolu/issues/934).
 
+* Fix an inconsistency in formatting of types in GADT declarations in
+  certain cases. [PR 932](https://github.com/tweag/ormolu/pull/932).
+
 ## Ormolu 0.5.0.1
 
 * Fixed a bug in the diff printing functionality. [Issue

--- a/data/examples/declaration/data/gadt/multiline-out.hs
+++ b/data/examples/declaration/data/gadt/multiline-out.hs
@@ -14,12 +14,8 @@ data Foo a where
     Foo 'Int
   -- | But 'Bar' is also not too bad.
   Bar ::
-    Int ->
-    Maybe Text ->
-    Foo 'Bool
+    Int -> Maybe Text -> Foo 'Bool
   -- | So is 'Baz'.
   Baz ::
-    forall a.
-    a ->
-    Foo 'String
+    forall a. a -> Foo 'String
   (:~>) :: Foo a -> Foo a -> Foo a

--- a/data/examples/declaration/data/gadt/multiple-declaration-out.hs
+++ b/data/examples/declaration/data/gadt/multiple-declaration-out.hs
@@ -4,12 +4,10 @@ data GADT0 a where
 data GADT1 a where
   GADT11,
     GADT12 ::
-    Int ->
-    GADT1 a
+    Int -> GADT1 a
 
 data GADT2 a where
   GADT21,
     GADT21,
     GADT22 ::
-    Int ->
-    GADT2 a
+    Int -> GADT2 a

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -125,13 +125,6 @@ p_conDecl singleConstRec = \case
             commaDel
             sep commaDel p_rdrName cs
       inci $ do
-        space
-        txt "::"
-        let interArgBreak =
-              if hasDocStrings (unLoc con_res_ty)
-                then newline
-                else breakpoint
-        interArgBreak
         let conTy = case con_g_args of
               PrefixConGADT xs ->
                 let go (HsScaled a b) t = addCLocAA t b (HsFunTy EpAnnNotUsed a b t)
@@ -151,7 +144,12 @@ p_conDecl singleConstRec = \case
             quantifiedTy =
               addCLocAA con_bndrs qualTy $
                 hsOuterTyVarBndrsToHsType (unLoc con_bndrs) qualTy
-        p_hsType (unLoc quantifiedTy)
+        space
+        txt "::"
+        if hasDocStrings (unLoc con_res_ty)
+          then newline
+          else breakpoint
+        located quantifiedTy p_hsType
   ConDeclH98 {..} -> do
     mapM_ (p_hsDocString Pipe True) con_doc
     let conDeclWithContextSpn =


### PR DESCRIPTION
Is there a particular reason why `p_hsType` was being called on `unLoc quantifiedType` instead of using the `located` combinator? It seems like it was initially implemented when GADT args + result type were separate, so there wasn't a single HsType object representing the entire type to be located, but now that we have `quantifiedType`, it seems better to be consistent between function signatures + GADT constructors.