### PR TITLE
Avoid building ghc-lib-parser if GHC 9.6 is already being used

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -245,7 +245,11 @@ optsParserInfo =
         [ unwords $
             ["ormolu", showVersion version]
               <> maybeToList $$(envQ @String "ORMOLU_REV"),
+#ifdef VERSION_ghc_lib_parser
           "using ghc-lib-parser " ++ VERSION_ghc_lib_parser
+#else
+          "using ghc " ++ VERSION_ghc
+#endif
         ]
     exts :: Parser (a -> a)
     exts =

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -110,11 +110,18 @@ library
         directory ^>=1.3,
         file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.6 && <9.7,
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
         text >=2.0 && <3.0
+
+    if impl(ghc >= 9.6.1) && impl(ghc < 9.7.0)
+      build-depends:
+        ghc == 9.6.*,
+        ghc-boot-th
+    else
+      build-depends:
+          ghc-lib-parser == 9.6.*
 
     if flag(dev)
         ghc-options:
@@ -139,11 +146,18 @@ executable ormolu
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.6 && <9.7,
         optparse-applicative >=0.14 && <0.19,
         ormolu,
         text >=2.0 && <3.0,
         th-env >=0.1.1 && <0.2
+
+    if impl(ghc >= 9.6.1) && impl(ghc < 9.7.0)
+      build-depends:
+        ghc == 9.6.*,
+        ghc-boot-th
+    else
+      build-depends:
+          ghc-lib-parser == 9.6.*
 
     if flag(dev)
         ghc-options:
@@ -178,7 +192,6 @@ test-suite tests
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.6 && <9.7,
         hspec >=2.0 && <3.0,
         hspec-megaparsec >=2.2,
         megaparsec >=9.0,
@@ -187,6 +200,13 @@ test-suite tests
         path-io >=1.4.2 && <2.0,
         temporary ^>=1.3,
         text >=2.0 && <3.0
+
+    if impl(ghc >= 9.6.1) && impl(ghc < 9.7.0)
+      build-depends:
+        ghc == 9.6.*
+    else
+      build-depends:
+          ghc-lib-parser == 9.6.*
 
     if flag(dev)
         ghc-options:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,8 @@
-resolver: lts-20.11
+resolver: nightly-2023-06-27
 
 packages:
 - '.'
 - extract-hackage-info
-
-extra-deps:
-- Cabal-syntax-3.10.1.0
-- ghc-lib-parser-9.6.1.20230312
-- text-2.0.1
-- parsec-3.1.16.1
-- hashable-1.4.2.0
-- data-array-byte-0.1.0.1
 
 nix:
   packages:

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -36,7 +36,7 @@ spec = do
       mentioned `shouldBe` True
       unPackageName ciPackageName `shouldBe` "ormolu"
       ciDynOpts `shouldBe` [DynOption "-XGHC2021"]
-      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "ansi-terminal", "array", "base", "binary", "bytestring", "containers", "deepseq", "directory", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "text"]
+      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "ansi-terminal", "array", "base", "binary", "bytestring", "containers", "deepseq", "directory", "file-embed", "filepath", "ghc", "ghc-boot-th", "ghc-lib-parser", "megaparsec", "mtl", "syb", "text"]
       ciCabalFilePath `shouldSatisfy` isAbsolute
       makeRelativeToCurrentDirectory ciCabalFilePath `shouldReturn` "ormolu.cabal"
     it "extracts correct cabal info from ormolu.cabal for tests/Ormolu/PrinterSpec.hs" $ do
@@ -44,7 +44,7 @@ spec = do
       mentioned `shouldBe` True
       unPackageName ciPackageName `shouldBe` "ormolu"
       ciDynOpts `shouldBe` [DynOption "-XGHC2021"]
-      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
+      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "QuickCheck", "base", "containers", "directory", "filepath", "ghc", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "ormolu", "path", "path-io", "temporary", "text"]
       ciCabalFilePath `shouldSatisfy` isAbsolute
       makeRelativeToCurrentDirectory ciCabalFilePath `shouldReturn` "ormolu.cabal"
     it "handles correctly files that are not mentioned in ormolu.cabal" $ do


### PR DESCRIPTION
This speeds up a clean build on GHC 9.6 by a ton