### PR TITLE
Propagate `BracketStyle` in arrow application

### DIFF
--- a/data/examples/declaration/value/function/arrow/proc-form-do-indent-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-form-do-indent-out.hs
@@ -12,3 +12,10 @@ foo1 x = proc (y, z) -> do
       (bindA -< y)
     |)
     z
+
+foo2 = proc () -> do
+  ( proc () ->
+      returnA -< ()
+    )
+    -<
+      ()

--- a/data/examples/declaration/value/function/arrow/proc-form-do-indent.hs
+++ b/data/examples/declaration/value/function/arrow/proc-form-do-indent.hs
@@ -11,3 +11,8 @@ foo1 x = proc (y, z) -> do
     bar
       (bindA -< y)
     |) z
+
+foo2 = proc () -> do
+  (proc () ->
+    returnA -< ()
+    ) -< ()

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -345,7 +345,7 @@ p_hsCmd' :: IsApplicand -> BracketStyle -> HsCmd GhcPs -> R ()
 p_hsCmd' isApp s = \case
   HsCmdArrApp _ body input arrType rightToLeft -> do
     let (l, r) = if rightToLeft then (body, input) else (input, body)
-    located l p_hsExpr
+    located l $ p_hsExpr' NotApplicand s
     breakpoint
     inci $ do
       case (arrType, rightToLeft) of


### PR DESCRIPTION
Closes #1144 

We need to indent the closing parenthesis in arrow `do` blocks, just as we need to do for regular `do` blocks. We already have `BracketStyle` for that, we just need to propagate it.