### PR TITLE
Fix formatting single-line `MultiWayIf`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Make multiline function signatures in RequiredTypeArguments consistent with
   types [PR 1170](https://github.com/tweag/ormolu/pull/1170)
 
+* Correctly format single-line `MultiWayIf`s. [Issue
+  1171](https://github.com/tweag/ormolu/issues/1171).
+
 ## Ormolu 0.8.0.0
 
 * Format multiple files in parallel. [Issue

--- a/data/examples/declaration/value/function/multi-way-if-out.hs
+++ b/data/examples/declaration/value/function/multi-way-if-out.hs
@@ -14,3 +14,5 @@ baz =
       | p -> f
       | otherwise -> g
     x
+
+x y = if | foo -> False | otherwise -> True

--- a/data/examples/declaration/value/function/multi-way-if.hs
+++ b/data/examples/declaration/value/function/multi-way-if.hs
@@ -12,3 +12,5 @@ baz =
   if | p -> f
      | otherwise -> g
     x
+
+x y = if | foo -> False | otherwise -> True

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -733,7 +733,7 @@ p_hsExpr' isApp s = \case
   HsMultiIf _ guards -> do
     txt "if"
     breakpoint
-    inciApplicand isApp $ sep newline (located' (p_grhs RightArrow)) guards
+    inciApplicand isApp $ sep breakpoint (located' (p_grhs RightArrow)) guards
   HsLet _ localBinds e ->
     p_let p_hsExpr localBinds e
   HsDo _ doFlavor es -> do


### PR DESCRIPTION
Closes #1171 

Support for `MultiWayIf` was introduced in 45e25a11466a8dfce80fd0b96dce61c742a34799 using `breakpoint` separating different guards, but that was changed in the next commit 777524b6de237b25b60c44054569e16fdab3d762 to use `newline`, I am not exactly sure why.