### PR TITLE
Remove unused `Lift` instances and packages

### DIFF
--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -99,24 +99,19 @@ library
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         dlist >=0.8 && <2.0,
-        exceptions >=0.6 && <0.11,
         file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,
         ghc-lib-parser >=9.4 && <9.5,
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
-        template-haskell,
-        text >=0.2 && <3.0,
-        th-lift-instances >=0.1 && <0.2
-
-    mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
+        text >=0.2 && <3.0
 
     if flag(dev)
         ghc-options:
             -Wall -Werror -Wcompat -Wincomplete-record-updates
             -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
-            -Wno-missing-home-modules
+            -Wno-missing-home-modules -Wunused-packages
 
     else
         ghc-options: -O2 -Wall
@@ -141,7 +136,8 @@ executable ormolu
         ghc-options:
             -Wall -Werror -Wcompat -Wincomplete-record-updates
             -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
-            -optP-Wno-nonportable-include-path
+            -optP-Wno-nonportable-include-path -Wunused-packages
+            -Wwarn=unused-packages
 
     else
         ghc-options: -O2 -Wall -rtsopts
@@ -173,7 +169,6 @@ test-suite tests
         ghc-lib-parser >=9.4 && <9.5,
         hspec >=2.0 && <3.0,
         hspec-megaparsec >=2.2,
-        megaparsec >=9.0,
         ormolu,
         path >=0.6 && <0.10,
         path-io >=1.4.2 && <2.0,
@@ -181,7 +176,7 @@ test-suite tests
         text >=0.2 && <3.0
 
     if flag(dev)
-        ghc-options: -Wall -Werror
+        ghc-options: -Wall -Werror -Wunused-packages
 
     else
         ghc-options: -O2 -Wall

--- a/src/Ormolu/Fixity/Internal.hs
+++ b/src/Ormolu/Fixity/Internal.hs
@@ -22,15 +22,13 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
-import Instances.TH.Lift ()
-import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Fixity direction.
 data FixityDirection
   = InfixL
   | InfixR
   | InfixN
-  deriving (Eq, Ord, Show, TH.Lift)
+  deriving (Eq, Ord, Show)
 
 instance FromJSON FixityDirection where
   parseJSON = A.withText "FixityDirection" $ \case
@@ -58,7 +56,7 @@ data FixityInfo = FixityInfo
     -- definitions for the operator (inclusive)
     fiMaxPrecedence :: Int
   }
-  deriving (Eq, Ord, Show, TH.Lift)
+  deriving (Eq, Ord, Show)
 
 instance FromJSON FixityInfo where
   parseJSON = A.withObject "FixitiyInfo" $ \o ->
@@ -130,7 +128,6 @@ data HackageInfo
       -- ^ Map from package name to a map from operator name to its fixity
       (Map String Int)
       -- ^ Map from package name to its 30-days download count from Hackage
-  deriving (TH.Lift)
 
 instance FromJSON HackageInfo where
   parseJSON = A.withObject "HackageInfo" $ \o ->

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -38,10 +38,10 @@ spec = do
       ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
     it "extracts correct dependencies from ormolu.cabal (src/Ormolu/Config.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "src/Ormolu/Config.hs"
-      ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "template-haskell", "text", "th-lift-instances"]
+      ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "text"]
     it "extracts correct dependencies from ormolu.cabal (tests/Ormolu/PrinterSpec.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "ormolu.cabal" "tests/Ormolu/PrinterSpec.hs"
-      ciDependencies `shouldBe` Set.fromList ["QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
+      ciDependencies `shouldBe` Set.fromList ["QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
 
     it "handles `hs-source-dirs: .`" $ do
       CabalInfo {..} <- parseTestCabalInfo "Foo.hs"


### PR DESCRIPTION
Somewhat of a follow-up to #954. As I removed a few packages, I also went ahead and enabled `-Wunused-packages`. Note this has a false positive for `exe:ormolu` as we depend on `ghc-lib-parser` there only for the `VERSION_ghc_lib_parser` macro which GHC can not be aware of.