### PR TITLE
Gitignore .direnv/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist/
 stack.yaml.lock
 result*
 .pre-commit-config.yaml
+.direnv/
 
 # These are touched on every :reload in GHCi.
 # https://gitlab.haskell.org/ghc/ghc/-/issues/22669


### PR DESCRIPTION
This seems to be created when direnv uses a nix flake?