### PR TITLE
Don't error on `JavaScriptFFI` language pragma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Don't error when the `JavaScriptFFI` language pragma is present. [Issue
+  1087](https://github.com/tweag/ormolu/issues/1087).
+
 ## Ormolu 0.7.3.0
 
 * Switched to `ghc-lib-parser-9.8`, with the following new syntactic features:

--- a/data/examples/other/jsffi-out.hs
+++ b/data/examples/other/jsffi-out.hs
@@ -1,0 +1,1 @@
+{-# LANGUAGE JavaScriptFFI #-}

--- a/data/examples/other/jsffi.hs
+++ b/data/examples/other/jsffi.hs
@@ -1,0 +1,1 @@
+{-# language JavaScriptFFI #-}

--- a/src/GHC/DynFlags.hs
+++ b/src/GHC/DynFlags.hs
@@ -26,7 +26,8 @@ fakeSettings =
         Platform
           { platformArchOS =
               ArchOS
-                { archOS_arch = ArchUnknown,
+                { -- see https://github.com/tweag/ormolu/issues/1087
+                  archOS_arch = ArchJavaScript,
                   archOS_OS = OSUnknown
                 },
             platformWordSize = PW8,


### PR DESCRIPTION
Closes #1087 

According to the ["Split out AST and Parser libraries from GHC" Haskell Foundation tech proposal](https://github.com/Ericson2314/tech-proposals/blob/ast-parser-libs/proposals/accepted/000-ast-parser-libs.rst#proof-of-success-use-by-hlint), `parseDynamicFilePragma` (which is responsible here) is known to be in need of a refactoring to be fit for purpose as being nicely usable by external tools, so I am not going to try to change this upstream, but rather work around it for the time being, as the fix is very simple.