### PR TITLE
Use `ghc` instead of `ghc-lib-parser` when possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ dist-*/
 dist/
 stack.yaml.lock
 result*
+
+# These are touched on every :reload in GHCi.
+# https://gitlab.haskell.org/ghc/ghc/-/issues/22669
+*.o-boot

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -230,7 +230,7 @@ optsParserInfo =
               $gitBranch,
               $gitHash
             ],
-          "using ghc-lib-parser " ++ VERSION_ghc_lib_parser
+          ghcApiVersion
         ]
     exts :: Parser (a -> a)
     exts =
@@ -239,6 +239,13 @@ optsParserInfo =
           help "Display extensions that need to be enabled manually"
         ]
     displayExts = unlines $ sort (showOutputable <$> manualExts)
+
+ghcApiVersion :: String
+#ifdef VERSION_ghc_lib_parser
+ghcApiVersion = "using ghc-lib-parser " ++ VERSION_ghc_lib_parser
+#else
+ghcApiVersion = "using ghc " ++ VERSION_ghc
+#endif
 
 optsParser :: Parser Opts
 optsParser =

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -105,7 +105,6 @@ library
         dlist >=0.8 && <2.0,
         exceptions >=0.6 && <0.11,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
@@ -113,7 +112,14 @@ library
         text >=0.2 && <3.0,
         th-lift-instances >=0.1 && <0.2
 
-    mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
+    if impl(ghc >=9.4 && <9.5)
+        build-depends:
+            ghc,
+            ghc-boot-th
+
+    else
+        build-depends: ghc-lib-parser >=9.4 && <9.5
+        mixins:        ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
 
     if (flag(fixity-th) && impl(ghc <9.4))
         cpp-options: -DFIXITY_TH
@@ -140,11 +146,18 @@ executable ormolu
         base >=4.12 && <5.0,
         containers >=0.5 && <0.7,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
         gitrev >=1.3 && <1.4,
         optparse-applicative >=0.14 && <0.18,
         ormolu,
         text >=0.2 && <3.0
+
+    if impl(ghc >=9.4 && <9.5)
+        build-depends:
+            ghc,
+            ghc-boot-th
+
+    else
+        build-depends: ghc-lib-parser >=9.4 && <9.5
 
     if flag(dev)
         ghc-options:
@@ -179,7 +192,6 @@ test-suite tests
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
         hspec >=2.0 && <3.0,
         hspec-megaparsec >=2.2,
         megaparsec >=9.0,
@@ -188,6 +200,14 @@ test-suite tests
         path-io >=1.4.2 && <2.0,
         temporary ^>=1.3,
         text >=0.2 && <3.0
+
+    if impl(ghc >=9.4 && <9.5)
+        build-depends:
+            ghc,
+            ghc-boot-th
+
+    else
+        build-depends: ghc-lib-parser >=9.4 && <9.5
 
     if flag(dev)
         ghc-options: -Wall -Werror

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -38,10 +38,10 @@ spec = do
       ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
     it "extracts correct dependencies from ormolu.cabal (src/Ormolu/Config.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "src/Ormolu/Config.hs"
-      ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "template-haskell", "text", "th-lift-instances"]
+      ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc", "ghc-boot-th", "ghc-lib-parser", "megaparsec", "mtl", "syb", "template-haskell", "text", "th-lift-instances"]
     it "extracts correct dependencies from ormolu.cabal (tests/Ormolu/PrinterSpec.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "tests/Ormolu/PrinterSpec.hs"
-      ciDependencies `shouldBe` Set.fromList ["QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
+      ciDependencies `shouldBe` Set.fromList ["QuickCheck", "base", "containers", "directory", "filepath", "ghc", "ghc-boot-th", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
 
     it "handles `hs-source-dirs: .`" $ do
       CabalInfo {..} <- parseTestCabalInfo "Foo.hs"


### PR DESCRIPTION
This significantly reduces the build time with recent version of GHC.