### PR TITLE
Fix extra blank lines in multiline strings causing AST mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Correctly format string literals containing the `\^\` escape sequence. [Issue
   1165](https://github.com/tweag/ormolu/issues/1165).
 
+* Correctly preserve consecutive blank lines in multiline strings. [Issue
+  1194](https://github.com/tweag/ormolu/issues/1194).
+
 ## Ormolu 0.8.0.2
 
 * Fixed a performance regression introduced in 0.8.0.0. [Issue

--- a/data/examples/declaration/value/function/multiline-strings-9-out.hs
+++ b/data/examples/declaration/value/function/multiline-strings-9-out.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE MultilineStrings #-}
+
+multilineBlank =
+  """
+  1
+
+
+
+
+  6
+  """

--- a/data/examples/declaration/value/function/multiline-strings-9.hs
+++ b/data/examples/declaration/value/function/multiline-strings-9.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE MultilineStrings #-}
+
+multilineBlank =
+  """
+  1
+
+
+
+
+  6
+  """

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -21,6 +21,7 @@ module Ormolu.Printer.Combinators
     atom,
     space,
     newline,
+    newlineLiteral,
     inci,
     inciIf,
     askSourceType,

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -17,6 +17,7 @@ module Ormolu.Printer.Internal
     atom,
     space,
     newline,
+    newlineLiteral,
     askSourceType,
     askModuleFixityMap,
     askDebug,
@@ -385,6 +386,19 @@ newlineRaw = R . modify $ \sc ->
             VeryBeginning -> VeryBeginning
             _ -> AfterNewline
         }
+
+-- | Insert a newline literal without modifying the internal state of the
+-- parser. This is to be used exceptionally, e.g. for printing multiline
+-- string literals.
+newlineLiteral :: R ()
+newlineLiteral = R . modify $ \sc ->
+  sc
+    { scBuilder = scBuilder sc <> "\n",
+      scColumn = 0,
+      scIndent = 0,
+      scThisLineSpans = [],
+      scRequestedDelimiter = AfterNewline
+    }
 
 -- | Return the source type.
 askSourceType :: R SourceType

--- a/src/Ormolu/Printer/Meat/Declaration/StringLiteral.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/StringLiteral.hs
@@ -40,7 +40,7 @@ p_stringLit src = case parseStringLiteral $ T.pack $ unpackFS src of
                   LastPos -> txt "\\" *> txt s
         vlayout singleLine multiLine
       MultilineStringLiteral ->
-        sep breakpoint' txt segments
+        sep newlineLiteral txt segments
     txt endMarker
 
 -- | The start/end marker of the literal, whether it is a regular or a multiline


### PR DESCRIPTION
Added a `newlineAlways` (open to renaming if preferred) helper for preserving the newlines in the `MultilineStringLiteral` case.

Fixes #1194 