### PR TITLE
Preserve necessary braces for final function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Preserve necessary braces for final function arguments. [Issue
+  1044](https://github.com/tweag/ormolu/issues/1044).
+
 ## Ormolu 0.7.1.0
 
 * Include `base` fixity information when formatting a Haskell file that's

--- a/data/examples/other/necessary-brackets-out.hs
+++ b/data/examples/other/necessary-brackets-out.hs
@@ -1,0 +1,3 @@
+insertEmDash = Text.concat . map \case { x | x == "--" -> "—"; x -> x } . Text.groupBy ((==) `on` Char.isSpace)
+
+foo f a b c = f do { a } + f do { b } + f do c

--- a/data/examples/other/necessary-brackets.hs
+++ b/data/examples/other/necessary-brackets.hs
@@ -1,0 +1,3 @@
+insertEmDash = Text.concat . map \case{ x | x == "--" -> "—"; x -> x } . Text.groupBy ((==) `on` Char.isSpace)
+
+foo f a b c = f do {a} + f do {b} + f do {c}


### PR DESCRIPTION
Closes #1044 

This PR basically is a re-implementation of #767: Instead of unconditionally omitting braces for the final function argument, we set layout-based brace information in `do` blocks (statements) only for all *but* the last statement. This means that the brace information is now properly propagated in cases like #1044.