### PR TITLE
Warn when fixities are different from base

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
     * [Regions](#regions)
     * [Exit codes](#exit-codes)
     * [Using as a library](#using-as-a-library)
+* [Troubleshooting](#troubleshooting)
+    * [Operators are being formatted weirdly!](#operators-are-being-formatted-weirdly)
 * [Limitations](#limitations)
 * [Running on Hackage](#running-on-hackage)
 * [Forks and modifications](#forks-and-modifications)
@@ -271,6 +273,23 @@ The `ormolu` package can also be depended upon from other Haskell programs.
 For these purposes only the top `Ormolu` module should be considered stable.
 It follows [PVP](https://pvp.haskell.org/) starting from the version
 0.5.3.0. Rely on other modules at your own risk.
+
+## Troubleshooting
+
+### Operators are being formatted weirdly!
+
+This can happen when Ormolu doesn't know or can't determine the fixity of an operator.
+
+* If this is a custom operator, see the instructions in the "Language extensions, dependencies, and fixities" section to specify the correct fixities in a `.ormolu` file.
+
+* If this is a third-party operator (e.g. from `base` or some other package from Hackage), Ormolu probably doesn't recognize that the operator is the same as the third-party one.
+    
+    Some reasons this might be the case:
+
+    * You might have a custom Prelude that re-exports things from Prelude
+    * You might have `-XNoImplicitPrelude` turned on
+
+    If any of these are true, make sure to specify the reexports correctly in a `.ormolu` file.
 
 ## Limitations
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -40,6 +40,7 @@ import System.IO (stderr)
 main :: IO ()
 main = do
   Opts {..} <- execParser optsParserInfo
+  initializeLogging optConfig
   let formatOne' =
         formatOne
           optConfigFileOpts
@@ -85,11 +86,11 @@ formatOne ConfigFileOpts {..} mode reqSourceType rawConfig mpath =
           cabalSearchResult <- getCabalInfoForSourceFile sourceFile
           case cabalSearchResult of
             CabalNotFound -> do
-              logDebug rawConfig "CABAL FILE" $ "Could not find a .cabal file for " <> sourceFile
+              logDebugM "CABAL FILE" $ "Could not find a .cabal file for " <> sourceFile
               return Nothing
             CabalDidNotMention cabalInfo -> do
               relativeCabalFile <- makeRelativeToCurrentDirectory (ciCabalFilePath cabalInfo)
-              logDebug rawConfig "CABAL FILE" $
+              logDebugM "CABAL FILE" $
                 "Found .cabal file "
                   <> relativeCabalFile
                   <> ", but it did not mention "
@@ -116,7 +117,7 @@ formatOne ConfigFileOpts {..} mode reqSourceType rawConfig mpath =
             ormoluStdin config >>= TIO.putStr
             return ExitSuccess
           InPlace -> do
-            logError "In place editing is not supported when input comes from stdin."
+            logErrorM "In place editing is not supported when input comes from stdin."
             -- 101 is different from all the other exit codes we already use.
             return (ExitFailure 101)
           Check -> do

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -47,6 +47,7 @@ library
         Ormolu.Diff.Text
         Ormolu.Exception
         Ormolu.Imports
+        Ormolu.Logging
         Ormolu.Parser
         Ormolu.Parser.CommentStream
         Ormolu.Parser.Pragma

--- a/ormolu.cabal
+++ b/ormolu.cabal
@@ -156,10 +156,11 @@ executable ormolu
 
 test-suite tests
     type:               exitcode-stdio-1.0
-    main-is:            Spec.hs
+    main-is:            Main.hs
     build-tool-depends: hspec-discover:hspec-discover >=2 && <3
     hs-source-dirs:     tests
     other-modules:
+        Spec
         Ormolu.CabalInfoSpec
         Ormolu.Diff.TextSpec
         Ormolu.Fixity.ParserSpec

--- a/src/Ormolu/Fixity/Internal.hs
+++ b/src/Ormolu/Fixity/Internal.hs
@@ -16,6 +16,7 @@ module Ormolu.Fixity.Internal
     defaultFixityInfo,
     FixityApproximation (..),
     defaultFixityApproximation,
+    fixityInfoToApproximation,
     HackageInfo (..),
     FixityOverrides (..),
     defaultFixityOverrides,

--- a/src/Ormolu/Logging.hs
+++ b/src/Ormolu/Logging.hs
@@ -2,6 +2,7 @@ module Ormolu.Logging
   ( initializeLogging,
     logDebug,
     logDebugM,
+    logWarn,
     logError,
     logErrorM,
   )
@@ -62,6 +63,9 @@ logDebugM ::
   String ->
   m ()
 logDebugM label msg = logDebug label msg $ pure ()
+
+logWarn :: String -> a -> a
+logWarn = logDebug "WARNING"
 
 logError :: String -> a -> a
 logError = logToStderr . pure . Just

--- a/src/Ormolu/Logging.hs
+++ b/src/Ormolu/Logging.hs
@@ -1,0 +1,31 @@
+module Ormolu.Logging
+  ( logDebug,
+    logError,
+  )
+where
+
+import Control.Monad (when)
+import Control.Monad.IO.Class (MonadIO (..))
+import Ormolu.Config (Config (..))
+import System.IO (hPutStrLn, stderr)
+
+logDebug ::
+  (MonadIO m) =>
+  Config region ->
+  -- | Some label to prefix the message with
+  String ->
+  -- | The message, ideally on a single line
+  String ->
+  m ()
+logDebug Config {cfgDebug} label msg =
+  when cfgDebug $
+    logToStderr . unwords $
+      [ "*** " <> label <> " ***",
+        msg
+      ]
+
+logError :: (MonadIO m) => String -> m ()
+logError = logToStderr
+
+logToStderr :: (MonadIO m) => String -> m ()
+logToStderr = liftIO . hPutStrLn stderr

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import Ormolu.Config qualified as Ormolu
+import Ormolu.Logging (initializeLogging)
+import Spec qualified
+import Test.Hspec.Runner
+
+main :: IO ()
+main = do
+  initializeLogging Ormolu.defaultConfig
+  hspec Spec.spec

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,1 +1,1 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/weeder.toml
+++ b/weeder.toml
@@ -1,6 +1,7 @@
 roots = [
   "^Main.main$",
   "^Paths_",
+  "^Spec.main$",
   "^Ormolu.Terminal.QualifiedDo.>>$" # https://github.com/ocharles/weeder/issues/112
 ]
 type-class-roots = true


### PR DESCRIPTION
Resolves #1060 

Tested with:
```hs
{-# LANGUAGE NoImplicitPrelude #-}

import MyCustomPrelude

main :: IO ()
main =
  putStrLn $
    "hello " ++ "world"
```
This shows the following with `--debug`:
```
*** WARNING *** Operator is possibly using the wrong fixity. Got: FixityApproximation {faDirection = Just InfixL, faMinPrecedence = 9, faMaxPrecedence = 9}, Fixities being shadowed: [FixityInfo {fiDirection = InfixR, fiPrecedence = 5},FixityInfo {fiDirection = InfixR, fiPrecedence = 5},FixityInfo {fiDirection = InfixR, fiPrecedence = 5},FixityInfo {fiDirection = InfixR, fiPrecedence = 5},FixityInfo {fiDirection = InfixR, fiPrecedence = 5}]
*** WARNING *** Operator is possibly using the wrong fixity. Got: FixityApproximation {faDirection = Just InfixL, faMinPrecedence = 9, faMaxPrecedence = 9}, Fixities being shadowed: [FixityInfo {fiDirection = InfixR, fiPrecedence = 0},FixityInfo {fiDirection = InfixR, fiPrecedence = 0},FixityInfo {fiDirection = InfixR, fiPrecedence = 0}]
```