### PR TITLE
Fix interaction of operators starting with `#` and `UnboxedSums`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Put `"this"` `PackageImports` at the end. [Issue
   1048](https://github.com/tweag/ormolu/issues/1048).
 
+* Format parenthesized operators starting with a `#` correctly in the presence
+  of `UnboxedSums`. [Issue 1062](https://github.com/tweag/ormolu/issues/1062).
+
 ## Ormolu 0.7.1.0
 
 * Include `base` fixity information when formatting a Haskell file that's

--- a/data/examples/declaration/value/function/operator-hash-with-unboxed-sums-out.hs
+++ b/data/examples/declaration/value/function/operator-hash-with-unboxed-sums-out.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE UnboxedSums #-}
+
+module Foo (( #<| )) where
+
+( #<| ) :: Int -> Int -> Int
+( #<| ) = (+)
+
+(+) = (+)

--- a/data/examples/declaration/value/function/operator-hash-with-unboxed-sums.hs
+++ b/data/examples/declaration/value/function/operator-hash-with-unboxed-sums.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE UnboxedSums #-}
+
+module Foo (( #<| )) where
+
+( #<| ) :: Int -> Int -> Int
+( #<| ) = (+)
+
+(+) = (+)

--- a/data/examples/declaration/value/function/operator-hash-without-unboxed-sums-out.hs
+++ b/data/examples/declaration/value/function/operator-hash-without-unboxed-sums-out.hs
@@ -1,0 +1,6 @@
+module Foo ((#<|)) where
+
+(#<|) :: Int -> Int -> Int
+(#<|) = (+)
+
+(+) = (+)

--- a/data/examples/declaration/value/function/operator-hash-without-unboxed-sums.hs
+++ b/data/examples/declaration/value/function/operator-hash-without-unboxed-sums.hs
@@ -1,0 +1,6 @@
+module Foo (( #<| )) where
+
+( #<| ) :: Int -> Int -> Int
+( #<| ) = (+)
+
+(+) = (+)


### PR DESCRIPTION
Closes #1062 

From https://downloads.haskell.org/ghc/9.6.2/docs/users_guide/exts/primitives.html:

> Note that when unboxed tuples are enabled, `(#` is a single lexeme, so for example when using operators like `#` and `#-` you need to write `( # )` and `( #- )` rather than `(#)` and `(#-)`.

It turns that this is already the case for `UnboxedSums` (which is implied by `UnboxedTuples`).