### PR TITLE
Ormolu Live: exclude certain packages with conflicting modules

### DIFF
--- a/ormolu-live/ormolu-live.cabal
+++ b/ormolu-live/ormolu-live.cabal
@@ -21,4 +21,5 @@ executable ormolu-live
         containers,
         aeson,
         ghc-lib-parser,
+        Cabal-syntax,
         deepseq


### PR DESCRIPTION
Since we made all packages available in Ormolu Live by default in #1015, there are some surprising discrepancies between the CLI and Ormolu Live, for example:

<table>
<tr>
<th>Input, also a fixed point in the CLI</th>
<th>
Output in <a href="https://49eb083d2b94ad882b1ff5f8b65f9870ee94a53d--ormolu-live.netlify.app/">current Ormolu Live</a>
</th>
</tr>
<tr>
<td>

```haskell
foo =
  bar $
    baz
```
</td>
<td>

```haskell
foo =
  bar
    $ baz
```
</td>
</tr>
<tr>
<td>

```haskell
-- with -p lens
import Control.Lens

foo =
  bar
    & a .~ 1
    & b .~ 2
```
</td>
<td>

```haskell
-- with -p lens
import Control.Lens

foo =
  bar
    & a
    .~ 1
    & b
    .~ 2
```
</td>
</tr>
</table>

Another example is the snippet from #1028. [With this PR](https://github.com/tweag/ormolu/pull/1029#issuecomment-1555949752), all of them are now also fixed points in Ormolu Live.

---

The reason for this is that certain modules (`Prelude` and `Control.Lens`) are also defined in other packages than the "obvious" candidates, but the operators there are inferred to have a different fixity, so we get suboptimal layout as above.

Concretely, I have noticed two cases:

 - For certain (very old?) packages, the Hoogle DB does not include fixity information for (certain?) operators, such that `extract-hackage-info` has to assume the default fixity.
    - The package [haskell2010](https://hackage.haskell.org/package/haskell2010) also defines the `Prelude` module, which also exports the `$` operator, but the corresponding Hoogle `.txt` file does not contain any fixity info for `$`.
    - The package [reasonable-lens](https://hackage.haskell.org/package/reasonable-lens) defines the `Control.Lens.Setter` module (as does `lens`), which also exports the `.~` operator, but again with no fixity info attached.
 - Sometimes, packages define an operator both at the value and at the type level with *different* fixity info (was already mentioned e.g. [here](https://github.com/tweag/ormolu/pull/994#pullrequestreview-1396958951)).
    - A concrete example is [morley-prelude](https://hackage.haskell.org/package/morley-prelude), which defines a `Prelude` module and exports both the usual `$` value-level operator (with the usual fixity `infixr 0`) and the [`$` type-level operator](https://hackage.haskell.org/package/morley-prelude-0.5.2/docs/Prelude.html#t:-36-) with fixity `infixr 2`.

   We could think about improving this (most heavyweight solution would be to explicitly handle the different namespaces for Haskell names), but as already mentioned previously, it is not clear that this pays its weight.

---

In order to fix this in Ormolu Live, we are now excluding all packages that *also* define a module present in one of a few selected packages (currently, only `base` and `lens`). Concretely, the complement of `liveDependencies` is
```haskell
["NonEmptyList","Prelude","Semigroup","bizzlelude","fay-base","haskell2010","haskell2020","haskell98","hs-functors","morley-prelude","reasonable-lens","simpleprelude"]
```
In general, I don't think there are many packages that both share module names and suffer from operator fixity discrepancies due to one of the reasons above, so a static list seems fine to me.