### PR TITLE
Update debug logs

### DIFF
--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -94,8 +94,9 @@ ormolu cfgWithIndices path originalInput = do
   (warnings, result0) <-
     parseModule' cfg fixityMap OrmoluParsingFailed path originalInput
   when (cfgDebug cfg) $ do
-    traceM "warnings:\n"
-    traceM (concatMap showWarn warnings)
+    unless (null warnings) $ do
+      traceM "warnings:\n"
+      traceM (concatMap showWarn warnings)
     forM_ result0 $ \case
       ParsedSnippet r -> traceM . showCommentStream . prCommentStream $ r
       _ -> pure ()

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -91,6 +91,8 @@ ormolu cfgWithIndices path originalInput = do
       fixityMap =
         packageFixityMap
           (overapproximatedDependencies cfg) -- memoized on the set of dependencies
+  when (cfgDebug cfg) $ do
+    traceM $ unwords ["*** CONFIG ***", show cfg]
   (warnings, result0) <-
     parseModule' cfg fixityMap OrmoluParsingFailed path originalInput
   when (cfgDebug cfg) $ do

--- a/src/Ormolu/Parser/CommentStream.hs
+++ b/src/Ormolu/Parser/CommentStream.hs
@@ -7,7 +7,6 @@ module Ormolu.Parser.CommentStream
   ( -- * Comment stream
     CommentStream (..),
     mkCommentStream,
-    showCommentStream,
 
     -- * Comment
     LComment,
@@ -38,7 +37,7 @@ import GHC.Parser.Annotation (EpAnnComments (..), getLocA)
 import GHC.Parser.Annotation qualified as GHC
 import GHC.Types.SrcLoc
 import Ormolu.Parser.Pragma
-import Ormolu.Utils (onTheSameLine, showOutputable)
+import Ormolu.Utils (onTheSameLine)
 
 ----------------------------------------------------------------------------
 -- Comment stream
@@ -104,14 +103,6 @@ mkCommentStream input hsModule =
               _ -> False
     only :: a -> Bool
     only _ = True
-
--- | Pretty-print a 'CommentStream'.
-showCommentStream :: CommentStream -> String
-showCommentStream (CommentStream xs) =
-  unlines $
-    showComment <$> xs
-  where
-    showComment (L l str) = showOutputable l ++ " " ++ show str
 
 ----------------------------------------------------------------------------
 -- Comment


### PR DESCRIPTION
Make debug logs more informative + useful.

Printing out the config is useful now with the fixity + reexport configuration.

## Test
```bash
stack run -- ormolu --debug data/examples/declaration/class/associated-type-defaults.hs
```
```
Found .cabal file ormolu.cabal, but it did not mention data/examples/declaration/class/associated-type-defaults.hs
*** CONFIG *** Config {cfgDynOptions = [], cfgFixityOverrides = FixityOverrides {unFixityOverrides = fromList []}, cfgModuleReexports = ModuleReexports {unModuleReexports = fromList [(ModuleName "Control.Lens",(Just (PackageName "lens"),ModuleName "Control.Lens.At") :| [(Just (PackageName "lens"),ModuleName "Control.Lens.Cons"),(Just (PackageName "lens"),ModuleName "Control.Lens.Each"),(Just (PackageName "lens"),ModuleName "Control.Lens.Empty"),(Just (PackageName "lens"),ModuleName "Control.Lens.Equality"),(Just (PackageName "lens"),ModuleName "Control.Lens.Fold"),(Just (PackageName "lens"),ModuleName "Control.Lens.Getter"),(Just (PackageName "lens"),ModuleName "Control.Lens.Indexed"),(Just (PackageName "lens"),ModuleName "Control.Lens.Iso"),(Just (PackageName "lens"),ModuleName "Control.Lens.Lens"),(Just (PackageName "lens"),ModuleName "Control.Lens.Level"),(Just (PackageName "lens"),ModuleName "Control.Lens.Plated"),(Just (PackageName "lens"),ModuleName "Control.Lens.Prism"),(Just (PackageName "lens"),ModuleName "Control.Lens.Reified"),(Just (PackageName "lens"),ModuleName "Control.Lens.Review"),(Just (PackageName "lens"),ModuleName "Control.Lens.Setter"),(Just (PackageName "lens"),ModuleName "Control.Lens.TH"),(Just (PackageName "lens"),ModuleName "Control.Lens.Traversal"),(Just (PackageName "lens"),ModuleName "Control.Lens.Tuple"),(Just (PackageName "lens"),ModuleName "Control.Lens.Type"),(Just (PackageName "lens"),ModuleName "Control.Lens.Wrapped"),(Just (PackageName "lens"),ModuleName "Control.Lens.Zoom"),(Just (PackageName "lens"),ModuleName "Control.Lens.At"),(Just (PackageName "lens"),ModuleName "Control.Lens.Cons"),(Just (PackageName "lens"),ModuleName "Control.Lens.Each"),(Just (PackageName "lens"),ModuleName "Control.Lens.Empty"),(Just (PackageName "lens"),ModuleName "Control.Lens.Equality"),(Just (PackageName "lens"),ModuleName "Control.Lens.Fold"),(Just (PackageName "lens"),ModuleName "Control.Lens.Getter"),(Just (PackageName "lens"),ModuleName "Control.Lens.Indexed"),(Just (PackageName "lens"),ModuleName "Control.Lens.Iso"),(Just (PackageName "lens"),ModuleName "Control.Lens.Lens"),(Just (PackageName "lens"),ModuleName "Control.Lens.Level"),(Just (PackageName "lens"),ModuleName "Control.Lens.Plated"),(Just (PackageName "lens"),ModuleName "Control.Lens.Prism"),(Just (PackageName "lens"),ModuleName "Control.Lens.Reified"),(Just (PackageName "lens"),ModuleName "Control.Lens.Review"),(Just (PackageName "lens"),ModuleName "Control.Lens.Setter"),(Just (PackageName "lens"),ModuleName "Control.Lens.TH"),(Just (PackageName "lens"),ModuleName "Control.Lens.Traversal"),(Just (PackageName "lens"),ModuleName "Control.Lens.Tuple"),(Just (PackageName "lens"),ModuleName "Control.Lens.Type"),(Just (PackageName "lens"),ModuleName "Control.Lens.Wrapped"),(Just (PackageName "lens"),ModuleName "Control.Lens.Zoom")]),(ModuleName "Optics",(Just (PackageName "optics"),ModuleName "Optics.Fold") :| [(Just (PackageName "optics"),ModuleName "Optics.Operators"),(Just (PackageName "optics"),ModuleName "Optics.IxAffineFold"),(Just (PackageName "optics"),ModuleName "Optics.IxFold"),(Just (PackageName "optics"),ModuleName "Optics.IxTraversal"),(Just (PackageName "optics"),ModuleName "Optics.Traversal"),(Just (PackageName "optics"),ModuleName "Optics.Fold"),(Just (PackageName "optics"),ModuleName "Optics.Operators"),(Just (PackageName "optics"),ModuleName "Optics.IxAffineFold"),(Just (PackageName "optics"),ModuleName "Optics.IxFold"),(Just (PackageName "optics"),ModuleName "Optics.IxTraversal"),(Just (PackageName "optics"),ModuleName "Optics.Traversal")]),(ModuleName "Servant",(Just (PackageName "servant"),ModuleName "Servant.API") :| [(Just (PackageName "servant"),ModuleName "Servant.API")]),(ModuleName "Test.Hspec",(Just (PackageName "hspec-expectations"),ModuleName "Test.Hspec.Expectations") :| [(Just (PackageName "hspec-expectations"),ModuleName "Test.Hspec.Expectations")])]}, cfgDependencies = fromList [PackageName "base",PackageName "ormolu"], cfgUnsafe = False, cfgDebug = True, cfgCheckIdempotence = False, cfgSourceType = ModuleSource, cfgColorMode = Auto, cfgRegion = RegionDeltas {regionPrefixLength = 0, regionSuffixLength = 0}}
*** COMMENT *** data/examples/declaration/class/associated-type-defaults.hs:7:3-15 Comment False ("-- Define bar" :| [])
*** COMMENT *** data/examples/declaration/class/associated-type-defaults.hs:10:3-15 Comment False ("-- Define baz" :| [])
*** COMMENT *** data/examples/declaration/class/associated-type-defaults.hs:12:21-37 Comment True ("-- Middle comment" :| [])
{-# LANGUAGE TypeFamilies #-}

class Foo a where type FooBar a = Int

-- | Something.
class Bar a where
  -- Define bar
  type
    BarBar a =
      BarBaz a

  -- Define baz
  type
    BarBaz
      a =
      BarBar -- Middle comment
        a

class Baz a where
  type
    BazBar
      a

  type
    BazBar a =
      Bar a
```