### PR TITLE
Format `\cases` with multiple patterns across multiple lines correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 * Don't let comments escape from empty export lists. [Issue
   906](https://github.com/tweag/ormolu/issues/906).
 
+* Format `\cases` with multiple patterns across multiple lines correctly. [Issue
+  1025](https://github.com/tweag/ormolu/issues/1025).
+
 ## Ormolu 0.6.0.1
 
 * Fix false positives in AST diffing related to `UnicodeSyntax`. [PR

--- a/data/examples/declaration/value/function/lambda-case-out.hs
+++ b/data/examples/declaration/value/function/lambda-case-out.hs
@@ -15,3 +15,9 @@ foo :: Maybe Int -> Maybe Int -> Int
 foo = \cases
   (Just a) (Just a) -> a + a
   _ _ -> 0
+
+foo :: Bool -> Bool -> Bool
+foo = \cases
+  True
+    True -> True
+  _ _ -> False

--- a/data/examples/declaration/value/function/lambda-case.hs
+++ b/data/examples/declaration/value/function/lambda-case.hs
@@ -15,3 +15,9 @@ foo :: Maybe Int -> Maybe Int -> Int
 foo = \cases
   (Just a) (Just a) -> a + a
   _         _       -> 0
+
+foo :: Bool -> Bool -> Bool
+foo = \cases
+  True
+   True -> True
+  _ _ -> False


### PR DESCRIPTION
Closes #1025