### PR TITLE
Update flake inputs, add GHC 9.4.4 to CI, minor tweaks 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ghc902, ghc925]
+        ghc: [ghc902, ghc925, ghc944]
     name: Build and test on ${{ matrix.ghc }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
         with:
-          # https://github.com/NixOS/nix/issues/7644
-          install_url: https://releases.nixos.org/nix/nix-2.12.0/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: cachix/cachix-action@v12
@@ -38,8 +36,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
         with:
-          # https://github.com/NixOS/nix/issues/7644
-          install_url: https://releases.nixos.org/nix/nix-2.12.0/install
           extra_nix_config: |
             accept-flake-config = true
       - name: Format via Cabal and Ormolu
@@ -57,8 +53,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
         with:
-          # https://github.com/NixOS/nix/issues/7644
-          install_url: https://releases.nixos.org/nix/nix-2.12.0/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: actions/cache@v3
@@ -87,8 +81,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
         with:
-          # https://github.com/NixOS/nix/issues/7644
-          install_url: https://releases.nixos.org/nix/nix-2.12.0/install
           extra_nix_config: |
             accept-flake-config = true
       - uses: cachix/cachix-action@v12

--- a/flake.lock
+++ b/flake.lock
@@ -438,15 +438,16 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1635892615,
-        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -470,15 +471,16 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1635892615,
-        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
         "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -502,11 +504,11 @@
     "flake-compat_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -720,11 +722,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1672766266,
-        "narHash": "sha256-N70za5dO7m3gzaJFF98JpKSt1C527tpzccB+zGIsMS0=",
+        "lastModified": 1674662399,
+        "narHash": "sha256-2eAxHUZ5yE5kpyPsMj+cH5n6msTmH2baj8yadK6GHZ4=",
         "owner": "ghc",
         "repo": "ghc-wasm-meta",
-        "rev": "c32a21f4de44c95b8e3f987281ea2cbf9cbf7301",
+        "rev": "6f0a1cd74e9468730786563ce10b93a44167152c",
         "type": "gitlab"
       },
       "original": {
@@ -818,11 +820,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1672619208,
-        "narHash": "sha256-9H5fe4381KfJRlzIPOWpXSkMm6mVdnIOmUgpxHZ9F9g=",
+        "lastModified": 1674606328,
+        "narHash": "sha256-W9gFANLZ0HgtYIqQMva589j8Lcx1+7NNDWHs3y4NopQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "62cfb0193b70b442e2fc5c426a66b77cc6f9228c",
+        "rev": "4d77291ca5dcff20a065646468a513c1ce000a4d",
         "type": "github"
       },
       "original": {
@@ -834,11 +836,11 @@
     "hackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1668561455,
-        "narHash": "sha256-7F7G7auywqrpqflR5qxSg+lwcZMor009G1miwEvYrts=",
+        "lastModified": 1674692755,
+        "narHash": "sha256-p/FnWnCFNF6bqU3lyUJgKUsKEEoeZPOoBdTLqU2O4R0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "ccd32d7f97a5ce5e4f89167ef75b8a30a4565647",
+        "rev": "47b88d3591e159961e149de9381a35dc8dc62cfb",
         "type": "github"
       },
       "original": {
@@ -877,11 +879,11 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1672620670,
-        "narHash": "sha256-UdbaI/HQh8I56GVcXuOjK64hAHFW0fe61uLvhbaeH5s=",
+        "lastModified": 1674607842,
+        "narHash": "sha256-iieSE8dJjfFxa+NXR8JqaHexVXZ8sM2Tn0sqcgdBnMI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "47a1186dcc5ab90645572617d095a086764ad2d5",
+        "rev": "119e6e2de682d7a10be43bd32b96ddf348ce07b4",
         "type": "github"
       },
       "original": {
@@ -903,6 +905,7 @@
         "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_2",
         "hydra": "hydra_2",
+        "iserv-proxy": "iserv-proxy_2",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -911,17 +914,18 @@
         "nixpkgs-2105": "nixpkgs-2105_2",
         "nixpkgs-2111": "nixpkgs-2111_2",
         "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-2211": "nixpkgs-2211_2",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "old-ghc-nix": "old-ghc-nix_2",
         "stackage": "stackage_2",
         "tullia": "tullia_2"
       },
       "locked": {
-        "lastModified": 1668600639,
-        "narHash": "sha256-7KECcJ+UEzJt2IXUFS0rs4Jt5MpNzIm6bUFB8aGHEFM=",
+        "lastModified": 1674694244,
+        "narHash": "sha256-WiRjhSOxIqBwAP39VPf4ZrCqPK2Jf58up2xyk3tYyxI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a88458a496c5e2d3ae889bb22c24f1b4d8e7fa5a",
+        "rev": "418612f2f2b814ae6161682fb3770c3c86c41b44",
         "type": "github"
       },
       "original": {
@@ -1012,17 +1016,35 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1639165170,
-        "narHash": "sha256-QsWL/sBDL5GM8IXd/dE/ORiL4RvteEN+aok23tXgAoc=",
-        "rev": "6e95df7be6dd29680f983db07a057fc2f34f81f6",
-        "revCount": 7,
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "ref": "hkm/remote-iserv",
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
         "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/iserv-proxy.git"
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
       "original": {
-        "rev": "6e95df7be6dd29680f983db07a057fc2f34f81f6",
+        "ref": "hkm/remote-iserv",
         "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/iserv-proxy.git"
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "iserv-proxy_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
+        "ref": "hkm/remote-iserv",
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      },
+      "original": {
+        "ref": "hkm/remote-iserv",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       }
     },
     "lowdown-src": {
@@ -1591,6 +1613,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2211_2": {
+      "locked": {
+        "lastModified": 1669997163,
+        "narHash": "sha256-vhjC0kZMFoN6jzK0GR+tBzKi5KgBXgehadfidW8+Va4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6f87491a54d8d64d30af6663cb3bf5d2ee7db958",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1623,16 +1661,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1671271954,
-        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1901,11 +1939,11 @@
     "npmlock2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1670666882,
-        "narHash": "sha256-hoCm6Z6fXuYML+gh+HISsRVPMXDmyknAWlaentg9zcc=",
+        "lastModified": 1673447413,
+        "narHash": "sha256-sJM82Sj8yfQYs9axEmGZ9Evzdv/kDcI9sddqJ45frrU=",
         "owner": "nix-community",
         "repo": "npmlock2nix",
-        "rev": "cc11d791fdc3afb2ae7c2f11e10abf7c33b40763",
+        "rev": "9197bbf397d76059a76310523d45df10d2e4ca81",
         "type": "github"
       },
       "original": {
@@ -1976,11 +2014,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1672659856,
-        "narHash": "sha256-9vJvy5O87WyIYZGzFaHMeRTishV0SNDeSewvnyRCrMI=",
+        "lastModified": 1674550893,
+        "narHash": "sha256-HXI8AB96PP7UZ7iPANACXM8qc9eMz0ljxBEDM8JJKhY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2d947ef03b7cba461aab65a5df1ede03be567068",
+        "rev": "7bdf85f6bbef581eb687838d19f2b35a4c9d77f0",
         "type": "github"
       },
       "original": {
@@ -2025,11 +2063,11 @@
         "utils": "utils_6"
       },
       "locked": {
-        "lastModified": 1673825304,
-        "narHash": "sha256-cWhvJMCrb6wQJ8aCGzzwieh8W05jhqWNEPf4YXdJGh8=",
+        "lastModified": 1674243319,
+        "narHash": "sha256-o39rBVSNqchahHrMYNixdlasDro8omlf/n7yQZsdNI8=",
         "owner": "purs-nix",
         "repo": "purs-nix",
-        "rev": "0ec8c6b6177a4de93834892376a84b9a4079aad3",
+        "rev": "2b7761ffaded363d0d00afe320350cc5c9ee9012",
         "type": "github"
       },
       "original": {
@@ -2114,11 +2152,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1672618324,
-        "narHash": "sha256-ZL0qClLsK2/s+Aphb0SEUw7jtT6126w10ueuJ3BQv7Q=",
+        "lastModified": 1674605441,
+        "narHash": "sha256-GX5OHXYP6jRSlDq0KOpb4AXgeEU70zVTRQ/ogKg7vR4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "27364e06f36e887d7ddc38a52f1bcf413223c570",
+        "rev": "17e090ed82bc8aedaf251a8becb7ba2455db816a",
         "type": "github"
       },
       "original": {
@@ -2130,11 +2168,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1668561558,
-        "narHash": "sha256-kPphlxLhorScEWLushwUInuSRSCNpeL5Q12pYDqo3dk=",
+        "lastModified": 1674605441,
+        "narHash": "sha256-GX5OHXYP6jRSlDq0KOpb4AXgeEU70zVTRQ/ogKg7vR4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "0feb1639188527219bee04656693a043e1864ecb",
+        "rev": "17e090ed82bc8aedaf251a8becb7ba2455db816a",
         "type": "github"
       },
       "original": {
@@ -2277,11 +2315,11 @@
         "std": "std_2"
       },
       "locked": {
-        "lastModified": 1666200256,
-        "narHash": "sha256-cJPS8zBu30SMhxMe7I8DWutwqMuhPsEez87y9gxMKc4=",
+        "lastModified": 1668711738,
+        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "575362c2244498e8d2c97f72861510fa72e75d44",
+        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
         "type": "github"
       },
       "original": {

--- a/ormolu-live/cabal.project
+++ b/ormolu-live/cabal.project
@@ -4,7 +4,7 @@ index-state:
   , hackage.haskell.org 2023-01-13T16:50:23Z
   , head.hackage 2022-12-25T15:05:28Z
 
-allow-newer: base, ghc-prim, transformers, unix
+allow-newer: base, ghc-prim, transformers, unix, template-haskell
 
 package ormolu
   flags: -internal-bundle-fixities

--- a/ormolu-live/default.nix
+++ b/ormolu-live/default.nix
@@ -23,11 +23,7 @@ let
     ghcAPIVersion =
       defaultGHC.dev.hsPkgs.ghc-lib-parser.components.library.version;
   };
-  ghcWasmDeps = [
-    inputs.ghc-wasm-meta.packages.${system}.default
-    pkgs.haskellPackages.happy
-    pkgs.haskellPackages.alex
-  ];
+  ghcWasmDeps = [ inputs.ghc-wasm-meta.packages.${system}.default ];
 in
 {
   package = npmlock2nix.build {

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -4,7 +4,7 @@ version:            0.5.3.0
 license:            BSD-3-Clause
 license-file:       LICENSE.md
 maintainer:         Mark Karpov <mark.karpov@tweag.io>
-tested-with:        ghc ==9.0.2 ghc ==9.2.5
+tested-with:        ghc ==9.0.2 ghc ==9.2.5 ghc ==9.4.4
 homepage:           https://github.com/tweag/ormolu
 bug-reports:        https://github.com/tweag/ormolu/issues
 synopsis:           A formatter for Haskell source code


### PR DESCRIPTION
 - Update haskell.nix
    - adds GHC 9.4.4 to CI
    - haskell.nix uses a different cache right now (probably temporarily)
 - Update ghc-wasm-meta
 - Nix 2.13.2 fixed the bug we encountered: https://github.com/NixOS/nix/issues/7644#issuecomment-1404957780
 - Fixes an IFD issue for the macOS binary (it tried to build Linux GHCs...); successful test run is here: https://github.com/amesgen/ormolu/actions/runs/4018230397