### PR TITLE
Ensure source file not mentioned in cabal file has same behavior as cabal file not existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Include `base` fixity information when formatting a Haskell file that's
+  not mentioned in an existing cabal file. [Issue
+  1032](https://github.com/tweag/ormolu/issues/1032)
+
 ## Ormolu 0.7.0.0
 
 * Inference of operator fixity information is now more precise and takes

--- a/src/Ormolu/Utils/Cabal.hs
+++ b/src/Ormolu/Utils/Cabal.hs
@@ -28,6 +28,7 @@ import Distribution.Utils.Path (getSymbolicPath)
 import Language.Haskell.Extension
 import Ormolu.Config
 import Ormolu.Exception
+import Ormolu.Fixity
 import Ormolu.Utils.IO (findClosestFileSatisfying)
 import System.Directory
 import System.FilePath
@@ -130,7 +131,7 @@ parseCabalInfo cabalFileAsGiven sourceFileAsGiven = liftIO $ do
       (,cachedCabalFile) . M.insert cabalFile cachedCabalFile
   let (dynOpts, dependencies, mentioned) =
         case M.lookup (dropExtensions sourceFileAbs) extensionsAndDeps of
-          Nothing -> ([], [], False)
+          Nothing -> ([], Set.toList defaultDependencies, False)
           Just (dynOpts', dependencies') -> (dynOpts', dependencies', True)
       pdesc = packageDescription genericPackageDescription
   return

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -52,7 +52,7 @@ spec = do
       mentioned `shouldBe` False
       unPackageName ciPackageName `shouldBe` "ormolu"
       ciDynOpts `shouldBe` []
-      Set.map unPackageName ciDependencies `shouldBe` Set.empty
+      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["base"]
       ciCabalFilePath `shouldSatisfy` isAbsolute
       makeRelativeToCurrentDirectory ciCabalFilePath `shouldReturn` "ormolu.cabal"
     it "handles `hs-source-dirs: .`" $ do


### PR DESCRIPTION
Resolves #1032

Technically, only the first commit is necessary to solve the issue. But I refactored the `CabalInfo` subsystem to ensure that the former `CabalFileNotFound` + `CabalFileDidNotMention` branches used the same logic. Specifically, this change allows `refineConfig` to be the sole source of truth for defining the Cabal information for both a cabal file not existing and a cabal file not mentioning a source file (previously, this was two different locations: `parseCabalInfo` was doing it for `CabalFileDidNotMention` and `refineConfig` was doing it for `CabalFileNotFound`).

## Test

Add the following Haskell file:
```hs
foo =
  unlines $
    hello <> world : ["Line " ++ show x | x <- [10 .. 20]]
  where
    hello = "hello"
    world = " world"
```
Running `ormolu` on it formats the same in both cases:
1. The Haskell file is in an empty directory
2. The Haskell file is in a directory with a Cabal file, but it's not mentioned in the Cabal file