### PR TITLE
Add hie.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ stack.yaml.lock
 result*
 .pre-commit-config.yaml
 .direnv/
+hie.yaml
 
 # These are touched on every :reload in GHCi.
 # https://gitlab.haskell.org/ghc/ghc/-/issues/22669


### PR DESCRIPTION
This file is typically automatically derived with [`implicit-hie`](https://hackage.haskell.org/package/implicit-hie).