### PR TITLE
ghc-lib-parser 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [ghc902, ghc925, ghc944]
+        ghc: [ghc927, ghc944, ghc961]
     name: Build and test on ${{ matrix.ghc }}
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 * Insert space before char literals in ticked promoted constructs when
   necessary. [Issue 1000](https://github.com/tweag/ormolu/issues/1000).
 
+* Switched to `ghc-lib-parser-9.6`:
+  * Extended `OverloadedLabels`: `#Foo`, `#3`, `#"Hello there"`.
+
+    Also, it is now disabled by default, as it causes e.g. `a#b` to be parsed
+    differently.
+  * New extension: `TypeData`, enabled by default.
+  * Parse errors now include error codes, cf. https://errors.haskell.org.
+
+* Updated to `Cabal-syntax-3.10`.
+
 ## Ormolu 0.5.3.0
 
 * Stop making empty `let`s move comments. [Issue

--- a/data/examples/declaration/data/type-data-out.hs
+++ b/data/examples/declaration/data/type-data-out.hs
@@ -1,0 +1,8 @@
+type data Universe = Character | Number | Boolean
+
+type data Maybe a
+  = Just a
+  | Nothing
+
+type data P :: Type -> Type -> Type where
+  MkP :: (a ~ Natural, b ~~ Char) => P a b

--- a/data/examples/declaration/data/type-data.hs
+++ b/data/examples/declaration/data/type-data.hs
@@ -1,0 +1,7 @@
+type data Universe = Character | Number | Boolean
+
+type data Maybe a = Just a
+                  | Nothing
+
+type data P :: Type -> Type -> Type where
+  MkP :: (a ~ Natural, b ~~ Char) => P a b

--- a/data/examples/declaration/value/function/overloaded-labels-out.hs
+++ b/data/examples/declaration/value/function/overloaded-labels-out.hs
@@ -3,3 +3,36 @@
 foo = #field
 
 bar = (#this) (#that)
+
+baz = #Foo #"Hello world!" #"\"" #3 #"\n"
+
+-- from https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.6.1-alpha3/testsuite/tests/overloadedrecflds/should_run/T11671_run.hs
+-- unnecessary once https://github.com/tweag/ormolu/issues/821 lands
+main =
+  traverse_
+    putStrLn
+    [ #a,
+      #number17,
+      #do,
+      #type,
+      #Foo,
+      #3,
+      #"199.4",
+      #17a23b,
+      #f'a',
+      #'a',
+      #',
+      #''notTHSplice,
+      #"...",
+      #привет,
+      #こんにちは,
+      #"3",
+      #":",
+      #"Foo",
+      #"The quick brown fox",
+      #"\"",
+      (++) #hello #world,
+      (++) #"hello" #"world",
+      #"hello" # 1, -- equivalent to `(fromLabel @"hello") # 1`
+      f "hello" #2 -- equivalent to `f ("hello"# :: Addr#) 2`
+    ]

--- a/data/examples/declaration/value/function/overloaded-labels.hs
+++ b/data/examples/declaration/value/function/overloaded-labels.hs
@@ -2,3 +2,33 @@
 
 foo = #field
 bar = (#this ) ( #that)
+baz = #Foo #"Hello world!" #"\"" #3 #"\n"
+
+-- from https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.6.1-alpha3/testsuite/tests/overloadedrecflds/should_run/T11671_run.hs
+-- unnecessary once https://github.com/tweag/ormolu/issues/821 lands
+main = traverse_ putStrLn
+  [ #a
+  , #number17
+  , #do
+  , #type
+  , #Foo
+  , #3
+  , #"199.4"
+  , #17a23b
+  , #f'a'
+  , #'a'
+  , #'
+  , #''notTHSplice
+  , #"..."
+  , #привет
+  , #こんにちは
+  , #"3"
+  , #":"
+  , #"Foo"
+  , #"The quick brown fox"
+  , #"\""
+  , (++) #hello#world
+  , (++) #"hello"#"world"
+  , #"hello"# 1 -- equivalent to `(fromLabel @"hello") # 1`
+  , f "hello"#2 -- equivalent to `f ("hello"# :: Addr#) 2`
+  ]

--- a/expected-failures/esqueleto.txt
+++ b/expected-failures/esqueleto.txt
@@ -1,3 +1,3 @@
 src/Database/Esqueleto/Internal/Internal.hs:410:1
   The GHC parser (in Haddock mode) failed:
-  lexical error in string/character literal at character 's'
+  [GHC-21231] lexical error in string/character literal at character 's'

--- a/expected-failures/hlint.txt
+++ b/expected-failures/hlint.txt
@@ -1,31 +1,32 @@
 src/Extension.hs
-@@ -17,6 +17,7 @@
+@@ -17,7 +17,8 @@
            UnboxedTuples,
            UnboxedSums, -- breaks (#) lens operator
            QuasiQuotes, -- breaks [x| ...], making whitespace free list comps break
 -          {- DoRec , -} RecursiveDo, -- breaks rec
 +          {- DoRec , -}
 +          RecursiveDo, -- breaks rec
-           LexicalNegation -- changes '-', see https://github.com/ndmitchell/hlint/issues/1230
-         ]
+           LexicalNegation, -- changes '-', see https://github.com/ndmitchell/hlint/issues/1230
+           -- These next two change syntax significantly and must be opt-in.
+           OverloadedRecordDot,
 
   Formatting is not idempotent.
   Please, consider reporting the bug.
 src/Hint/Bracket.hs
-@@ -263,8 +263,11 @@
-                 let y = noLoc $ HsApp noExtField a1 (noLoc (HsPar noExtField a2)),
-                 let r = Replace Expr (toSS e) [("a", toSS a1), ("b", toSS a2)] "a (b)"
+@@ -259,8 +259,11 @@
+                 let y = noLocA $ HsApp EpAnnNotUsed a1 (noLocA (HsPar EpAnnNotUsed a2)),
+                 let r = Replace Expr (toSSA e) [("a", toSSA a1), ("b", toSSA a2)] "a (b)"
              ]
--         ++ [ (suggest "Redundant bracket" x y [r]) {ideaSpan -- Special case of (v1 . v2) <$> v3
--                                                     = locPar}
-+         ++ [ (suggest "Redundant bracket" x y [r])
+-         ++ [ (suggest "Redundant bracket" (reLoc x) (reLoc y) [r]) {ideaSpan -- Special case of (v1 . v2) <$> v3
+-                                                                     = locA locPar}
++         ++ [ (suggest "Redundant bracket" (reLoc x) (reLoc y) [r])
 +                { ideaSpan -- Special case of (v1 . v2) <$> v3
 +                  =
-+                    locPar
++                    locA locPar
 +                }
                | L _ (OpApp _ (L locPar (HsPar _ o1@(L locNoPar (OpApp _ _ (isDot -> True) _)))) o2 v3) <- [x],
                  varToStr o2 == "<$>",
-                 let y = noLoc (OpApp noExtField o1 o2 v3) :: LHsExpr GhcPs,
+                 let y = noLocA (OpApp EpAnnNotUsed o1 o2 v3) :: LHsExpr GhcPs,
 
   Formatting is not idempotent.
   Please, consider reporting the bug.

--- a/expected-failures/leksah.txt
+++ b/expected-failures/leksah.txt
@@ -1,6 +1,6 @@
 src/IDE/Find.hs:615:36-46
   The GHC parser (in Haddock mode) failed:
-  Bang pattern in expression context: !matchIndex
+  [GHC-95644] Bang pattern in expression context: !matchIndex
 Did you mean to add a space after the '!'?
 src/IDE/Pane/Modules.hs
 @@ -1183,9 +1183,9 @@

--- a/expected-failures/lens.txt
+++ b/expected-failures/lens.txt
@@ -1,3 +1,3 @@
-tests/properties.hs:121:26-28
+tests/properties.hs:117:26-28
   The GHC parser (in Haddock mode) failed:
-  parse error on input `KVS'
+  [GHC-58481] parse error on input `KVS'

--- a/expected-failures/pandoc.txt
+++ b/expected-failures/pandoc.txt
@@ -13,7 +13,7 @@ src/Text/Pandoc/Readers/Org/Inlines.hs
   Formatting is not idempotent.
   Please, consider reporting the bug.
 src/Text/Pandoc/Readers/RST.hs
-@@ -1119,7 +1119,7 @@
+@@ -1124,7 +1124,7 @@
               -- if no ":class:" field is given, the default is the role name
               classFieldClasses = maybe [role] T.words (lookup "class" fields)
 -             -- nub in case role name & language class are the same

--- a/expected-failures/postgrest.txt
+++ b/expected-failures/postgrest.txt
@@ -1,42 +1,21 @@
-src/PostgREST/Request/DbRequestBuilder.hs
-@@ -202,12 +202,11 @@
-                     -- /projects?select=clients(*)
-                     origin == tableName relTable
-                       && target == tableName relForeignTable -- projects
--                      || -- clients
-+                      || ( origin == tableName relTable -- clients
-                       -- /projects?select=projects_client_id_fkey(*)
--                      ( origin == tableName relTable
--                          && matchConstraint (Just target) relCardinality -- projects
--                          -- projects_client_id_fkey
--                      )
-+                             && matchConstraint (Just target) relCardinality -- projects
-+                             -- projects_client_id_fkey
-+                         )
-                       ||
-                       -- /projects?select=client_id(*)
-                       ( origin == tableName relTable
-@@ -216,16 +215,14 @@
-                       )
-                   )
-                && ( isNothing hint
--                      || -- hint is optional
-+                      || matchConstraint hint relCardinality -- hint is optional
-                       -- /projects?select=clients!projects_client_id_fkey(*)
--                      matchConstraint hint relCardinality
--                      || -- projects_client_id_fkey
-+                      || matchFKSingleCol hint relColumns -- projects_client_id_fkey
-                       -- /projects?select=clients!client_id(*) or /projects?select=clients!id(*)
--                      matchFKSingleCol hint relColumns
-                       || matchFKSingleCol hint relForeignColumns -- client_id
--                      || -- id
-+                      || matchJunction hint relCardinality -- id
-                       -- /users?select=tasks!users_tasks(*) many-to-many between users and tasks
--                      matchJunction hint relCardinality -- users_tasks
-+                      -- users_tasks
-                   )
+src/PostgREST/Plan.hs
+@@ -273,13 +273,12 @@
+                        && (
+                             -- /projects?select=clients!projects_client_id_fkey(*)
+                             matchConstraint hnt relCardinality
+-                              || -- projects_client_id_fkey
++                              || matchFKSingleCol hnt relCardinality -- projects_client_id_fkey
+                               -- /projects?select=clients!client_id(*) or /projects?select=clients!id(*)
+-                              matchFKSingleCol hnt relCardinality
+                               || matchFKRefSingleCol hnt relCardinality -- client_id
+-                              || -- id
++                              || matchJunction hnt relCardinality -- id
+                               -- /users?select=tasks!users_tasks(*) many-to-many between users and tasks
+-                              matchJunction hnt relCardinality -- users_tasks
++                              -- users_tasks
+                           )
           )
-          allRels
+          $ fromMaybe mempty
 
   Formatting is not idempotent.
   Please, consider reporting the bug.

--- a/expected-failures/purescript.txt
+++ b/expected-failures/purescript.txt
@@ -1,5 +1,5 @@
 src/Language/PureScript/CoreFn/CSE.hs
-@@ -218,11 +218,12 @@
+@@ -227,11 +227,12 @@
     at d . non mempty . at e %%<~ \case
       Nothing -> freshIdent (nameHint e) <&> \ident -> ((True, ident), Just ident)
       Just ident -> pure ((False, ident), Just ident)
@@ -17,7 +17,7 @@ src/Language/PureScript/CoreFn/CSE.hs
   Formatting is not idempotent.
   Please, consider reporting the bug.
 src/Language/PureScript/CoreFn/Laziness.hs
-@@ -527,12 +527,12 @@
+@@ -525,12 +525,12 @@
                           makeForceCall ann ident'
                     q -> Var ann q
              in (ident, rewriteExpr <$> item)

--- a/extract-hackage-info/extract-hackage-info.cabal
+++ b/extract-hackage-info/extract-hackage-info.cabal
@@ -10,7 +10,7 @@ executable extract-hackage-info
     default-language: Haskell2010
     ghc-options:      -O2 -Wall -rtsopts -Wunused-packages
     build-depends:
-        Cabal-syntax >=3.8 && <3.9,
+        Cabal-syntax >=3.10 && <3.11,
         base >=4.12 && <5.0,
         binary >=0.8 && <0.9,
         bytestring >=0.10 && <0.12,

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     "cabal-34": {
       "flake": false,
       "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     "cabal-36": {
       "flake": false,
       "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
         "type": "github"
       },
       "original": {
@@ -104,27 +104,6 @@
         "naersk": "naersk",
         "nixpkgs": "nixpkgs_8",
         "utils": "utils_2"
-      },
-      "locked": {
-        "lastModified": 1655647809,
-        "narHash": "sha256-npyHYIJW7HyGIFpCZZK+t5JM/v2LsyFhAGJxX1DXO7E=",
-        "owner": "astro",
-        "repo": "deadnix",
-        "rev": "83c42cc64d190ecb72f5929eab0f64fe88e25dc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "astro",
-        "repo": "deadnix",
-        "type": "github"
-      }
-    },
-    "deadnix_2": {
-      "inputs": {
-        "fenix": "fenix_2",
-        "naersk": "naersk_2",
-        "nixpkgs": "nixpkgs_11",
-        "utils": "utils_3"
       },
       "locked": {
         "lastModified": 1656370114,
@@ -201,11 +180,11 @@
     "docs-search": {
       "flake": false,
       "locked": {
-        "lastModified": 1661787609,
-        "narHash": "sha256-jgOl8PKisRmcaHOya3HzArI3eKjVErx+XIBGminh9Zk=",
+        "lastModified": 1675992564,
+        "narHash": "sha256-Tk9VSogFHXtXe9O9vuCEfM/PV/S7plMIO0I++fCZn7U=",
         "owner": "purs-nix",
         "repo": "purescript-docs-search",
-        "rev": "4620575e21886fcbf516d0b43910ba4ead2a60d0",
+        "rev": "35822b1d6ce65b1a07f80dd9e2caf15c3ee83e2c",
         "type": "github"
       },
       "original": {
@@ -225,48 +204,6 @@
         "owner": "nix-community",
         "repo": "fenix",
         "rev": "b6630603af13df17d0dd4df8629e9a24e6ba0fbd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "fenix_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_9",
-        "rust-analyzer-src": "rust-analyzer-src_2"
-      },
-      "locked": {
-        "lastModified": 1655533500,
-        "narHash": "sha256-qJJmLVoMYfDLywI9MNL7sb0W/GsKQF9HDatdHm1tSl0=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "b6630603af13df17d0dd4df8629e9a24e6ba0fbd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "fenix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "purs-nix",
-          "statix",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_3"
-      },
-      "locked": {
-        "lastModified": 1645251813,
-        "narHash": "sha256-cQ66tGjnZclBCS3nD26mZ5fUH+3/HnysGffBiWXUSHk=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "9892337b588c38ec59466a1c89befce464aae7f8",
         "type": "github"
       },
       "original": {
@@ -341,11 +278,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -386,21 +323,6 @@
     },
     "flake-utils_5": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "locked": {
         "lastModified": 1618217525,
         "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
         "owner": "numtide",
@@ -414,7 +336,7 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
+    "flake-utils_6": {
       "locked": {
         "lastModified": 1618217525,
         "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
@@ -468,11 +390,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1676545742,
-        "narHash": "sha256-j0PtTtNh7OAy2DsaB6/UMD7tDhtDyXl1Rgr6A9RUeSQ=",
+        "lastModified": 1678818975,
+        "narHash": "sha256-9Gnli850Jdb18dTqCNcZHm92B1L0TmLDWfr23G6BvCo=",
         "owner": "ghc",
         "repo": "ghc-wasm-meta",
-        "rev": "3071f3fbe6dfe9d07ae88af700fb32e74f8a1a11",
+        "rev": "b0856a88cf3edeed317e51a007077c177f8db0fd",
         "type": "gitlab"
       },
       "original": {
@@ -503,28 +425,6 @@
         "type": "github"
       }
     },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "purs-nix",
-          "statix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1635165013,
-        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "gomod2nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_3",
@@ -547,11 +447,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1674692755,
-        "narHash": "sha256-p/FnWnCFNF6bqU3lyUJgKUsKEEoeZPOoBdTLqU2O4R0=",
+        "lastModified": 1678926579,
+        "narHash": "sha256-5t1QRBTsEM2wREtDf3xrHp9Kphs+AdQZKAEltaylIJQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "47b88d3591e159961e149de9381a35dc8dc62cfb",
+        "rev": "fb58b0ba5773c5f0211f284b0fae061426cf8267",
         "type": "github"
       },
       "original": {
@@ -589,11 +489,11 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1674694244,
-        "narHash": "sha256-WiRjhSOxIqBwAP39VPf4ZrCqPK2Jf58up2xyk3tYyxI=",
+        "lastModified": 1678950661,
+        "narHash": "sha256-lvL54W90BTvwLVnFjPYmFVmgHyaGcFrt5FBy1F0rro8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "418612f2f2b814ae6161682fb3770c3c86c41b44",
+        "rev": "fce554bc6a41d12f7a18a0e8290bf43f925d7a29",
         "type": "github"
       },
       "original": {
@@ -629,16 +529,39 @@
         ]
       },
       "locked": {
-        "lastModified": 1646878427,
-        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
         "owner": "NixOS",
         "repo": "hydra",
-        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
         "type": "github"
       },
       "original": {
         "id": "hydra",
         "type": "indirect"
+      }
+    },
+    "incl": {
+      "inputs": {
+        "nixlib": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
       }
     },
     "iserv-proxy": {
@@ -706,25 +629,14 @@
         "type": "github"
       }
     },
-    "mdbook-kroki-preprocessor": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661755005,
-        "narHash": "sha256-1TJuUzfyMycWlOQH67LR63/ll2GDZz25I3JfScy/Jnw=",
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "rev": "93adb5716d035829efed27f65f2f0833a7d3e76f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JoelCourtney",
-        "repo": "mdbook-kroki-preprocessor",
-        "type": "github"
-      }
-    },
     "n2c": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "haskellNix",
           "tullia",
@@ -764,24 +676,6 @@
         "type": "github"
       }
     },
