### PR TITLE
Replace DList with Seq

### DIFF
--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -105,7 +105,6 @@ library
         bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
         directory ^>=1.3,
-        dlist >=0.8 && <2.0,
         file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,
         ghc-lib-parser >=9.4 && <9.5,

--- a/src/Ormolu/Printer/SpanStream.hs
+++ b/src/Ormolu/Printer/SpanStream.hs
@@ -8,12 +8,13 @@ module Ormolu.Printer.SpanStream
   )
 where
 
-import Data.DList (DList)
-import qualified Data.DList as D
 import Data.Data (Data)
+import Data.Foldable (toList)
 import Data.Generics (everything, ext1Q, ext2Q)
 import Data.List (sortOn)
 import Data.Maybe (maybeToList)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import Data.Typeable (cast)
 import GHC.Parser.Annotation
 import GHC.Types.SrcLoc
@@ -34,16 +35,16 @@ mkSpanStream ::
 mkSpanStream a =
   SpanStream
     . sortOn realSrcSpanStart
-    . D.toList
+    . toList
     $ everything mappend (const mempty `ext2Q` queryLocated `ext1Q` querySrcSpanAnn) a
   where
     queryLocated ::
       (Data e0) =>
       GenLocated e0 e1 ->
-      DList RealSrcSpan
+      Seq RealSrcSpan
     queryLocated (L mspn _) =
-      maybe mempty srcSpanToRealSrcSpanDList (cast mspn :: Maybe SrcSpan)
-    querySrcSpanAnn :: SrcSpanAnn' a -> DList RealSrcSpan
-    querySrcSpanAnn = srcSpanToRealSrcSpanDList . locA
-    srcSpanToRealSrcSpanDList =
-      D.fromList . maybeToList . srcSpanToRealSrcSpan
+      maybe mempty srcSpanToRealSrcSpanSeq (cast mspn :: Maybe SrcSpan)
+    querySrcSpanAnn :: SrcSpanAnn' a -> Seq RealSrcSpan
+    querySrcSpanAnn = srcSpanToRealSrcSpanSeq . locA
+    srcSpanToRealSrcSpanSeq =
+      Seq.fromList . maybeToList . srcSpanToRealSrcSpan

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -36,7 +36,7 @@ spec = do
       mentioned `shouldBe` True
       unPackageName ciPackageName `shouldBe` "ormolu"
       ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
-      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "ansi-terminal", "array", "base", "binary", "bytestring", "containers", "directory", "dlist", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "text"]
+      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "ansi-terminal", "array", "base", "binary", "bytestring", "containers", "directory", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "text"]
       ciCabalFilePath `shouldSatisfy` isAbsolute
       makeRelativeToCurrentDirectory ciCabalFilePath `shouldReturn` "ormolu.cabal"
     it "extracts correct cabal info from ormolu.cabal for tests/Ormolu/PrinterSpec.hs" $ do


### PR DESCRIPTION
I find `Data.Sequence` has a better API than `DList`, and it avoids adding another dependency (given that most projects use `containers` anyway). The two should have roughly the same performance: https://stackoverflow.com/a/37507346/4966649

Will conflict with https://github.com/tweag/ormolu/pull/985, will resolve after PR is merged