### PR TITLE
Implement Term as pure operation

### DIFF
--- a/ormolu-live/ormolu-live.cabal
+++ b/ormolu-live/ormolu-live.cabal
@@ -18,5 +18,4 @@ executable ormolu-live
         bytestring,
         text,
         aeson,
-        ghc-lib-parser,
-        knob
+        ghc-lib-parser

--- a/src/Ormolu/Exception.hs
+++ b/src/Ormolu/Exception.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QualifiedDo #-}
 
 -- | 'OrmoluException' type and surrounding definitions.
 module Ormolu.Exception
@@ -10,7 +11,7 @@ module Ormolu.Exception
 where
 
 import Control.Exception
-import Control.Monad (forM_)
+import Data.Foldable (for_)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
@@ -19,6 +20,7 @@ import Data.Void (Void)
 import GHC.Types.SrcLoc
 import Ormolu.Diff.Text (TextDiff, printTextDiff)
 import Ormolu.Terminal
+import qualified Ormolu.Terminal.QualifiedDo as Term
 import System.Exit (ExitCode (..))
 import System.IO
 import Text.Megaparsec (ParseErrorBundle, errorBundlePretty)
@@ -49,61 +51,62 @@ instance Exception OrmoluException
 -- | Print an 'OrmoluException'.
 printOrmoluException ::
   OrmoluException ->
-  Term ()
+  Term
 printOrmoluException = \case
-  OrmoluParsingFailed s e -> do
-    bold (putSrcSpan s)
+  OrmoluParsingFailed s e -> Term.do
+    bold (putOutputable s)
     newline
     put "  The GHC parser (in Haddock mode) failed:"
     newline
     put "  "
     put (T.pack e)
     newline
-  OrmoluOutputParsingFailed s e -> do
-    bold (putSrcSpan s)
+  OrmoluOutputParsingFailed s e -> Term.do
+    bold (putOutputable s)
     newline
     put "  Parsing of formatted code failed:"
+    newline
     put "  "
     put (T.pack e)
     newline
-  OrmoluASTDiffers diff ss -> do
+  OrmoluASTDiffers diff ss -> Term.do
     printTextDiff diff
     newline
     put "  AST of input and AST of formatted code differ."
     newline
-    forM_ ss $ \s -> do
+    for_ ss $ \s -> Term.do
       put "    at "
-      putRealSrcSpan s
+      putOutputable s
       newline
     put "  Please, consider reporting the bug."
     newline
     put "  To format anyway, use --unsafe."
     newline
-  OrmoluNonIdempotentOutput diff -> do
+  OrmoluNonIdempotentOutput diff -> Term.do
     printTextDiff diff
     newline
     put "  Formatting is not idempotent."
     newline
     put "  Please, consider reporting the bug."
     newline
-  OrmoluUnrecognizedOpts opts -> do
+  OrmoluUnrecognizedOpts opts -> Term.do
     put "The following GHC options were not recognized:"
     newline
     put "  "
-    (putS . unwords . NE.toList) opts
+    (put . T.unwords . map T.pack . NE.toList) opts
     newline
-  OrmoluCabalFileParsingFailed cabalFile -> do
+  OrmoluCabalFileParsingFailed cabalFile -> Term.do
     put "Parsing this .cabal file failed:"
     newline
     put $ "  " <> T.pack cabalFile
     newline
-  OrmoluMissingStdinInputFile -> do
+  OrmoluMissingStdinInputFile -> Term.do
     put "The --stdin-input-file option is necessary when using input"
     newline
     put "from stdin and accounting for .cabal files"
     newline
-  OrmoluFixityOverridesParseError errorBundle -> do
-    putS (errorBundlePretty errorBundle)
+  OrmoluFixityOverridesParseError errorBundle -> Term.do
+    put . T.pack . errorBundlePretty $ errorBundle
     newline
 
 -- | Inside this wrapper 'OrmoluException' will be caught and displayed

--- a/src/Ormolu/Terminal/QualifiedDo.hs
+++ b/src/Ormolu/Terminal/QualifiedDo.hs
@@ -1,0 +1,7 @@
+module Ormolu.Terminal.QualifiedDo ((>>)) where
+
+import Ormolu.Terminal
+import Prelude hiding ((>>))
+
+(>>) :: Term -> Term -> Term
+(>>) = (<>)

--- a/tests/Ormolu/Diff/TextSpec.hs
+++ b/tests/Ormolu/Diff/TextSpec.hs
@@ -2,14 +2,11 @@
 
 module Ormolu.Diff.TextSpec (spec) where
 
-import Data.Text (Text)
 import Ormolu.Diff.Text
 import Ormolu.Terminal
 import Ormolu.Utils.IO
 import Path
-import Path.IO
 import qualified System.FilePath as FP
-import System.IO (hClose)
 import Test.Hspec
 
 spec :: Spec
@@ -48,16 +45,7 @@ stdTest name pathA pathB = it name $ do
     parseRelFile expectedDiffPath
       >>= readFileUtf8 . toFilePath . (diffOutputsDir </>)
   Just actualDiff <- pure $ diffText inputA inputB "TEST"
-  actualDiffText <- printDiff actualDiff
-  actualDiffText `shouldBe` expectedDiffText
-
--- | Print to a 'Text' value.
-printDiff :: TextDiff -> IO Text
-printDiff diff =
-  withSystemTempFile "ormolu-diff-test" $ \path h -> do
-    runTerm (printTextDiff diff) Never h
-    hClose h
-    readFileUtf8 (toFilePath path)
+  runTermPure (printTextDiff actualDiff) `shouldBe` expectedDiffText
 
 diffTestsDir :: Path Rel Dir
 diffTestsDir = $(mkRelDir "data/diff-tests")

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -1,6 +1,7 @@
 { roots =
   [ "^Main.main\$"
   , "^Paths_"
+  , "^Ormolu.Terminal.QualifiedDo.>>\$" -- https://github.com/ocharles/weeder/issues/112
   ]
 , type-class-roots = False
 }


### PR DESCRIPTION
Implement Term as an AST builder + interpreter, so that tests and ormolu-live (and Fourmolu) don't have to use hacky work-arounds to print exceptions.

The monad instance is a bit sus, but no one should really be using `<-` in any `Term` blocks. If someone does, it'll just blow up in tests. We can get rid of the monad weirdness by just writing everything as
```hs
prettyOrmoluException :: OrmoluException -> PrettyText
prettyOrmoluException = \case
  OrmoluParsingFailed s e ->
    [ WithBold [putOutputable s]
    , ...
    ]

type PrettyText = [PrettyNode]
data PrettyNode
  = OutputText Text
  | WithColor Color PrettyText
  | WithBold PrettyText

hPutPretty :: ColorMode -> Handle -> PrettyText -> IO ()
getPretty :: PrettyText -> Text
```
But the do-notation does look a bit nicer, so I didn't want to rewrite all of that for now.