### PR TITLE
Disable `fixity-th` on GHC 9.4

### DIFF
--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -115,7 +115,7 @@ library
 
     mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
 
-    if flag(fixity-th)
+    if (flag(fixity-th) && impl(ghc <9.4))
         cpp-options: -DFIXITY_TH
 
     else


### PR DESCRIPTION
Workaround for #941, until this (upstream) bug can be properly investigated/reported/worked around.

Could be published as a revision for 0.5.1.0 to avoid unpleasant surprises as seen e.g. in #944.