### PR TITLE
Fix false positives in AST diffing related to `UnicodeSyntax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Fix false positives in AST diffing related to `UnicodeSyntax`. [PR
+  1009](https://github.com/tweag/ormolu/pull/1009).
+
 ## Ormolu 0.6.0.0
 
 * Haddocks attached to arguments of a data constructor are now formatted in

--- a/data/examples/declaration/data/gadt/unicode-out.hs
+++ b/data/examples/declaration/data/gadt/unicode-out.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo :: Type -> Type where
+  Foo :: a -> Foo a

--- a/data/examples/declaration/data/gadt/unicode.hs
+++ b/data/examples/declaration/data/gadt/unicode.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo ∷ Type → Type where
+  Foo ∷ a → Foo a


### PR DESCRIPTION
Inspired by and alternative to #1008 (except the first commit there).

See the new example snippet for the snippet that caused errors before this PR.

Close #1008.