### PR TITLE
Make RequiredTypeArguments consistent with types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   fixity, such as `infix +`. [Issue
   1166](https://github.com/tweag/ormolu/issues/1166).
 
+* Make multiline function signatures in RequiredTypeArguments consistent with
+  types [PR 1170](https://github.com/tweag/ormolu/pull/1170)
+
 ## Ormolu 0.8.0.0
 
 * Format multiple files in parallel. [Issue

--- a/data/examples/declaration/value/function/required-type-arguments-2-out.hs
+++ b/data/examples/declaration/value/function/required-type-arguments-2-out.hs
@@ -18,5 +18,6 @@ long =
       Maybe Int ->
       Maybe
         (String, Int) %1 ->
-      Word %m -> Text
+      Word %m ->
+      Text
     )

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -860,7 +860,9 @@ p_hsExpr' isApp s = \case
     space
     p_arrow (located' p_hsExpr) arrow
     breakpoint
-    located y p_hsExpr
+    case unLoc y of
+      HsFunArr {} -> p_hsExpr (unLoc y)
+      _ -> located y p_hsExpr
 
 -- | Print a list comprehension.
 --

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -87,13 +87,13 @@ p_hsType' multilineArgs = \case
     inci $ do
       txt "@"
       located kd p_hsType
-  HsFunTy _ arrow x y@(L _ y') -> do
+  HsFunTy _ arrow x y -> do
     located x p_hsType
     space
     p_arrow (located' p_hsTypeR) arrow
     interArgBreak
-    case y' of
-      HsFunTy {} -> p_hsTypeR y'
+    case unLoc y of
+      HsFunTy {} -> p_hsTypeR (unLoc y)
       _ -> located y p_hsTypeR
   HsListTy _ t ->
     located t (brackets N . p_hsType)


### PR DESCRIPTION
Input:
```hs
typeSig ::
  ( Int
  -> Int -> Int
  )
  
requiredType =
  f ( Int
    -> Int -> Int
    )
```

Current output:
```hs
typeSig ::
  ( Int ->
    Int ->
    Int
  )

requiredType =
  f
    ( Int ->
      Int -> Int
    )
```

After this PR:
```hs
typeSig ::
  ( Int ->
    Int ->
    Int
  )

requiredType =
  f
    ( Int ->
      Int ->
      Int
    )
```