### PR TITLE
Update CI for release binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,34 +20,30 @@ jobs:
     name: Build binary for ${{ matrix.targetOs }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v15
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            substituters = https://cache.nixos.org https://hydra.iohk.io
+            substituters = https://cache.nixos.org https://cache.iog.io
       - name: Build binary
         run: nix-build -A binaries.${{ matrix.targetOS }}
       - name: Prepare upload
         run: |
           cd result/bin
           7z a -l ${{ github.workspace }}/ormolu.zip .
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ormolu.zip
           asset_name: ormolu-${{ matrix.targetOs }}.zip
-          asset_content_type: application/zip
   test:
     strategy:
       fail-fast: false
       matrix:
         os:
           - ubuntu-latest
-          - macOS-10.15
-          - macOS-11
+          - macOS-latest
           - windows-latest
     name: Test built binaries
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
 - Update versions of the actions we use, and switch from the deprecated [actions/upload-release-asset](https://github.com/actions/upload-release-asset) to a maintained fork.
 - The IOG binary cache is now preferrably referred to by cache.iog.io (see [here](https://input-output-hk.github.io/haskell.nix/tutorials/getting-started.html#setting-up-the-binary-cache)).
 - The macOS-10.15 runner will [soon be fully unsupported](https://github.com/actions/runner-images/issues/5583).