### PR TITLE
Handle `UnicodeSyntax` variants more consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Support type applications in patterns. [Issue
   930](https://github.com/tweag/ormolu/issues/930).
 
+* Handle `UnicodeSyntax` variants more consistently. [Issue
+  934](https://github.com/tweag/ormolu/issues/934).
+
 ## Ormolu 0.5.0.1
 
 * Fixed a bug in the diff printing functionality. [Issue

--- a/data/examples/declaration/data/existential-unicode-out.hs
+++ b/data/examples/declaration/data/existential-unicode-out.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo
+  = forall a.
+    Foo
+
+data Bar
+  = forall a.
+    Bar

--- a/data/examples/declaration/data/existential-unicode.hs
+++ b/data/examples/declaration/data/existential-unicode.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo = forall
+  a. Foo
+
+data Bar = ∀
+  a. Bar

--- a/data/examples/declaration/splice/bracket-unicode-out.hs
+++ b/data/examples/declaration/splice/bracket-unicode-out.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+ascii = [|x|]
+
+unicode = [|x|]

--- a/data/examples/declaration/splice/bracket-unicode.hs
+++ b/data/examples/declaration/splice/bracket-unicode.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UnicodeSyntax   #-}
+
+ascii = [|x|]
+
+unicode = ⟦x⟧

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -21,6 +21,7 @@ import GHC.Types.SrcLoc
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Type
+import Ormolu.Utils (matchAddEpAnn)
 
 p_dataDecl ::
   -- | Whether to format as data family
@@ -154,7 +155,9 @@ p_conDecl singleConstRec = \case
   ConDeclH98 {..} -> do
     mapM_ (p_hsDocString Pipe True) con_doc
     let conDeclWithContextSpn =
-          [RealSrcSpan real Nothing | AddEpAnn AnnForall (EpaSpan real) <- epAnnAnns con_ext]
+          [ RealSrcSpan real Nothing
+            | Just (EpaSpan real) <- matchAddEpAnn AnnForall <$> epAnnAnns con_ext
+          ]
             <> fmap getLocA con_ex_tvs
             <> maybeToList (fmap getLocA con_mb_cxt)
             <> conDeclSpn

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1143,7 +1143,7 @@ p_hsBracket :: EpAnn [AddEpAnn] -> HsBracket GhcPs -> R ()
 p_hsBracket epAnn = \case
   ExpBr _ expr -> do
     let name
-          | or [True | AddEpAnn AnnOpenEQ _ <- epAnnAnns epAnn] = ""
+          | any isJust (matchAddEpAnn AnnOpenEQ <$> epAnnAnns epAnn) = ""
           | otherwise = "e"
     quote name (located expr p_hsExpr)
   PatBr _ pat -> located pat (quote "p" . p_pat)

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -16,6 +16,7 @@ module Ormolu.Utils
     onTheSameLine,
     HasSrcSpan (..),
     getLoc',
+    matchAddEpAnn,
   )
 where
 
@@ -141,3 +142,10 @@ instance HasSrcSpan (SrcSpanAnn' ann) where
 
 getLoc' :: HasSrcSpan l => GenLocated l a -> SrcSpan
 getLoc' = loc' . getLoc
+
+-- | Check whether the given 'AnnKeywordId' or its Unicode variant is in an
+-- 'AddEpAnn', and return the 'EpaLocation' if so.
+matchAddEpAnn :: AnnKeywordId -> AddEpAnn -> Maybe EpaLocation
+matchAddEpAnn annId (AddEpAnn annId' loc)
+  | annId == annId' || unicodeAnn annId == annId' = Just loc
+  | otherwise = Nothing


### PR DESCRIPTION
Closes #934, key function is [`unicodeAnn`](https://hackage.haskell.org/package/ghc-9.4.2/docs/GHC-Parser-Annotation.html#v:unicodeAnn).

I also spotted another case w.r.t. existential types where we were previously only matching the non-Unicode variant, see the added test case.