### PR TITLE
Provide more context on Cabal file parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 * Updated to `Cabal-syntax-3.10`.
 
+* Now whenever Ormolu fails to parse a `.cabal` file it also explains why.
+  [PR 999](https://github.com/tweag/ormolu/pull/999).
+
 ## Ormolu 0.5.3.0
 
 * Stop making empty `let`s move comments. [Issue


### PR DESCRIPTION
When ormolu fails to parse the Cabal file the user doesn't know what is the actual error as only the cabal filepath is reported. This makes the necessary changes to actually show what errors the cabal file parser encountered.

Before:
```
  Parsing this .cabal file failed:
    /path/to/file.cabal
```

After:
```
  Parsing this .cabal file failed:
    /path/to/file.cabal:0:0: Unsupported cabal-version 3.8. See https://github.com/haskell/cabal/issues/4899.
```

Note: Removing the `Eq` instance on `OrmoluException` was the easy way to not
  having to implement an orphan `Eq` instance on `PError`. This does not have
  any impact elsewhere as we're actually not making use of the `Eq` instance
  on this exception type.