### PR TITLE
Remove last reference to JSON as the fixity DB format

### DIFF
--- a/extract-hackage-info/src/Main.hs
+++ b/extract-hackage-info/src/Main.hs
@@ -45,7 +45,7 @@ import qualified Text.Megaparsec as MP
 import qualified Text.Megaparsec.Char as MP
 
 defaultOutputPath :: FilePath
-defaultOutputPath = "extract-hackage-info/hackage-info.json"
+defaultOutputPath = "extract-hackage-info/hackage-info.bin"
 
 -- | This fixity info is used when we find an operator declaration in a
 -- package, but no matching fixity declaration.


### PR DESCRIPTION
Thanks to @brandonchinn178 in https://github.com/tweag/ormolu/pull/960#issuecomment-1372494313

The extensions in https://github.com/tweag/ormolu/blob/810eb7839cbf4e358821447e8f4603955999e62d/extract-hackage-info.sh are correct in contrast.