### PR TITLE
Preserve single line function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   1120](https://github.com/tweag/ormolu/issues/1120).
 
 * Allow function arguments to be on the same line even if the full type
-  (with constraints and foralls) are on multiple lines. [Issue
+  (with constraints and foralls) are on multiple lines. [PR
   1125](https://github.com/tweag/ormolu/pull/1125)
 
 ## Ormolu 0.7.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Use single-line layout for parens around single-line content. [Issue
   1120](https://github.com/tweag/ormolu/issues/1120).
 
+* Allow function arguments to be on the same line even if the full type
+  (with constraints and foralls) are on multiple lines. [Issue
+  1125](https://github.com/tweag/ormolu/pull/1125)
+
 ## Ormolu 0.7.6.0
 
 * Fix Haddock comments on infix constructors

--- a/data/examples/declaration/class/default-signatures-out.hs
+++ b/data/examples/declaration/class/default-signatures-out.hs
@@ -14,9 +14,7 @@ class Bar a where
     ( Read a,
       Semigroup a
     ) =>
-    a ->
-    a ->
-    a
+    a -> a -> a
   -- Even more pointless comment
   bar
     a

--- a/data/examples/declaration/data/gadt/multiline-out.hs
+++ b/data/examples/declaration/data/gadt/multiline-out.hs
@@ -9,9 +9,7 @@ data Foo a where
     forall a b.
     (Show a, Eq b) => -- foo
     -- bar
-    a ->
-    b ->
-    Foo 'Int
+    a -> b -> Foo 'Int
   -- | But 'Bar' is also not too bad.
   Bar ::
     Int -> Maybe Text -> Foo 'Bool

--- a/data/examples/declaration/rewrite-rule/type-signature-out.hs
+++ b/data/examples/declaration/rewrite-rule/type-signature-out.hs
@@ -8,9 +8,7 @@
   z
   ( g ::
       forall b.
-      (a -> b -> b) ->
-      b ->
-      b
+      (a -> b -> b) -> b -> b
   ).
   foldr k z (build g) =
     g k z

--- a/data/examples/declaration/value/function/fancy-forall-0-out.hs
+++ b/data/examples/declaration/value/function/fancy-forall-0-out.hs
@@ -6,5 +6,4 @@ wrapError ::
     HasCatch innertag inner (t m'),
     HasCatch outertag outer m
   ) =>
-  (forall m'. (HasCatch innertag inner m') => m' a) ->
-  m a
+  (forall m'. (HasCatch innertag inner m') => m' a) -> m a

--- a/data/examples/declaration/value/function/fancy-forall-1-out.hs
+++ b/data/examples/declaration/value/function/fancy-forall-1-out.hs
@@ -6,5 +6,4 @@ magnify ::
     HasReader innertag inner (t m'),
     HasReader outertag outer m
   ) =>
-  (forall m'. (HasReader innertag inner m') => m' a) ->
-  m a
+  (forall m'. (HasReader innertag inner m') => m' a) -> m a

--- a/data/examples/declaration/value/function/implicit-params-out.hs
+++ b/data/examples/declaration/value/function/implicit-params-out.hs
@@ -11,6 +11,5 @@ sort' ::
       a -> a -> Bool,
     ?foo :: Int
   ) =>
-  [a] ->
-  [a]
+  [a] -> [a]
 sort' = sort

--- a/data/examples/declaration/value/function/multiline-types-out.hs
+++ b/data/examples/declaration/value/function/multiline-types-out.hs
@@ -1,0 +1,20 @@
+foo ::
+  (Monad m, Show a) =>
+  a ->
+  m String
+bar ::
+  ( Monad m,
+    Show a
+  ) =>
+  a ->
+  m String
+multiConstraints ::
+  (Show a) =>
+  a ->
+  a ->
+  a ->
+  (Eq a) =>
+  (Num a) =>
+  a ->
+  a ->
+  ()

--- a/data/examples/declaration/value/function/multiline-types-out.hs
+++ b/data/examples/declaration/value/function/multiline-types-out.hs
@@ -6,8 +6,7 @@ bar ::
   ( Monad m,
     Show a
   ) =>
-  a ->
-  m String
+  a -> m String
 multiConstraints ::
   (Show a) =>
   a ->
@@ -15,6 +14,4 @@ multiConstraints ::
   a ->
   (Eq a) =>
   (Num a) =>
-  a ->
-  a ->
-  ()
+  a -> a -> ()

--- a/data/examples/declaration/value/function/multiline-types.hs
+++ b/data/examples/declaration/value/function/multiline-types.hs
@@ -1,0 +1,15 @@
+foo ::
+   (Monad m, Show a) =>
+   a ->
+   m String
+
+bar ::
+   (Monad m,
+      Show a) =>
+   a -> m String
+
+multiConstraints ::
+  Show a =>
+  a -> a -> a ->
+  Eq a => Num a =>
+  a -> a -> ()

--- a/data/examples/other/multiline-forall-out.hs
+++ b/data/examples/other/multiline-forall-out.hs
@@ -22,8 +22,7 @@ data G where
       )
       (x :: *)
       (y :: *).
-    f x y ->
-    G
+    f x y -> G
 
 f ::
   forall
@@ -32,8 +31,7 @@ f ::
     )
     (x :: *)
     (y :: *).
-  f x y ->
-  ()
+  f x y -> ()
 f = const ()
 
 type family T f x y where

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -44,7 +44,7 @@ p_hsType' multilineArgs = \case
       HsForAllInvis _ bndrs -> p_forallBndrs ForAllInvis p_hsTyVarBndr bndrs
       HsForAllVis _ bndrs -> p_forallBndrs ForAllVis p_hsTyVarBndr bndrs
     interArgBreak
-    p_hsTypeR (unLoc t)
+    located t p_hsType
   HsQualTy _ qs t -> do
     located qs p_hsContext
     space
@@ -52,7 +52,7 @@ p_hsType' multilineArgs = \case
     interArgBreak
     case unLoc t of
       HsQualTy {} -> p_hsTypeR (unLoc t)
-      HsFunTy {} -> p_hsTypeR (unLoc t)
+      HsFunTy {} -> located t p_hsType
       _ -> located t p_hsTypeR
   HsTyVar _ p n -> do
     case p of


### PR DESCRIPTION
Currently, function arguments are forced to be on multiple lines if the whole type is multiline:
```hs
foo ::
  Show a =>
  a ->
  String
```

This allows the arguments to stay on the same line if they were originally:
```hs
foo ::
  Show a =>
  a -> String
```

If the user wrote the function args on multiple lines, it will stay on multiple lines. So this change is not a breaking change for people with already formatted code

ref. https://github.com/fourmolu/fourmolu/pull/277 https://github.com/fourmolu/fourmolu/pull/410