### PR TITLE
Remove decommissioned zw3rk cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,12 +173,10 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.iog.io"
-      "https://cache.zw3rk.com" # https://github.com/input-output-hk/haskell.nix/issues/1824#issuecomment-1402339923
       "https://tweag-ormolu.cachix.org"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-      "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk="
       "tweag-ormolu.cachix.org-1:3O4XG3o4AGquSwzzmhF6lov58PYG6j9zHcTDiROqkjM="
     ];
   };


### PR DESCRIPTION
Trying to access the cache results in HTTP 500 errors. `cache.iog.io` should now contain everything. 