### PR TITLE
Fix false positives in AST diffing with implicit fixities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
   string represented by a string literal. [Issue
   1160](https://github.com/tweag/ormolu/issues/1160).
 
+* Fix false positives in AST diffing in fixity declarations with implicit
+  fixity, such as `infix +`. [Issue
+  1166](https://github.com/tweag/ormolu/issues/1166).
+
 ## Ormolu 0.8.0.0
 
 * Format multiple files in parallel. [Issue

--- a/data/examples/declaration/signature/fixity/infix-out.hs
+++ b/data/examples/declaration/signature/fixity/infix-out.hs
@@ -5,3 +5,5 @@ infix 9 <^-^>
 infix 2 ->
 
 infix 0 type <!>
+
+infix 9 +

--- a/data/examples/declaration/signature/fixity/infix.hs
+++ b/data/examples/declaration/signature/fixity/infix.hs
@@ -4,3 +4,5 @@ infix 9 <^-^>
 infix 2 ->
 
 infix 0 type <!>
+
+infix +

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -94,6 +94,7 @@ diffHsModule = genericQuery
                   `extQ` considerEqual @SourceText
                   `extQ` considerEqual @EpAnnComments -- ~ XCGRHSs GhcPs
                   `extQ` considerEqual @EpaLocation
+                  `extQ` considerEqual @(Maybe EpaLocation)
                   `extQ` considerEqual @EpLayout
                   `extQ` considerEqual @AnnSig
                   `extQ` considerEqual @HsRuleAnn


### PR DESCRIPTION
Closes #1166

The problem is that formatting `infix +` to `infix 9 +` changes the exact print annotations, namely in
```haskell
XFixSig ~ ((EpaLocation, Maybe EpaLocation), SourceText)
```
the `Maybe EpaLocation` (indicating the position of the number, if present) changes from `Nothing` to `Just`. The fix is simply to ignore this difference.

An alternative would be to preserve the input choice of whether the fixity is implicit, but I like the current behavior as it provides more consistency and explicitness.