-    "naersk_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_10"
-      },
-      "locked": {
-        "lastModified": 1655042882,
-        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -789,16 +683,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1643066034,
-        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "2.6.0",
+        "ref": "2.11.0",
         "repo": "nix",
         "type": "github"
       }
@@ -894,15 +788,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676426280,
-        "narHash": "sha256-7DltKPrvCP0A9Iemv2ts1vnBYn5xQKScK/sb1VALlao=",
-        "owner": "nixos",
+        "lastModified": 1678594102,
+        "narHash": "sha256-OHAHYiMWJFPNxuW/PcOMlSD2tvXnEYC1jxREBADHwwQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6d33e5e14fd12f99ba621683ae90cebadda753ca",
+        "rev": "796b4a3c1d903c4b9270cd2548fe46f524eeb886",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -958,11 +852,11 @@
     },
     "nixpkgs-2205": {
       "locked": {
-        "lastModified": 1663981975,
-        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
         "type": "github"
       },
       "original": {
@@ -974,11 +868,11 @@
     },
     "nixpkgs-2211": {
       "locked": {
-        "lastModified": 1669997163,
-        "narHash": "sha256-vhjC0kZMFoN6jzK0GR+tBzKi5KgBXgehadfidW8+Va4=",
+        "lastModified": 1675730325,
+        "narHash": "sha256-uNvD7fzO5hNlltNQUAFBPlcEjNG5Gkbhl/ROiX+GZU4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f87491a54d8d64d30af6663cb3bf5d2ee7db958",
+        "rev": "b7ce17b1ebf600a72178f6302c77b6382d09323f",
         "type": "github"
       },
       "original": {
@@ -998,9 +892,10 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
         "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "indirect"
+        "type": "github"
       }
     },
     "nixpkgs-stable": {
@@ -1021,75 +916,15 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1663905476,
-        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
+        "lastModified": 1675758091,
+        "narHash": "sha256-7gFSQbSVAFUHtGCNHPF7mPc5CcqDk9M2+inlVPZSneg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
+        "rev": "747927516efcb5e31ba03b7ff32f61f6d47e7d87",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1655481042,
-        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1655481042,
-        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_12": {
-      "locked": {
-        "lastModified": 1656549732,
-        "narHash": "sha256-eILutFZGjfk2bEzfim8S/qyYc//0S1KsCeO+OWbtoR0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d3248619647234b5dc74a6921bcdf6dd8323eb22",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_13": {
-      "locked": {
-        "lastModified": 1645013224,
-        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -1097,17 +932,18 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_3": {
@@ -1203,17 +1039,32 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1655400192,
-        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
-        "owner": "nixos",
+        "lastModified": 1656549732,
+        "narHash": "sha256-eILutFZGjfk2bEzfim8S/qyYc//0S1KsCeO+OWbtoR0=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
+        "rev": "d3248619647234b5dc74a6921bcdf6dd8323eb22",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nosys": {
+      "locked": {
+        "lastModified": 1667881534,
+        "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "2d0d5207f6a230e9d0f660903f8db9807b54814f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
         "type": "github"
       }
     },
@@ -1278,11 +1129,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674550893,
-        "narHash": "sha256-HXI8AB96PP7UZ7iPANACXM8qc9eMz0ljxBEDM8JJKhY=",
+        "lastModified": 1678376203,
+        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7bdf85f6bbef581eb687838d19f2b35a4c9d77f0",
+        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
         "type": "github"
       },
       "original": {
@@ -1293,17 +1144,17 @@
     },
     "ps-tools": {
       "inputs": {
-        "deadnix": "deadnix_2",
+        "deadnix": "deadnix",
         "make-shell": "make-shell_2",
-        "nixpkgs": "nixpkgs_12",
-        "utils": "utils_4"
+        "nixpkgs": "nixpkgs_9",
+        "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1658374818,
-        "narHash": "sha256-WxbQ/BR4Ep8tBbaOikXechspyZlvwfL5XNmRNEnaOFo=",
+        "lastModified": 1675987041,
+        "narHash": "sha256-0aHIrngBLXO95SH+PjyTWJ7LWoFdJtx8y6oSln0l5Ak=",
         "owner": "purs-nix",
         "repo": "purescript-tools",
-        "rev": "c0f887f60ea2331dfdc5b0e8be2e732976887345",
+        "rev": "7929148939325f1fed916884c53cad3c0dfa4be7",
         "type": "github"
       },
       "original": {
@@ -1314,7 +1165,6 @@
     },
     "purs-nix": {
       "inputs": {
-        "deadnix": "deadnix",
         "docs-search": "docs-search",
         "get-flake": "get-flake",
         "make-shell": "make-shell",
@@ -1323,15 +1173,14 @@
         ],
         "parsec": "parsec",
         "ps-tools": "ps-tools",
-        "statix": "statix",
-        "utils": "utils_5"
+        "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1674243319,
-        "narHash": "sha256-o39rBVSNqchahHrMYNixdlasDro8omlf/n7yQZsdNI8=",
+        "lastModified": 1677820987,
+        "narHash": "sha256-5lrWnpC39a0M9VL7GzP88K+bTzAZP9AjLNQpbtsfuUw=",
         "owner": "purs-nix",
         "repo": "purs-nix",
-        "rev": "2b7761ffaded363d0d00afe320350cc5c9ee9012",
+        "rev": "e5af208563a8e66f8a78f3b5aeaacea9074bcd27",
         "type": "github"
       },
       "original": {
@@ -1379,89 +1228,41 @@
         "type": "github"
       }
     },
-    "rust-analyzer-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1655507737,
-        "narHash": "sha256-o+AqNsjL6o2RHh4InZHQVpkmqg570YFJL4Db8mKq+fs=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "12dd81092e37df28b7a3591cae9675e668927198",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645205556,
-        "narHash": "sha256-e4lZW3qRyOEJ+vLKFQP7m2Dxh5P44NrnekZYLxlucww=",
-        "owner": "rust-analyzer",
-        "repo": "rust-analyzer",
-        "rev": "acf5874b39f3dc5262317a6074d9fc7285081161",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-analyzer",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1674605441,
-        "narHash": "sha256-GX5OHXYP6jRSlDq0KOpb4AXgeEU70zVTRQ/ogKg7vR4=",
+        "lastModified": 1678925630,
+        "narHash": "sha256-rl8qnpAUJl4tRZpaZ5DpgSueNfreArW09t4zTnOaoYA=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "17e090ed82bc8aedaf251a8becb7ba2455db816a",
+        "rev": "bf29b23fb77017e78c6e7b199b2c7bfb5079c4cd",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "statix": {
-      "inputs": {
-        "fenix": "fenix_3",
-        "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_13"
-      },
-      "locked": {
-        "lastModified": 1657460333,
-        "narHash": "sha256-5o6zMBASEsGKtjKDb3SizJnN9A7qpOcbzWBXsacfMyc=",
-        "owner": "nerdypepper",
-        "repo": "statix",
-        "rev": "6422c959d365dee2fda5eda8858fefad31f17b25",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nerdypepper",
-        "repo": "statix",
         "type": "github"
       }
     },
     "std": {
       "inputs": {
+        "arion": [
+          "haskellNix",
+          "tullia",
+          "std",
+          "blank"
+        ],
         "blank": "blank",
         "devshell": "devshell",
         "dmerge": "dmerge",
         "flake-utils": "flake-utils_4",
+        "incl": "incl",
         "makes": [
           "haskellNix",
           "tullia",
           "std",
           "blank"
         ],
-        "mdbook-kroki-preprocessor": "mdbook-kroki-preprocessor",
         "microvm": [
           "haskellNix",
           "tullia",
@@ -1471,14 +1272,15 @@
         "n2c": "n2c",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs_5",
+        "nosys": "nosys",
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1665513321,
-        "narHash": "sha256-D6Pacw9yf/HMs84KYuCxHXnNDL7v43gtcka5URagFqE=",
+        "lastModified": 1674526466,
+        "narHash": "sha256-tMTaS0bqLx6VJ+K+ZT6xqsXNpzvSXJTmogkraBGzymg=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "94a90eedb9cfc115b12ae8f6622d9904788559e4",
+        "rev": "516387e3d8d059b50e742a2ff1909ed3c8f82826",
         "type": "github"
       },
       "original": {
@@ -1498,11 +1300,11 @@
         "std": "std"
       },
       "locked": {
-        "lastModified": 1668711738,
-        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
+        "lastModified": 1675695930,
+        "narHash": "sha256-B7rEZ/DBUMlK1AcJ9ajnAPPxqXY6zW2SBX+51bZV0Ac=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
+        "rev": "621365f2c725608f381b3ad5b57afef389fd4c31",
         "type": "github"
       },
       "original": {
@@ -1542,23 +1344,8 @@
       }
     },
     "utils_3": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_4": {
       "inputs": {
-        "flake-utils": "flake-utils_6"
+        "flake-utils": "flake-utils_5"
       },
       "locked": {
         "lastModified": 1656044990,
@@ -1575,9 +1362,9 @@
         "type": "github"
       }
     },
-    "utils_5": {
+    "utils_4": {
       "inputs": {
-        "flake-utils": "flake-utils_7"
+        "flake-utils": "flake-utils_6"
       },
       "locked": {
         "lastModified": 1656044990,
@@ -1604,11 +1391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660507851,
-        "narHash": "sha256-BKjq7JnVuUR/xDtcv6Vm9GYGKAblisXrAgybor9hT/s=",
+        "lastModified": 1667096281,
+        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
         "owner": "divnix",
         "repo": "yants",
-        "rev": "0b895ca02a8fa72bad50b454cb3e7d8a66407c96",
+        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         inherit (pkgs) lib haskell-nix;
         inherit (haskell-nix) haskellLib;
 
-        ghcVersions = [ "ghc925" "ghc902" "ghc944" ];
+        ghcVersions = [ "ghc927" "ghc944" "ghc961" ];
         defaultGHCVersion = builtins.head ghcVersions;
         perGHC = lib.genAttrs ghcVersions (ghcVersion:
           let
@@ -71,8 +71,8 @@
             });
           in
           packages // {
-            ci = pkgs.linkFarmFromDrvs "ormolu-ci-${ghcVersion}"
-              (lib.attrValues (flake-utils.lib.flattenTree packages));
+            ci = pkgs.linkFarm "ormolu-ci-${ghcVersion}"
+              (flake-utils.lib.flattenTree packages);
           });
         defaultGHC = perGHC.${defaultGHCVersion};
 

--- a/ormolu-live/cabal.project
+++ b/ormolu-live/cabal.project
@@ -1,21 +1,20 @@
 packages: . ..
 
 index-state:
-  , hackage.haskell.org 2023-01-13T16:50:23Z
-  , head.hackage 2022-12-25T15:05:28Z
-
-allow-newer: base, ghc-prim, transformers, unix, template-haskell
+  , hackage.haskell.org 2023-03-16T09:32:28Z
+  , head.hackage 2023-02-16T05:32:02Z
 
 package ormolu
+  -- The WASM backend does not support TH.
   flags: -internal-bundle-fixities
 
--- Reasons for the fork:
---  - Disable threaded runtime: https://github.com/digital-asset/ghc-lib/issues/184#issuecomment-1372466968
---    Will be unnecessary starting with the next ghc-lib-parser release.
---  - Remove build-tool-depends. Cabal does not support cross-toolchains.
---  - Fix compile error due to GHC 9.6 change: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.6#type-changing-record-updates-involving-type-families
+package ghc-lib-parser
+  -- The WASM backend does not support the threaded RTS.
+  flags: -threaded-rts
+
+-- Remove build-tool-depends as Cabal does not support cross-toolchains.
 source-repository-package
   type: git
   location: https://github.com/amesgen/stuff
-  tag: 7745cda8368298589fd70f34463c24dcaa6145ea
-  subdir: ghc-lib-parser-9.4.4.20221225
+  tag: 6cd8d7efd9704d3a3384eb91b4fe9d9912b52739
+  subdir: ghc-lib-parser-9.6.1.20230312-wasm

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -4,7 +4,7 @@ version:            0.5.3.0
 license:            BSD-3-Clause
 license-file:       LICENSE.md
 maintainer:         Mark Karpov <mark.karpov@tweag.io>
-tested-with:        ghc ==9.0.2 ghc ==9.2.5 ghc ==9.4.4
+tested-with:        ghc ==9.2.7 ghc ==9.4.4 ghc ==9.6.1
 homepage:           https://github.com/tweag/ormolu
 bug-reports:        https://github.com/tweag/ormolu/issues
 synopsis:           A formatter for Haskell source code
@@ -96,7 +96,7 @@ library
     other-modules:    GHC.DynFlags
     default-language: Haskell2010
     build-depends:
-        Cabal-syntax >=3.8 && <3.9,
+        Cabal-syntax >=3.10 && <3.11,
         Diff >=0.4 && <1.0,
         MemoTrie >=0.6 && <0.7,
         ansi-terminal >=0.10 && <1.0,
@@ -109,7 +109,7 @@ library
         directory ^>=1.3,
         file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
+        ghc-lib-parser >=9.6 && <9.7,
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
@@ -138,7 +138,7 @@ executable ormolu
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
+        ghc-lib-parser >=9.6 && <9.7,
         th-env >=0.1.1 && <0.2,
         optparse-applicative >=0.14 && <0.18,
         ormolu,
@@ -173,13 +173,13 @@ test-suite tests
 
     default-language:   Haskell2010
     build-depends:
-        Cabal-syntax >=3.8 && <3.9,
+        Cabal-syntax >=3.10 && <3.11,
         QuickCheck >=2.14,
         base >=4.14 && <5.0,
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
+        ghc-lib-parser >=9.6 && <9.7,
         hspec >=2.0 && <3.0,
         hspec-megaparsec >=2.2,
         ormolu,

--- a/src/GHC/DynFlags.hs
+++ b/src/GHC/DynFlags.hs
@@ -49,8 +49,5 @@ fakeSettings =
           }
     }
 
