### PR TITLE
Make all packages available for fixity inference in Ormolu Live

### DIFF
--- a/ormolu-live/app/Main.hs
+++ b/ormolu-live/app/Main.hs
@@ -13,6 +13,7 @@ import Data.Aeson qualified as A
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Unsafe qualified as BU
 import Data.Functor (void)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Foreign hiding (void)
@@ -91,8 +92,11 @@ format Input {..} = do
       defaultConfig
         { cfgCheckIdempotence = checkIdempotence,
           cfgUnsafe = unsafeMode,
-          cfgSourceType = if formatBackpack then SignatureSource else ModuleSource
+          cfgSourceType = if formatBackpack then SignatureSource else ModuleSource,
+          cfgDependencies = Map.keysSet hackageInfo
         }
+      where
+        O.HackageInfo hackageInfo = O.hackageInfo
 
 prettyAST :: Config RegionIndices -> Text -> IO Text
 prettyAST cfg src = do

--- a/ormolu-live/ormolu-live.cabal
+++ b/ormolu-live/ormolu-live.cabal
@@ -18,6 +18,7 @@ executable ormolu-live
         ormolu,
         bytestring,
         text,
+        containers,
         aeson,
         ghc-lib-parser,
         deepseq


### PR DESCRIPTION
To see the difference, paste
```haskell
import Control.Lens.Operators

wreq =
  let opts = defaults & auth ?~ awsAuth AWSv4 "key" "secret"
                          & header "Accept" .~ ["application/json"]
                          & header "Runscope-Bucket-Auth" .~ ["1example-1111-4yyyy-zzzz-xxxxxxxx"]
  in  getWith opts
```
both in Ormolu Live [before this PR](https://badafc04524a7c0558fbc95d4b7482bd0b83bdf9--ormolu-live.netlify.app/) as well as after this PR (see link in https://github.com/tweag/ormolu/pull/1015#issuecomment-1520591200).