### PR TITLE
Restore the necessary Data.List import

### DIFF
--- a/extract-hackage-info/src/Main.hs
+++ b/extract-hackage-info/src/Main.hs
@@ -10,6 +10,7 @@
 module Main (main) where
 
 import Control.Exception
+import Control.Exception
 import Control.Monad
 import Data.Aeson qualified as A
 import Data.Binary qualified as Binary
@@ -17,6 +18,7 @@ import Data.Binary.Get qualified as Binary
 import Data.Binary.Put qualified as Binary
 import Data.ByteString qualified as ByteString
 import Data.ByteString.Lazy qualified as BL
+import Data.List (foldl')
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe


### PR DESCRIPTION
As it says on the tin -- f5e1c67 removed an import that was still necessary,
this restores and narrows it under the presumption that that was the commit's
intent.