-fakeLlvmConfig :: LlvmConfig
-fakeLlvmConfig = LlvmConfig [] []
-
 baseDynFlags :: DynFlags
-baseDynFlags = defaultDynFlags fakeSettings fakeLlvmConfig
+baseDynFlags = defaultDynFlags fakeSettings

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -44,7 +44,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Debug.Trace
 import qualified GHC.Driver.CmdLine as GHC
-import qualified GHC.Types.SrcLoc as GHC
+import GHC.Types.SrcLoc
 import Ormolu.Config
 import Ormolu.Diff.ParseResult
 import Ormolu.Diff.Text
@@ -220,7 +220,7 @@ parseModule' ::
   -- | Fixity Map for operators
   LazyFixityMap ->
   -- | How to obtain 'OrmoluException' to throw when parsing fails
-  (GHC.SrcSpan -> String -> OrmoluException) ->
+  (SrcSpan -> String -> OrmoluException) ->
   -- | File name to use in errors
   FilePath ->
   -- | Actual input for the parser
@@ -237,7 +237,7 @@ showWarn :: GHC.Warn -> String
 showWarn (GHC.Warn reason l) =
   unlines
     [ showOutputable reason,
-      showOutputable l
+      unLoc l
     ]
 
 -- | Detect 'SourceType' based on the file extension.

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -1,15 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeepSubsumption #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-#if !MIN_VERSION_base(4,17,0)
--- needed on GHC 9.0 and 9.2 due to simplified subsumption
-{-# LANGUAGE ImpredicativeTypes #-}
-#endif
 
 -- | This module allows us to diff two 'ParseResult's.
 module Ormolu.Diff.ParseResult
@@ -77,6 +73,8 @@ diffCommentStream (CommentStream cs) (CommentStream cs')
 --     * LayoutInfo (brace style) in extension fields
 --     * Empty contexts in type classes
 --     * Parens around derived type classes
+--     * 'TokenLocation' (in 'LHsUniToken')
+--     * 'EpaLocation'
 matchIgnoringSrcSpans :: (Data a) => a -> a -> ParseResultDiff
 matchIgnoringSrcSpans a = genericQuery a
   where
@@ -100,10 +98,12 @@ matchIgnoringSrcSpans a = genericQuery a
                   `extQ` hsDocStringEq
                   `extQ` importDeclQualifiedStyleEq
                   `extQ` unicodeArrowStyleEq
-                  `extQ` considerEqual @LayoutInfo
+                  `extQ` considerEqual @(LayoutInfo GhcPs)
                   `extQ` classDeclCtxEq
                   `extQ` derivedTyClsParensEq
                   `extQ` considerEqual @EpAnnComments -- ~ XCGRHSs GhcPs
+                  `extQ` considerEqual @TokenLocation
+                  `extQ` considerEqual @EpaLocation
                   `ext2Q` forLocated
               )
               x

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 #if !MIN_VERSION_base(4,17,0)
 -- needed on GHC 9.0 and 9.2 due to simplified subsumption
@@ -18,6 +20,7 @@ where
 
 import Data.ByteString (ByteString)
 import Data.Foldable
+import Data.Function
 import Data.Generics
 import GHC.Hs
 import GHC.Types.SourceText
@@ -91,44 +94,49 @@ matchIgnoringSrcSpans a = genericQuery a
           mconcat $
             gzipWithQ
               ( genericQuery
-                  `extQ` srcSpanEq
+                  `extQ` considerEqual @SrcSpan
                   `ext1Q` epAnnEq
-                  `extQ` sourceTextEq
+                  `extQ` considerEqual @SourceText
                   `extQ` hsDocStringEq
                   `extQ` importDeclQualifiedStyleEq
                   `extQ` unicodeArrowStyleEq
-                  `extQ` layoutInfoEq
+                  `extQ` considerEqual @LayoutInfo
                   `extQ` classDeclCtxEq
                   `extQ` derivedTyClsParensEq
-                  `extQ` epaCommentsEq
+                  `extQ` considerEqual @EpAnnComments -- ~ XCGRHSs GhcPs
                   `ext2Q` forLocated
               )
               x
               y
       | otherwise = Different []
-    srcSpanEq :: SrcSpan -> GenericQ ParseResultDiff
-    srcSpanEq _ _ = Same
+
+    considerEqualVia ::
+      forall a.
+      (Typeable a) =>
+      (a -> a -> ParseResultDiff) ->
+      a ->
+      GenericQ ParseResultDiff
+    considerEqualVia f x (cast -> Just x') = f x x'
+    considerEqualVia _ _ _ = Different []
+
+    considerEqualVia' f =
+      considerEqualVia $ \x x' -> if f x x' then Same else Different []
+
+    considerEqual :: forall a. (Typeable a) => a -> GenericQ ParseResultDiff
+    considerEqual = considerEqualVia $ \_ _ -> Same
+
     epAnnEq :: EpAnn a -> GenericQ ParseResultDiff
     epAnnEq _ _ = Same
-    sourceTextEq :: SourceText -> GenericQ ParseResultDiff
-    sourceTextEq _ _ = Same
-    importDeclQualifiedStyleEq ::
-      ImportDeclQualifiedStyle ->
-      GenericQ ParseResultDiff
-    importDeclQualifiedStyleEq d0 d1' =
-      case (d0, cast d1' :: Maybe ImportDeclQualifiedStyle) of
-        (x, Just x') | x == x' -> Same
-        (QualifiedPre, Just QualifiedPost) -> Same
-        (QualifiedPost, Just QualifiedPre) -> Same
-        _ -> Different []
+
+    importDeclQualifiedStyleEq = considerEqualVia' f
+      where
+        f QualifiedPre QualifiedPost = True
+        f QualifiedPost QualifiedPre = True
+        f x x' = x == x'
+
     hsDocStringEq :: HsDocString -> GenericQ ParseResultDiff
-    hsDocStringEq str0 str1' =
-      case cast str1' :: Maybe HsDocString of
-        Nothing -> Different []
-        Just str1 ->
-          if splitDocString str0 == splitDocString str1
-            then Same
-            else Different []
+    hsDocStringEq = considerEqualVia' ((==) `on` splitDocString)
+
     forLocated ::
       (Data e0, Data e1) =>
       GenLocated e0 e1 ->
@@ -144,25 +152,19 @@ matchIgnoringSrcSpans a = genericQuery a
             else d
         UnhelpfulSpan _ -> d
     appendSpan _ d = d
+
     -- as we normalize arrow styles (e.g. -> vs →), we consider them equal here
-    unicodeArrowStyleEq :: HsArrow GhcPs -> GenericQ ParseResultDiff
-    unicodeArrowStyleEq (HsUnrestrictedArrow _) (castArrow -> Just (HsUnrestrictedArrow _)) = Same
-    unicodeArrowStyleEq (HsLinearArrow _) (castArrow -> Just (HsLinearArrow _)) = Same
-    unicodeArrowStyleEq (HsExplicitMult _ _ t) (castArrow -> Just (HsExplicitMult _ _ t')) = genericQuery t t'
-    unicodeArrowStyleEq _ _ = Different []
-    castArrow :: (Typeable a) => a -> Maybe (HsArrow GhcPs)
-    castArrow = cast
-    -- LayoutInfo ~ XClassDecl GhcPs tracks brace information
-    layoutInfoEq :: LayoutInfo -> GenericQ ParseResultDiff
-    layoutInfoEq _ (cast -> Just (_ :: LayoutInfo)) = Same
-    layoutInfoEq _ _ = Different []
+    unicodeArrowStyleEq = considerEqualVia @(HsArrow GhcPs) f
+      where
+        f (HsUnrestrictedArrow _) (HsUnrestrictedArrow _) = Same
+        f (HsLinearArrow _) (HsLinearArrow _) = Same
+        f (HsExplicitMult _ _ t) (HsExplicitMult _ _ t') = genericQuery t t'
+        f _ _ = Different []
+
     classDeclCtxEq :: TyClDecl GhcPs -> GenericQ ParseResultDiff
     classDeclCtxEq ClassDecl {tcdCtxt = Just (L _ []), ..} tc' = genericQuery ClassDecl {tcdCtxt = Nothing, ..} tc'
     classDeclCtxEq tc tc' = genericQuery tc tc'
+
     derivedTyClsParensEq :: DerivClauseTys GhcPs -> GenericQ ParseResultDiff
     derivedTyClsParensEq (DctSingle NoExtField sigTy) dct' = genericQuery (DctMulti NoExtField [sigTy]) dct'
     derivedTyClsParensEq dct dct' = genericQuery dct dct'
-    -- EpAnnComments ~ XCGRHSs GhcPs
-    epaCommentsEq :: EpAnnComments -> GenericQ ParseResultDiff
-    epaCommentsEq _ (cast -> Just (_ :: EpAnnComments)) = Same
-    epaCommentsEq _ _ = Different []

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -22,8 +23,6 @@ import GHC.Types.Name.Reader
 import GHC.Types.PkgQual
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
-import GHC.Unit.Module.Name
-import GHC.Unit.Types
 import Ormolu.Utils (notImplemented, showOutputable)
 
 -- | Sort and normalize imports.
@@ -39,7 +38,7 @@ normalizeImports =
       L
         l
         ImportDecl
-          { ideclHiding = second (fmap normalizeLies) <$> ideclHiding,
+          { ideclImportList = second (fmap normalizeLies) <$> ideclImportList,
             ..
           }
 
@@ -53,7 +52,7 @@ combineImports (L lx ImportDecl {..}) (L _ y) =
   L
     lx
     ImportDecl
-      { ideclHiding = case (ideclHiding, GHC.ideclHiding y) of
+      { ideclImportList = case (ideclImportList, GHC.ideclImportList y) of
           (Just (hiding, L l' xs), Just (_, L _ ys)) ->
             Just (hiding, (L l' (normalizeLies (xs ++ ys))))
           _ -> Nothing,
@@ -70,11 +69,22 @@ data ImportId = ImportId
     importSource :: IsBootInterface,
     importSafe :: Bool,
     importQualified :: Bool,
-    importImplicit :: Bool,
     importAs :: Maybe ModuleName,
-    importHiding :: Maybe Bool
+    importHiding :: Maybe ImportListInterpretationOrd
   }
   deriving (Eq, Ord)
+
+-- | 'ImportListInterpretation' does not have an 'Ord' instance.
+newtype ImportListInterpretationOrd = ImportListInterpretationOrd
+  { unImportListInterpretationOrd :: ImportListInterpretation
+  }
+  deriving stock (Eq)
+
+instance Ord ImportListInterpretationOrd where
+  compare = compare `on` toBool . unImportListInterpretationOrd
+    where
+      toBool Exactly = False
+      toBool EverythingBut = True
 
 -- | Obtain an 'ImportId' for a given import.
 importId :: LImportDecl GhcPs -> ImportId
@@ -89,9 +99,8 @@ importId (L _ ImportDecl {..}) =
         QualifiedPre -> True
         QualifiedPost -> True
         NotQualified -> False,
-      importImplicit = ideclImplicit,
       importAs = unLoc <$> ideclAs,
-      importHiding = fst <$> ideclHiding
+      importHiding = ImportListInterpretationOrd . fst <$> ideclImportList
     }
   where
     isPrelude = moduleNameString moduleName == "Prelude"
@@ -153,15 +162,15 @@ normalizeLies = sortOn (getIewn . unLoc) . M.elems . foldl' combine M.empty
                in Just (f <$> old)
        in M.alter alter wname m
 
--- | A wrapper for @'IEWrappedName' 'RdrName'@ that allows us to define an
+-- | A wrapper for @'IEWrappedName' 'GhcPs'@ that allows us to define an
 -- 'Ord' instance for it.
-newtype IEWrappedNameOrd = IEWrappedNameOrd (IEWrappedName RdrName)
+newtype IEWrappedNameOrd = IEWrappedNameOrd (IEWrappedName GhcPs)
   deriving (Eq)
 
 instance Ord IEWrappedNameOrd where
   compare (IEWrappedNameOrd x) (IEWrappedNameOrd y) = compareIewn x y
 
--- | Project @'IEWrappedName' 'RdrName'@ from @'IE' 'GhcPs'@.
+-- | Project @'IEWrappedName' 'GhcPs'@ from @'IE' 'GhcPs'@.
 getIewn :: IE GhcPs -> IEWrappedNameOrd
 getIewn = \case
   IEVar NoExtField x -> IEWrappedNameOrd (unLoc x)
@@ -174,18 +183,18 @@ getIewn = \case
   IEDocNamed NoExtField _ -> notImplemented "IEDocNamed"
 
 -- | Like 'compareIewn' for located wrapped names.
-compareLIewn :: LIEWrappedName RdrName -> LIEWrappedName RdrName -> Ordering
+compareLIewn :: LIEWrappedName GhcPs -> LIEWrappedName GhcPs -> Ordering
 compareLIewn = compareIewn `on` unLoc
 
--- | Compare two @'IEWrapppedName' 'RdrName'@ things.
-compareIewn :: IEWrappedName RdrName -> IEWrappedName RdrName -> Ordering
-compareIewn (IEName x) (IEName y) = unLoc x `compareRdrName` unLoc y
-compareIewn (IEName _) (IEPattern _ _) = LT
-compareIewn (IEName _) (IEType _ _) = LT
-compareIewn (IEPattern _ _) (IEName _) = GT
+-- | Compare two @'IEWrapppedName' 'GhcPs'@ things.
+compareIewn :: IEWrappedName GhcPs -> IEWrappedName GhcPs -> Ordering
+compareIewn (IEName _ x) (IEName _ y) = unLoc x `compareRdrName` unLoc y
+compareIewn (IEName _ _) (IEPattern _ _) = LT
+compareIewn (IEName _ _) (IEType _ _) = LT
+compareIewn (IEPattern _ _) (IEName _ _) = GT
 compareIewn (IEPattern _ x) (IEPattern _ y) = unLoc x `compareRdrName` unLoc y
 compareIewn (IEPattern _ _) (IEType _ _) = LT
-compareIewn (IEType _ _) (IEName _) = GT
+compareIewn (IEType _ _) (IEName _ _) = GT
 compareIewn (IEType _ _) (IEPattern _ _) = GT
 compareIewn (IEType _ x) (IEType _ y) = unLoc x `compareRdrName` unLoc y
 

--- a/src/Ormolu/Parser/CommentStream.hs
+++ b/src/Ormolu/Parser/CommentStream.hs
@@ -57,7 +57,7 @@ mkCommentStream ::
   -- | Original input
   Text ->
   -- | Module to use for comment extraction
-  HsModule ->
+  HsModule GhcPs ->
   -- | Stack header, pragmas, and comment stream
   ( Maybe (RealLocated Comment),
     [([RealLocated Comment], Pragma)],

--- a/src/Ormolu/Parser/Result.hs
+++ b/src/Ormolu/Parser/Result.hs
@@ -23,7 +23,7 @@ data SourceSnippet = RawSnippet Text | ParsedSnippet ParseResult
 -- | A collection of data that represents a parsed module in Ormolu.
 data ParseResult = ParseResult
   { -- | Parsed module or signature
-    prParsedSource :: HsModule,
+    prParsedSource :: HsModule GhcPs,
     -- | Either regular module or signature file
     prSourceType :: SourceType,
     -- | Stack header

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -175,4 +175,4 @@ p_hsDocName name = txt ("-- $" <> T.pack name)
 p_sourceText :: SourceText -> R ()
 p_sourceText = \case
   NoSourceText -> pure ()
-  SourceText s -> space >> txt (T.pack s)
+  SourceText s -> txt (T.pack s)

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -26,7 +26,7 @@ import GHC.Types.Name.Occurrence (OccName (..))
 import GHC.Types.Name.Reader
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
-import GHC.Unit.Module.Name
+import Language.Haskell.Syntax.Module.Name
 import Ormolu.Config (SourceType (..))
 import Ormolu.Printer.Combinators
 import Ormolu.Utils
@@ -48,9 +48,9 @@ p_hsmodName mname = do
   space
   atom mname
 
-p_ieWrappedName :: IEWrappedName RdrName -> R ()
+p_ieWrappedName :: IEWrappedName GhcPs -> R ()
 p_ieWrappedName = \case
-  IEName x -> p_rdrName x
+  IEName _ x -> p_rdrName x
   IEPattern _ x -> do
     txt "pattern"
     space

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -254,12 +254,12 @@ pattern
     RdrName -> HsDecl GhcPs
 pattern InlinePragma n <- SigD _ (InlineSig _ (L _ n) _)
 pattern SpecializePragma n <- SigD _ (SpecSig _ (L _ n) _ _)
-pattern SCCPragma n <- SigD _ (SCCFunSig _ _ (L _ n) _)
-pattern AnnTypePragma n <- AnnD _ (HsAnnotation _ _ (TypeAnnProvenance (L _ n)) _)
-pattern AnnValuePragma n <- AnnD _ (HsAnnotation _ _ (ValueAnnProvenance (L _ n)) _)
+pattern SCCPragma n <- SigD _ (SCCFunSig _ (L _ n) _)
+pattern AnnTypePragma n <- AnnD _ (HsAnnotation _ (TypeAnnProvenance (L _ n)) _)
+pattern AnnValuePragma n <- AnnD _ (HsAnnotation _ (ValueAnnProvenance (L _ n)) _)
 pattern Pattern n <- ValD _ (PatSynBind _ (PSB _ (L _ n) _ _ _))
 pattern DataDeclaration n <- TyClD _ (DataDecl _ (L _ n) _ _ _)
-pattern ClassDeclaration n <- TyClD _ (ClassDecl _ _ (L _ n) _ _ _ _ _ _ _ _)
+pattern ClassDeclaration n <- TyClD _ (ClassDecl _ _ _ (L _ n) _ _ _ _ _ _ _ _)
 pattern KindSignature n <- KindSigD _ (StandaloneKindSig _ (L _ n) _)
 pattern FamilyDeclaration n <- TyClD _ (FamDecl _ (FamilyDecl _ _ _ (L _ n) _ _ _ _))
 pattern TypeSynonym n <- TyClD _ (SynDecl _ (L _ n) _ _ _)
@@ -294,8 +294,8 @@ defSigRdrNames (SigD _ (ClassOpSig _ True ns _)) = Just $ map unLoc ns
 defSigRdrNames _ = Nothing
 
 funRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
-funRdrNames (ValD _ (FunBind _ (L _ n) _ _)) = Just [n]
-funRdrNames (ValD _ (PatBind _ (L _ n) _ _)) = Just $ patBindNames n
+funRdrNames (ValD _ (FunBind _ (L _ n) _)) = Just [n]
+funRdrNames (ValD _ (PatBind _ (L _ n) _)) = Just $ patBindNames n
 funRdrNames _ = Nothing
 
 patSigRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
@@ -303,7 +303,7 @@ patSigRdrNames (SigD _ (PatSynSig _ ns _)) = Just $ map unLoc ns
 patSigRdrNames _ = Nothing
 
 warnSigRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
-warnSigRdrNames (WarningD _ (Warnings _ _ ws)) = Just $
+warnSigRdrNames (WarningD _ (Warnings _ ws)) = Just $
   flip concatMap ws $
     \(L _ (Warning _ ns _)) -> map unLoc ns
 warnSigRdrNames _ = Nothing
@@ -316,7 +316,7 @@ patBindNames (LazyPat _ (L _ p)) = patBindNames p
 patBindNames (BangPat _ (L _ p)) = patBindNames p
 patBindNames (ParPat _ _ (L _ p) _) = patBindNames p
 patBindNames (ListPat _ ps) = concatMap (patBindNames . unLoc) ps
-patBindNames (AsPat _ (L _ n) (L _ p)) = n : patBindNames p
+patBindNames (AsPat _ (L _ n) _ (L _ p)) = n : patBindNames p
 patBindNames (SumPat _ (L _ p) _ _) = patBindNames p
 patBindNames (ViewPat _ _ (L _ p)) = patBindNames p
 patBindNames (SplicePat _ _) = []

--- a/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
@@ -12,7 +12,7 @@ import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration.Value
 
 p_annDecl :: AnnDecl GhcPs -> R ()
-p_annDecl (HsAnnotation _ _ annProv expr) =
+p_annDecl (HsAnnotation _ annProv expr) =
   pragma "ANN" . inci $ do
     p_annProv annProv
     breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -46,10 +46,12 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
   case unLoc <$> dd_cType of
     Nothing -> pure ()
     Just (CType prag header (type_, _)) -> do
+      space
       p_sourceText prag
       case header of
         Nothing -> pure ()
         Just (Header h _) -> space *> p_sourceText h
+      space
       p_sourceText type_
       txt " #-}"
   let constructorSpans = getLocA name : fmap lhsTypeArgSrcSpan tpats

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -57,6 +57,7 @@ p_foreignImport (CImport cCallConv safety _ _ sourceText) = do
   located cCallConv atom
   -- Need to check for 'noLoc' for the 'safe' annotation
   when (isGoodSrcSpan $ getLoc safety) (space >> atom safety)
+  space
   located sourceText p_sourceText
 
 p_foreignExport :: ForeignExport -> R ()
@@ -64,4 +65,5 @@ p_foreignExport (CExport (L loc (CExportStatic _ _ cCallConv)) sourceText) = do
   txt "foreign export"
   space
   located (L loc cCallConv) atom
+  space
   located sourceText p_sourceText

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -50,8 +50,8 @@ p_foreignTypeSig fd = do
 -- We also layout the identifier using the 'SourceText', because printing
 -- with the other two fields of 'CImport' is very complicated. See the
 -- 'Outputable' instance of 'ForeignImport' for details.
-p_foreignImport :: ForeignImport -> R ()
-p_foreignImport (CImport cCallConv safety _ _ sourceText) = do
+p_foreignImport :: ForeignImport GhcPs -> R ()
+p_foreignImport (CImport sourceText cCallConv safety _ _) = do
   txt "foreign import"
   space
   located cCallConv atom
@@ -60,8 +60,8 @@ p_foreignImport (CImport cCallConv safety _ _ sourceText) = do
   space
   located sourceText p_sourceText
 
-p_foreignExport :: ForeignExport -> R ()
-p_foreignExport (CExport (L loc (CExportStatic _ _ cCallConv)) sourceText) = do
+p_foreignExport :: ForeignExport GhcPs -> R ()
+p_foreignExport (CExport sourceText (L loc (CExportStatic _ _ cCallConv))) = do
   txt "foreign export"
   space
   located (L loc cCallConv) atom

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -18,7 +18,7 @@ import Ormolu.Printer.Meat.Declaration.Value
 import Ormolu.Printer.Meat.Type
 
 p_ruleDecls :: RuleDecls GhcPs -> R ()
-p_ruleDecls (HsRules _ _ xs) =
+p_ruleDecls (HsRules _ xs) =
   pragma "RULES" $ sep breakpoint (sitcc . located' p_ruleDecl) xs
 
 p_ruleDecl :: RuleDecl GhcPs -> R ()
@@ -46,8 +46,8 @@ p_ruleDecl (HsRule _ ruleName activation tyvars ruleBndrs lhs rhs) = do
       breakpoint
       located rhs p_hsExpr
 
-p_ruleName :: (SourceText, RuleName) -> R ()
-p_ruleName (_, name) = atom $ (HsString NoSourceText name :: HsLit GhcPs)
+p_ruleName :: RuleName -> R ()
+p_ruleName name = atom (HsString NoSourceText name :: HsLit GhcPs)
 
 p_ruleBndr :: RuleBndr GhcPs -> R ()
 p_ruleBndr = \case

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -32,11 +32,10 @@ p_sigDecl = \case
   FixSig _ sig -> p_fixSig sig
   InlineSig _ name inlinePragma -> p_inlineSig name inlinePragma
   SpecSig _ name ts inlinePragma -> p_specSig name ts inlinePragma
-  SpecInstSig _ _ sigType -> p_specInstSig sigType
-  MinimalSig _ _ booleanFormula -> p_minimalSig booleanFormula
-  CompleteMatchSig _ _sourceText cs ty -> p_completeSig cs ty
-  SCCFunSig _ _ name literal -> p_sccSig name literal
-  _ -> notImplemented "certain types of signature declarations"
+  SpecInstSig _ sigType -> p_specInstSig sigType
+  MinimalSig _ booleanFormula -> p_minimalSig booleanFormula
+  CompleteMatchSig _ cs ty -> p_completeSig cs ty
+  SCCFunSig _ name literal -> p_sccSig name literal
 
 p_typeSig ::
   -- | Should the tail of the names be indented

--- a/src/Ormolu/Printer/Meat/Declaration/Splice.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Splice.hs
@@ -7,8 +7,8 @@ where
 
 import GHC.Hs
 import Ormolu.Printer.Combinators
-import Ormolu.Printer.Meat.Declaration.Value (p_hsSplice)
+import Ormolu.Printer.Meat.Declaration.Value (p_hsUntypedSplice)
 
 p_spliceDecl :: SpliceDecl GhcPs -> R ()
-p_spliceDecl = \case
-  SpliceDecl NoExtField splice _explicit -> located splice p_hsSplice
+p_spliceDecl (SpliceDecl NoExtField splice deco) =
+  located splice $ p_hsUntypedSplice deco

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
@@ -2,7 +2,7 @@ module Ormolu.Printer.Meat.Declaration.Value
   ( p_valDecl,
     p_pat,
     p_hsExpr,
-    p_hsSplice,
+    p_hsUntypedSplice,
     p_stringLit,
     p_hsExpr',
     p_hsCmdTop,
@@ -11,16 +11,13 @@ module Ormolu.Printer.Meat.Declaration.Value
   )
 where
 
-import GHC.Hs.Binds
-import GHC.Hs.Expr
-import GHC.Hs.Extension
-import GHC.Hs.Pat
+import GHC.Hs
 import Ormolu.Printer.Combinators
 
 p_valDecl :: HsBindLR GhcPs GhcPs -> R ()
 p_pat :: Pat GhcPs -> R ()
 p_hsExpr :: HsExpr GhcPs -> R ()
-p_hsSplice :: HsSplice GhcPs -> R ()
+p_hsUntypedSplice :: SpliceDecoration -> HsUntypedSplice GhcPs -> R ()
 p_stringLit :: String -> R ()
 p_hsExpr' :: BracketStyle -> HsExpr GhcPs -> R ()
 p_hsCmdTop :: BracketStyle -> HsCmdTop GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Warning.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Warning.hs
@@ -18,7 +18,7 @@ import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 
 p_warnDecls :: WarnDecls GhcPs -> R ()
-p_warnDecls (Warnings _ _ warnings) =
+p_warnDecls (Warnings _ warnings) =
   traverse_ (located' p_warnDecl) warnings
 
 p_warnDecl :: WarnDecl GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -14,7 +14,6 @@ import GHC.Hs
 import GHC.LanguageExtensions.Type
 import GHC.Types.PkgQual
 import GHC.Types.SrcLoc
-import GHC.Unit.Types
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import Ormolu.Utils (RelativePos (..), attachRelativePos)
@@ -62,13 +61,12 @@ p_hsmodImport ImportDecl {..} = do
         space
         located l atom
     space
-    case ideclHiding of
+    case ideclImportList of
       Nothing -> return ()
-      Just (hiding, _) ->
-        when hiding (txt "hiding")
-    case ideclHiding of
-      Nothing -> return ()
-      Just (_, L _ xs) -> do
+      Just (hiding, L _ xs) -> do
+        case hiding of
+          Exactly -> pure ()
+          EverythingBut -> txt "hiding"
         breakpoint
         parens N $ do
           layout <- getLayout

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -29,10 +29,11 @@ p_hsModule ::
   -- | Pragmas and the associated comments
   [([RealLocated Comment], Pragma)] ->
   -- | AST to print
-  HsModule ->
+  HsModule GhcPs ->
   R ()
 p_hsModule mstackHeader pragmas HsModule {..} = do
-  let deprecSpan = maybe [] (pure . getLocA) hsmodDeprecMessage
+  let XModulePs {..} = hsmodExt
+      deprecSpan = maybe [] (pure . getLocA) hsmodDeprecMessage
       exportSpans = maybe [] (pure . getLocA) hsmodExports
   switchLayout (deprecSpan <> exportSpans) $ do
     forM_ mstackHeader $ \(L spn comment) -> do

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -21,15 +21,14 @@ module Ormolu.Printer.Meat.Type
   )
 where
 
-import GHC.Hs
-import GHC.Types.Basic hiding (isPromoted)
+import GHC.Hs hiding (isPromoted)
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
 import GHC.Types.Var
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.OpTree (p_tyOpTree, tyOpTree)
-import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsSplice, p_stringLit)
+import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsUntypedSplice, p_stringLit)
 import Ormolu.Printer.Operators
 import Ormolu.Utils
 
@@ -132,7 +131,7 @@ p_hsType' multilineArgs = \case
     txt "::"
     breakpoint
     inci (located k p_hsType)
-  HsSpliceTy _ splice -> p_hsSplice splice
+  HsSpliceTy _ splice -> p_hsUntypedSplice DollarSplice splice
   HsDocTy _ t str -> do
     p_hsDoc Pipe True str
     located t p_hsType

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -38,7 +38,7 @@ import GHC.ForeignPtr (mallocPlainForeignPtrBytes)
 import GHC.Hs
 import GHC.IO.Unsafe (unsafePerformIO)
 import GHC.Types.SrcLoc
-import GHC.Utils.Outputable
+import GHC.Utils.Outputable (Outputable (..))
 
 -- | Relative positions in a list.
 data RelativePos

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,12 @@
-resolver: lts-19.20
+resolver: lts-20.11
 
 packages:
 - '.'
 - extract-hackage-info
 
 extra-deps:
-- Cabal-syntax-3.8.1.0
-- ghc-lib-parser-9.4.1.20220807
+- Cabal-syntax-3.10.1.0
+- ghc-lib-parser-9.6.1.20230312
 - text-2.0.1
 - parsec-3.1.16.1
 - hashable-1.4.2.0


### PR DESCRIPTION
 - Upgrade to ghc-lib-parser-9.6 and Cabal-syntax-3.10 (see CHANGELOG entry)
 - CI: update to GHC 9.2.7 and add GHC 9.6.1

Closes #983