### PR TITLE
Fix AST diffing for empty Haddock comments in data decls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Format parenthesized operators starting with a `#` correctly in the presence
   of `UnboxedSums`. [Issue 1062](https://github.com/tweag/ormolu/issues/1062).
 
+* Fix false positives in AST diffing related to empty Haddock comments in data
+  declarations. [Issue 1065](https://github.com/tweag/ormolu/issues/1065).
+
 ## Ormolu 0.7.1.0
 
 * Include `base` fixity information when formatting a Haskell file that's

--- a/data/examples/other/empty-haddock-out.hs
+++ b/data/examples/other/empty-haddock-out.hs
@@ -5,3 +5,5 @@ where
 
 test ::
   test
+
+data T = T

--- a/data/examples/other/empty-haddock.hs
+++ b/data/examples/other/empty-haddock.hs
@@ -9,3 +9,5 @@ where
 test ::
   -- |
   test
+
+data T = T {- ^ -}


### PR DESCRIPTION
Closes #1065, by basically amending #818 with another case where Haddock comments can occur