### PR TITLE
Fix unicode normalization in diffParseResult

### DIFF
--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -51,7 +51,7 @@ diffParseResult
       prParsedSource = hs1
     } =
     diffCommentStream cstream0 cstream1
-      <> matchIgnoringSrcSpans hs0 hs1
+      <> diffHsModule hs0 hs1
 
 diffCommentStream :: CommentStream -> CommentStream -> ParseResultDiff
 diffCommentStream (CommentStream cs) (CommentStream cs')
@@ -60,7 +60,7 @@ diffCommentStream (CommentStream cs) (CommentStream cs')
   where
     commentLines = concatMap (toList . unComment . unLoc)
 
--- | Compare two values for equality disregarding the following aspects:
+-- | Compare two modules for equality disregarding the following aspects:
 --
 --     * 'SrcSpan's
 --     * ordering of import lists
@@ -70,8 +70,8 @@ diffCommentStream (CommentStream cs) (CommentStream cs')
 --     * Parens around derived type classes
 --     * 'TokenLocation' (in 'LHsUniToken')
 --     * 'EpaLocation'
-matchIgnoringSrcSpans :: (Data a) => a -> a -> ParseResultDiff
-matchIgnoringSrcSpans a = genericQuery a
+diffHsModule :: HsModule GhcPs -> HsModule GhcPs -> ParseResultDiff
+diffHsModule = genericQuery
   where
     genericQuery :: GenericQ (GenericQ ParseResultDiff)
     genericQuery x y


### PR DESCRIPTION
Did a few things:
* Renamed `matchIgnoringSrcSpans`, which was a misleading name (since it ignores a lot more now)
* Consolidated the unicode normalization code to keep it all together (we can do similarly for other rules too)
* Included `HsUniToken` (added in GHC 9.6) in the normalization rules for unicode