### PR TITLE
Use WASM GHC 9.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687171271,
-        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -275,17 +275,16 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1690814459,
-        "narHash": "sha256-9jRCeXRDrAw0FmRmPuaQmQnhAjkqgX/0REFhVm3jQ2Q=",
-        "owner": "amesgen",
+        "lastModified": 1693212235,
+        "narHash": "sha256-N3zIrWxMV+eE/gCkUw/GzM3RyX8kkxLAwsWLHDip9hA=",
+        "owner": "ghc",
         "repo": "ghc-wasm-meta",
-        "rev": "77273aea0650413dd435ec7d0863ed8c875da068",
+        "rev": "28ee3192f8be23761cfa6f89b2656bfef763c028",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.haskell.org",
-        "owner": "amesgen",
-        "ref": "bump",
+        "owner": "ghc",
         "repo": "ghc-wasm-meta",
         "type": "gitlab"
       }
@@ -550,11 +549,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687518131,
-        "narHash": "sha256-KirltRIc4SFfk8bTNudIqgKAALH5oqpW3PefmkfWK5M=",
+        "lastModified": 1691371061,
+        "narHash": "sha256-BxPbPVlBIoneaXIBiHd0LVzA+L4nmvFCNBU6TmQAiMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8a93602bc54ece7a4e689d9aea1a574e2bbc24",
+        "rev": "5068bc8fe943bde3c446326da8d0ca9c93d5a682",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     };
 
     # for Ormolu Live
-    ghc-wasm-meta.url = "gitlab:amesgen/ghc-wasm-meta/bump?host=gitlab.haskell.org";
+    ghc-wasm-meta.url = "gitlab:ghc/ghc-wasm-meta?host=gitlab.haskell.org";
     npmlock2nix = { url = "github:nix-community/npmlock2nix"; flake = false; };
     ps-tools = {
       follows = "purs-nix/ps-tools";

--- a/ormolu-live/cabal.project
+++ b/ormolu-live/cabal.project
@@ -1,8 +1,8 @@
 packages: . ..
 
-index-state:
-  , hackage.haskell.org 2023-07-31T13:43:03Z
-  , head.hackage 2023-07-21T04:26:25Z
+index-state: 2023-09-01T14:51:04Z
+allow-newer: all
+constraints: text >=2.0 && <2.0.2
 
 package ormolu
   -- The WASM backend does not support TH.
@@ -11,10 +11,3 @@ package ormolu
 package ghc-lib-parser
   -- The WASM backend does not support the threaded RTS.
   flags: -threaded-rts
-
--- Some fixes to compile with GHC 9.9 (master)
-source-repository-package
-  type: git
-  location: https://github.com/amesgen/stuff
-  tag: 0cbade491127ed2e5190629d906a982169d81824
-  subdir: ghc-lib-parser-9.6.2.20230523-wasm

--- a/ormolu-live/default.nix
+++ b/ormolu-live/default.nix
@@ -26,7 +26,7 @@ let
     ghcAPIVersion =
       defaultGHC.dev.hsPkgs.ghc-lib-parser.components.library.version;
   };
-  ghcWasmDeps = [ inputs.ghc-wasm-meta.packages.${system}.default ];
+  ghcWasmDeps = [ inputs.ghc-wasm-meta.packages.${system}.all_9_8 ];
 in
 {
   package = npmlock2nix.build (common-npmlock2nix // {


### PR DESCRIPTION
As already mentioned in #1063

This allows us to no longer depend on head.hackage which is, as a moving target due to the missing support for `index-state` ([upstream issue](https://gitlab.haskell.org/ghc/head.hackage/-/issues/53)), a source of annoying failures as mostly recently in #1063 ([logs](https://github.com/tweag/ormolu/actions/runs/6052132181/job/16425289419?pr=1063)).