### PR TITLE
Test different runtime fixity parsing approaches

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,6 @@ constraints: warp -x509, wai-app-static -cryptonite
 
 -- due to GHCJS 8.10
 allow-older: ghc-lib-parser:base
+
+package aeson
+  flags: +cffi -ordered-keymap

--- a/default.nix
+++ b/default.nix
@@ -101,7 +101,7 @@ in {
     inherit hsPkgs;
     ormoluShell = shellFor (ps: [ ps.ormolu ]);
     ormoluLiveShell = shellFor (ps: [ ps.ormolu-live ]);
-    extractHackageInfoShell = shellFor (ps: [ ps.extract-hackage-info ]);
+    extractHackageInfoShell = shellFor (ps: [ ps.ormolu ps.extract-hackage-info ]);
     cabalAndOrmolu = pkgs.mkShell {
       buildInputs = [
         (hsPkgs.tool "cabal" "latest")

--- a/extract-hackage-info/extract-hackage-info.cabal
+++ b/extract-hackage-info/extract-hackage-info.cabal
@@ -21,7 +21,9 @@ executable extract-hackage-info
         tagsoup >=0.14 && <0.15,
         text >=0.2 && <3.0,
         formatting >=7.1 && <7.2,
-        megaparsec >=9.0
+        megaparsec >=9.0,
+        binary >=0.8 && <0.9,
+        serialise >=0.2.6.0
 
     if !impl(ghc >=9.2 && <9.3)
         buildable: False

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -105,7 +105,9 @@ library
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
-        text >=0.2 && <3.0
+        text >=0.2 && <3.0,
+        binary >=0.8 && <0.9,
+        serialise >=0.2.6.0
 
     if flag(dev)
         ghc-options:

--- a/src/Ormolu/Fixity/Internal.hs
+++ b/src/Ormolu/Fixity/Internal.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -15,20 +17,24 @@ module Ormolu.Fixity.Internal
   )
 where
 
+import Codec.Serialise (Serialise)
 import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
+import Data.Binary (Binary)
 import Data.Foldable (asum)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
+import GHC.Generics (Generic)
 
 -- | Fixity direction.
 data FixityDirection
   = InfixL
   | InfixR
   | InfixN
-  deriving (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (Binary, Serialise)
 
 instance FromJSON FixityDirection where
   parseJSON = A.withText "FixityDirection" $ \case
@@ -56,7 +62,8 @@ data FixityInfo = FixityInfo
     -- definitions for the operator (inclusive)
     fiMaxPrecedence :: Int
   }
-  deriving (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (Binary, Serialise)
 
 instance FromJSON FixityInfo where
   parseJSON = A.withObject "FixitiyInfo" $ \o ->
@@ -127,6 +134,8 @@ data HackageInfo
       -- ^ Map from package name to a map from operator name to its fixity
       (Map String Int)
       -- ^ Map from package name to its 30-days download count from Hackage
+  deriving stock (Generic)
+  deriving anyclass (Binary, Serialise)
 
 instance FromJSON HackageInfo where
   parseJSON = A.withObject "HackageInfo" $ \o ->


### PR DESCRIPTION
Follow-up discussion PR to #954. One relatively low-hanging fruit is to use a different parsing format instead of JSON. The goal of this PR is not to get merged, but rather to provide an overview how much this choice matters.

Variants:

 - Ormolu 0.5.1.0
 - Ormolu `master`, i.e. b64a5fd79386bfa8e900c6c62e08b96837dc3e3e
 - `aeson` with different flags (see [Hackage](https://hackage.haskell.org/package/aeson)) applied: 
    - On `master`, we use the default flags: `-c+o`
    - Naively, one would expect `+c-o` to have the best performance, but we also test the other two combinations.
 - Use [`binary`](https://hackage.haskell.org/package/binary) with `Generic`-derived en-/decoding.
 - Use [`serialise`](https://hackage.haskell.org/package/serialise) with `Generic`-derived en-/decoding.

As the fixity parsing is a one-time cost per Ormolu binary invocation (also see https://github.com/tweag/ormolu/issues/944#issuecomment-1345545183 for more context), we benchmark formatting just one very simple file, with (a) no operators, (b) a `base` operator and (c) a non-`base` operator.

<table>
<tr><th>test-a.hs</th><th>test-b.hs</th><th>test-c.hs</th></tr>
<tr>
<td>

```haskell
1
```

</td>
<td>

```haskell
1+1
```

</td>
<td>

```haskell
1+++++++1
```

</td>
</tr>
</table>

## Results

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `ormolu --no-cabal test-a.hs` | 1.2 ± 0.5 | 0.6 | 4.0 | 1.00 |
| `result-master/bin/ormolu --no-cabal test-a.hs` | 1.7 ± 0.7 | 0.8 | 7.2 | 1.39 ± 0.79 |
| `result-aeson+c-o/bin/ormolu --no-cabal test-a.hs` | 1.7 ± 0.7 | 0.9 | 10.6 | 1.38 ± 0.77 |
| `result-binary/bin/ormolu --no-cabal test-a.hs` | 1.6 ± 0.6 | 0.8 | 6.6 | 1.32 ± 0.70 |
| `result-cborg/bin/ormolu --no-cabal test-a.hs` | 1.5 ± 0.5 | 0.8 | 4.0 | 1.24 ± 0.60 |
| `ormolu --no-cabal test-b.hs` | 1.3 ± 0.5 | 0.7 | 5.2 | 1.11 ± 0.61 |
| `result-master/bin/ormolu --no-cabal test-b.hs` | 154.3 ± 4.4 | 151.1 | 170.7 | 127.46 ± 48.00 |
| `result-aeson+c-o/bin/ormolu --no-cabal test-b.hs` | 172.4 ± 4.4 | 167.5 | 185.7 | 142.41 ± 53.59 |
| `result-binary/bin/ormolu --no-cabal test-b.hs` | 37.4 ± 3.0 | 34.4 | 52.3 | 30.88 ± 11.85 |
| `result-cborg/bin/ormolu --no-cabal test-b.hs` | 54.2 ± 2.6 | 50.3 | 69.0 | 44.79 ± 16.95 |
| `ormolu --no-cabal test-c.hs` | 53.3 ± 2.4 | 50.5 | 63.7 | 44.02 ± 16.65 |
| `result-master/bin/ormolu --no-cabal test-c.hs` | 223.9 ± 3.5 | 220.4 | 231.9 | 184.96 ± 69.50 |
| `result-aeson+c-o/bin/ormolu --no-cabal test-c.hs` | 261.4 ± 6.8 | 254.2 | 272.5 | 215.95 ± 81.28 |
| `result-binary/bin/ormolu --no-cabal test-c.hs` | 88.4 ± 2.7 | 82.9 | 92.9 | 73.01 ± 27.50 |
| `result-cborg/bin/ormolu --no-cabal test-c.hs` | 113.4 ± 3.3 | 109.5 | 125.9 | 93.65 ± 35.27 |

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `result-aeson-c+o/bin/ormolu --no-cabal test-a.hs` | 1.6 ± 0.6 | 0.8 | 6.7 | 1.00 |
| `result-aeson+c-o/bin/ormolu --no-cabal test-a.hs` | 1.8 ± 0.6 | 1.0 | 6.6 | 1.09 ± 0.55 |
| `result-aeson+c+o/bin/ormolu --no-cabal test-a.hs` | 1.8 ± 0.6 | 0.8 | 6.3 | 1.09 ± 0.57 |
| `result-aeson-c-o/bin/ormolu --no-cabal test-a.hs` | 1.9 ± 0.7 | 0.9 | 6.5 | 1.18 ± 0.63 |
| `result-aeson-c+o/bin/ormolu --no-cabal test-b.hs` | 156.4 ± 4.0 | 150.9 | 165.4 | 96.26 ± 35.82 |
| `result-aeson+c-o/bin/ormolu --no-cabal test-b.hs` | 170.8 ± 1.9 | 168.2 | 176.8 | 105.14 ± 39.05 |
| `result-aeson+c+o/bin/ormolu --no-cabal test-b.hs` | 157.9 ± 5.7 | 152.0 | 173.6 | 97.19 ± 36.25 |
| `result-aeson-c-o/bin/ormolu --no-cabal test-b.hs` | 172.7 ± 1.9 | 169.9 | 176.7 | 106.29 ± 39.48 |
| `result-aeson-c+o/bin/ormolu --no-cabal test-c.hs` | 226.1 ± 4.7 | 220.1 | 238.1 | 139.20 ± 51.76 |
| `result-aeson+c-o/bin/ormolu --no-cabal test-c.hs` | 261.1 ± 5.6 | 255.8 | 275.0 | 160.73 ± 59.78 |
| `result-aeson+c+o/bin/ormolu --no-cabal test-c.hs` | 226.5 ± 3.5 | 222.3 | 232.9 | 139.43 ± 51.81 |
| `result-aeson-c-o/bin/ormolu --no-cabal test-c.hs` | 263.3 ± 5.2 | 255.4 | 271.7 | 162.05 ± 60.25 |

## Analysis

 - Choice of parsing approach has significant influence.
 - `binary < cborg < aeson`
 - For aeson:
    - The `cffi` flag seems to make almost no difference.
    - Enabling `ordered-map` flag is actually faster, this might be because we use `Map`s in the current fixity processing code, so this might turn out to be better to flip if we also switch to `HashMap` there.
 - Maybe we can get better performance by hand-writing parsers instead of using `Generic` deriving.

## How to run these benchmarks

Build Ormolu via `nix-build -A ormoluExe --out-link result-flavor` and then run
```
hyperfine -w 10 -L ormolu ormolu,result-master/bin/ormolu,result-aeson+c-o/bin/ormolu,result-binary/bin/ormolu,result-cborg/bin/ormolu -L flavor a,b,c '{ormolu} --no-cabal test-{flavor}.hs' --export-markdown out.md
```
and
```
hyperfine -w 10 -L ormolu result-aeson-c+o/bin/ormolu,result-aeson+c-o/bin/ormolu,result-aeson+c+o/bin/ormolu,result-aeson-c-o/bin/ormolu -L flavor a,b,c '{ormolu} --no-cabal test-{flavor}.hs' --export-markdown out-aeson.md
```