### PR TITLE
CI: remove `delete-artifact` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,6 @@ jobs:
       - name: Combine
         run: |
           cp wasm/ormolu.wasm frontend/ormolu.*.wasm
-      - uses: geekyeggo/delete-artifact@v4
-        with:
-          name: |
-            wasm
-            frontend
       - name: Deploy to Netlify, preview
         if: env.NETLIFY_AUTH_TOKEN != ''
         uses: nwtgck/actions-netlify@v2


### PR DESCRIPTION
We currently use the [`geekyeggo/delete-artifact`](https://github.com/geekyeggo/delete-artifact) action to delete transient artifacts that only exist to copy files from one job to another. The motivation was to avoid storing them after the CI run finished.

However, since `v4` of that action, it requires more permissions to do its job. From the README:
> Support for `actions/upload-artifact@v4` utilizes the GitHub REST API, and requires a permissive [`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), or a PAT with read and write access to `actions`.

For external PRs (eg #1089 is judged to be one), the default GH token does not have the necessary permissions, so the action fails, leading to the CI failures in #1089 and #1090.

As I didn't want to fiddle with permissions and understand whether this is actually secure, the fix in this PR is simply to remove the action. Per CI run, we only create ~6MB worth of artifacts, and they still are evicted eventually after [at most 90 days](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization) (could also change that to eg one day if this turns out to be important), so I think this doesn't actually really matter.

Merging this PR should unblock #1089 and #1090.