### PR TITLE
Format type applications of `QuasiQuotes` correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Format multiple files in parallel. [Issue
   1128](https://github.com/tweag/ormolu/issues/1128).
 
+* Correctly format type applications of `QuasiQuotes`. [Issue
+  1134](https://github.com/tweag/ormolu/issues/1134).
+
 ## Ormolu 0.7.7.0
 
 * Use single-line layout for parens around single-line content. [Issue

--- a/data/examples/declaration/value/function/type-applications-out.hs
+++ b/data/examples/declaration/value/function/type-applications-out.hs
@@ -22,3 +22,5 @@ test x = case x of
     @u
     v ->
       ""
+
+foo = foo @[k|bar|]

--- a/data/examples/declaration/value/function/type-applications.hs
+++ b/data/examples/declaration/value/function/type-applications.hs
@@ -17,3 +17,5 @@ test x = case x of
   Bar
    @t @u v
     -> ""
+
+foo = foo @[k|bar|]

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -672,11 +672,6 @@ p_hsExpr' isApp s = \case
     breakpoint
     inci $ do
       txt "@"
-      -- Insert a space when the type is represented as a TH splice to avoid
-      -- gluing @ and $ together.
-      case unLoc (hswc_body a) of
-        HsSpliceTy {} -> space
-        _ -> return ()
       located (hswc_body a) p_hsType
   OpApp _ x op y -> do
     modFixityMap <- askModuleFixityMap


### PR DESCRIPTION
Closes #1134 

This PR basically reverts #616 (but keeps the tests that were added there), which was necessary back then, but no longer is due to [GHC proposal 229 ("Whitespace-sensitive operator parsing")](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst).

Concretely, the example from #613/#616
```haskell
sing @ $(symFQN name)
```
is nowadays always parsed as an application of the (value-level) operator `@` to two value-level arguments, in contrast to a type application back then (when `TypeApplications` was enabled). Hence, we don't need to handle anything specially here by inserting extra spaces.

This fixes the bug because `HsSpliceTy` is also used to represent `QuasiQuotes`.