### PR TITLE
Eliminate the fixity-th cabal flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Ormolu 0.5.2.0
+
+* Eliminated the `fixity-th` Cabal flag because it caused issues on GHC 9.4 as
+  well as on aarch64. See [issue
+  941](https://github.com/tweag/ormolu/issues/941) and [issue
+  927](https://github.com/tweag/ormolu/issues/927).
+
 ## Ormolu 0.5.1.0
 
 * Imports are now sorted by package qualifier, if one is present.

--- a/default.nix
+++ b/default.nix
@@ -28,7 +28,6 @@ let
         ({ pkgs, lib, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isGhcjs {
           reinstallableLibGhc = false;
           packages.ormolu = {
-            flags.fixity-th = false;
             writeHieFiles = lib.mkForce false;
           };
           packages.ormolu-live.ghcOptions =

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -32,10 +32,6 @@ flag dev
     default:     False
     manual:      True
 
-flag fixity-th
-    description: Parse the default fixity information via Template Haskell
-    manual:      True
-
 library
     exposed-modules:
         Ormolu
@@ -104,6 +100,7 @@ library
         directory ^>=1.3,
         dlist >=0.8 && <2.0,
         exceptions >=0.6 && <0.11,
+        file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,
         ghc-lib-parser >=9.4 && <9.5,
         megaparsec >=9.0,
@@ -114,12 +111,6 @@ library
         th-lift-instances >=0.1 && <0.2
 
     mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
-
-    if (flag(fixity-th) && impl(ghc <9.4))
-        cpp-options: -DFIXITY_TH
-
-    else
-        build-depends: file-embed >=0.0.15 && <0.1
 
     if flag(dev)
         ghc-options:

--- a/src/Ormolu/Fixity.hs
+++ b/src/Ormolu/Fixity.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -22,38 +21,23 @@ module Ormolu.Fixity
 where
 
 import qualified Data.Aeson as A
+import Data.FileEmbed (embedFile)
 import Data.Foldable (foldl')
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromJust, fromMaybe)
 import Data.MemoTrie (HasTrie, memo)
 import Data.Semigroup (sconcat)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Ormolu.Fixity.Internal
-#if FIXITY_TH
-import Control.Monad.IO.Class (MonadIO (liftIO))
-import qualified Language.Haskell.TH.Syntax as TH
-#else
-import Data.FileEmbed (embedFile)
-import Data.Maybe (fromJust)
-#endif
 
 packageToOps :: Map String FixityMap
 packageToPopularity :: Map String Int
-#if FIXITY_TH
-HackageInfo packageToOps packageToPopularity =
-  $( do
-       let path = "extract-hackage-info/hackage-info.json"
-       info <- liftIO $ either fail pure =<< A.eitherDecodeFileStrict' path
-       TH.lift (info :: HackageInfo)
-   )
-#else
 HackageInfo packageToOps packageToPopularity =
   fromJust $ A.decodeStrict $(embedFile "extract-hackage-info/hackage-info.json")
-#endif
 
 -- | List of packages shipped with GHC, for which the download count from
 -- Hackage does not reflect their high popularity.


### PR DESCRIPTION
Close #927, close #941.

The flag caused problems on GHC 9.4 and generally was a magnet for bugs. We are going to try to use `file-embed` unconditionally and make parsing more efficient instead.