### PR TITLE
Indent multiline bracketed expr with minimal amount of space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix Haddock comments on infix constructors
   [Issue 758](https://github.com/tweag/ormolu/issues/758)
+* Multiline bracketed expressions indent closing bracket by just 1 space instead of a full indentation
 
 ## Ormolu 0.7.5.0
 

--- a/data/examples/declaration/value/function/arrow/proc-applications-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications-out.hs
@@ -9,7 +9,7 @@ bar f x =
     ( y,
       z,
       w
-      )
+     )
   ->
     f -- The value
       -<

--- a/data/examples/declaration/value/function/arrow/proc-cases-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-cases-out.hs
@@ -7,7 +7,7 @@ bar f g h j =
     Left
       ( (a, b),
         (c, d)
-        ) -> f (a <> c) -< b <> d
+       ) -> f (a <> c) -< b <> d
     Right
       (Left a) ->
         h -< a

--- a/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
@@ -9,7 +9,7 @@ foo
       ( (a, b),
         (c, d),
         (e, f)
-        )
+       )
     -> do
       -- Begin do
       (x, y) <- -- GHC parser fails if layed out over multiple lines
@@ -29,7 +29,7 @@ foo
           Left
             ( z,
               w
-              ) -> \u ->
+             ) -> \u ->
               -- Procs can have lambdas
               let v =
                     u -- Actually never used

--- a/data/examples/declaration/value/function/arrow/proc-form-do-indent-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-form-do-indent-out.hs
@@ -4,11 +4,11 @@ foo x = proc (y, z) -> do
   (|
     bar
       (bindA -< y)
-    |)
+   |)
 
 foo1 x = proc (y, z) -> do
   (|
     bar
       (bindA -< y)
-    |)
+   |)
     z

--- a/data/examples/declaration/value/function/do-single-multi-out.hs
+++ b/data/examples/declaration/value/function/do-single-multi-out.hs
@@ -1,4 +1,4 @@
 foo = do
   ( bar
       baz
-    )
+   )

--- a/data/examples/declaration/value/function/do/applications-and-parens-out.hs
+++ b/data/examples/declaration/value/function/do/applications-and-parens-out.hs
@@ -4,6 +4,6 @@ warningFor var place = do
   ( if includeGlobals || isLocal var
       then warningForLocals
       else warningForGlobals
-    )
+   )
     var
     place

--- a/data/examples/declaration/value/function/do/operator-and-parens-out.hs
+++ b/data/examples/declaration/value/function/do/operator-and-parens-out.hs
@@ -3,5 +3,5 @@ scientifically h = do
   something
   ( I.satisfy (\w -> w == 'e' || w == 'E')
       *> fmap (h . Sci.scientific signedCoeff . (e +)) (signed decimal)
-    )
+   )
     <|> return (h $ Sci.scientific signedCoeff e)

--- a/data/examples/declaration/value/function/list-comprehensions-out.hs
+++ b/data/examples/declaration/value/function/list-comprehensions-out.hs
@@ -26,7 +26,7 @@ barbaz x y z w =
 a = do
   [ c
     | c <- d
-    ]
+   ]
 
 trans =
   [ x

--- a/data/examples/declaration/value/function/multiline-arguments-out.hs
+++ b/data/examples/declaration/value/function/multiline-arguments-out.hs
@@ -4,5 +4,5 @@ foo
   ( Bar
       x
       y
-    )
+   )
   z = x

--- a/data/examples/declaration/value/function/pattern/famous-cardano-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/famous-cardano-pattern-out.hs
@@ -2,7 +2,7 @@
     :<|> getNodeInfoR
     :<|> getNextUpdateR
     :<|> restartNodeR
-  )
+ )
   :<|> ( getUtxoR
            :<|> getConfirmedProposalsR
-         ) = client nodeV1Api
+        ) = client nodeV1Api

--- a/data/examples/declaration/value/function/pattern/multiline-case-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/multiline-case-pattern-out.hs
@@ -2,14 +2,14 @@ readerBench doc name =
   runPure $ case (getReader name, getWriter name) of
     ( Right (TextReader r, rexts),
       Right (TextWriter w, wexts)
-      ) -> undefined
+     ) -> undefined
 
 f xs = case xs of
   [ a,
     b
-    ] -> a + b
+   ] -> a + b
 
 g xs = case xs of
   ( a
       : bs
-    ) -> a + b
+   ) -> a + b

--- a/data/examples/declaration/value/function/pattern/n-plus-k-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/n-plus-k-pattern-out.hs
@@ -7,7 +7,7 @@ multiline :: Int
 multiline
   ( n
       + 1
-    ) = n
+   ) = n
 
 n :: Int
 (n + 1) = 3

--- a/data/examples/declaration/value/function/pattern/unboxed-sum-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/unboxed-sum-pattern-out.hs
@@ -20,7 +20,7 @@ z_multiline = True
   where
     (#
       | | _x
-      #) =
+     #) =
         (#
           | | True
         #)

--- a/data/examples/declaration/value/function/pattern/view-pattern-out.hs
+++ b/data/examples/declaration/value/function/pattern/view-pattern-out.hs
@@ -12,4 +12,4 @@ multiline
       Foo
         bar
         baz
-    ) = True
+   ) = True

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -311,7 +311,11 @@ brackets_ needBreaks open close style m = sitcc (vlayout singleLine multiLine)
         then newline >> inci m
         else space >> sitcc m
       newline
-      inciIf (style == S) (txt close)
+      inciIfS (txt close)
+
+    -- ideally this would be 0, but some contexts require at least one space,
+    -- e.g. case patterns or top-level patterns
+    inciIfS = if style == S then inciBy 1 else id
 
 ----------------------------------------------------------------------------
 -- Literals

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -20,6 +20,7 @@ module Ormolu.Printer.Internal
     askModuleFixityMap,
     askDebug,
     inci,
+    inciBy,
     sitcc,
     Layout (..),
     enterLayout,
@@ -396,6 +397,7 @@ askModuleFixityMap = R (asks rcModuleFixityMap)
 askDebug :: R Bool
 askDebug = R (asks rcDebug)
 
+-- | Like 'inci', but indents by exactly the given number of steps.
 inciBy :: Int -> R () -> R ()
 inciBy step (R m) = R (local modRC m)
   where

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -207,7 +207,7 @@ declSeries (L _ x) (L _ y) =
   case (x, y) of
     ( SigD _ (TypeSig _ _ _),
       SigD _ (TypeSig _ _ _)
-      ) -> True
+     ) -> True
     _ -> False
 
 intersects :: (Ord a) => [a] -> [a] -> Bool


### PR DESCRIPTION
Supercedes #1101 

AFAICT, the only motivation for `BracketStyle` is to prevent the closing bracket from being in the same column as the opening bracket, which can be a parse error in certain contexts, like case patterns. So this only needs to indent by a single space, not a full indentation.

It's not that big of an issue here (1 vs 2 spaces), but it's a bigger issue with larger indentations. So I had to make this fix in Fourmolu anyway, but I'm opening this PR just in case you want to merge it upstream. IMO this encodes the intention better, but I recognize that the breakage might not be worthwhile