### PR TITLE
Don't let comments escape from empty export lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Support the (deprecated) `DatatypeContexts` extension to avoid surprises.
   [Issue 1012](https://github.com/tweag/ormolu/issues/1012).
 
+* Don't let comments escape from empty export lists. [Issue
+  906](https://github.com/tweag/ormolu/issues/906).
+
 ## Ormolu 0.6.0.1
 
 * Fix false positives in AST diffing related to `UnicodeSyntax`. [PR

--- a/data/examples/module-header/multiline-empty-comment-out.hs
+++ b/data/examples/module-header/multiline-empty-comment-out.hs
@@ -1,0 +1,4 @@
+module Foo
+  ( -- test
+  )
+where

--- a/data/examples/module-header/multiline-empty-comment.hs
+++ b/data/examples/module-header/multiline-empty-comment.hs
@@ -1,0 +1,2 @@
+module Foo ( -- test
+           ) where

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -54,7 +54,7 @@ p_hsModule mstackHeader pragmas HsModule {..} = do
         case hsmodExports of
           Nothing -> return ()
           Just l -> do
-            located l $ \exports -> do
+            encloseLocated l $ \exports -> do
               inci (p_hsmodExports exports)
             breakpoint
         txt "where"


### PR DESCRIPTION
Closes #906, see https://github.com/tweag/ormolu/pull/933#issuecomment-1369080586 for more context. The main advantage of this PR to #933 is that it is much more minimal, bu it is still relatively ad-hoc.

There is a similar issue in other cases, e.g. also with this PR (or also with #933), comments "escape" here:
```haskell
data Foo = Foo {
  -- foo
  }

foo = [
  -- foo
  ]

foo = (
  -- foo
  )
```

See https://github.com/tweag/ormolu/commit/54dfe3ebe3d30f4b248eba7192b400ca477c6a97 for an approach to call `encloseLocated` "automatically" via an overlapping instance, which e.g. "catches" the comment in the first case in the example above. The other two would probably need ad-hoc handling in `p_rdrName`.