### PR TITLE
Add flexible semicolon insertion and context-aware pattern rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Correctly preserve consecutive blank lines in multiline strings. [Issue
   1194](https://github.com/tweag/ormolu/issues/1194).
 
+* Fixed printing of multi-line or-patterns inside as-patterns. [Issue
+  1183](https://github.com/tweag/ormolu/issues/1183).
+
 ## Ormolu 0.8.0.2
 
 * Fixed a performance regression introduced in 0.8.0.0. [Issue

--- a/data/examples/declaration/value/function/pattern/or-patterns-out.hs
+++ b/data/examples/declaration/value/function/pattern/or-patterns-out.hs
@@ -34,3 +34,10 @@ insane e = case e of
   (D; E (Just _) Nothing) ->
     4
   F -> 5
+
+food
+  foo@( A;
+        B;
+        C
+        ) = Just foo
+food _ = Nothing

--- a/data/examples/declaration/value/function/pattern/or-patterns.hs
+++ b/data/examples/declaration/value/function/pattern/or-patterns.hs
@@ -31,3 +31,8 @@ insane e = case e of
   (D; E (Just _) Nothing)
    -> 4
   F -> 5
+
+food foo@(A;
+          B;
+          C) = Just foo
+food _ = Nothing

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -40,6 +40,7 @@ module Ormolu.Printer.Combinators
     -- ** Formatting lists
     sep,
     sepSemi,
+    sepSemi',
     canUseBraces,
     useBraces,
     dontUseBraces,
@@ -197,18 +198,20 @@ sep s f xs = sequence_ (intersperse s (f <$> xs))
 -- inserting semicolons if necessary and respecting 'useBraces' and
 -- 'dontUseBraces' combinators.
 --
--- > useBraces $ sepSemi txt ["foo", "bar"]
+-- > useBraces $ sepSemi' False txt ["foo", "bar"]
 -- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
 --
--- > dontUseBraces $ sepSemi txt ["foo", "bar"]
--- >   == vlayout (txt "foo; bar") (txt "foo\nbar")
-sepSemi ::
+-- > dontUseBraces $ sepSemi' True txt ["foo", "bar"]
+-- >   == vlayout (txt "foo; bar") (txt "foo;\nbar")
+sepSemi' ::
+  -- | Whether to insert semicolons in multi-line layout
+  Bool ->
   -- | How to render an element
   (a -> R ()) ->
   -- | Elements to render
   [a] ->
   R ()
-sepSemi f xs = vlayout singleLine multiLine
+sepSemi' addMultiColSemi f xs = vlayout singleLine multiLine
   where
     singleLine = do
       ub <- canUseBraces
@@ -224,7 +227,16 @@ sepSemi f xs = vlayout singleLine multiLine
               txt "}"
             else sep (txt ";" >> space) f xs'
     multiLine =
-      sep newline (dontUseBraces . f) xs
+      sep (if addMultiColSemi then txt ";" >> newline else newline) (dontUseBraces . f) xs
+
+-- | A version of 'sepSemi'' with semicolons in multi-line layout and no semicolons in single-line layout.
+sepSemi ::
+  -- | How to render an element
+  (a -> R ()) ->
+  -- | Elements to render
+  [a] ->
+  R ()
+sepSemi = sepSemi' False
 
 ----------------------------------------------------------------------------
 -- Wrapping

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -194,9 +194,8 @@ sep ::
   R ()
 sep s f xs = sequence_ (intersperse s (f <$> xs))
 
--- | Render a collection of elements layout-sensitively using given printer,
--- inserting semicolons if necessary and respecting 'useBraces' and
--- 'dontUseBraces' combinators.
+-- | A version of `sepSemi` that allows to control whether semicolons should be
+-- inserted in multi-line layout.
 --
 -- > useBraces $ sepSemi' False txt ["foo", "bar"]
 -- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
@@ -229,7 +228,15 @@ sepSemi' addMultiColSemi f xs = vlayout singleLine multiLine
     multiLine =
       sep (if addMultiColSemi then txt ";" >> newline else newline) (dontUseBraces . f) xs
 
--- | A version of 'sepSemi'' with semicolons in multi-line layout and no semicolons in single-line layout.
+-- | Render a collection of elements layout-sensitively using given printer,
+-- inserting semicolons if necessary and respecting 'useBraces' and
+-- 'dontUseBraces' combinators.
+--
+-- > useBraces $ sepSemi txt ["foo", "bar"]
+-- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
+--
+-- > dontUseBraces $ sepSemi txt ["foo", "bar"]
+-- >   == vlayout (txt "foo; bar") (txt "foo\nbar")
 sepSemi ::
   -- | How to render an element
   (a -> R ()) ->

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -194,8 +194,25 @@ sep ::
   R ()
 sep s f xs = sequence_ (intersperse s (f <$> xs))
 
--- | A version of `sepSemi` that allows to control whether semicolons should be
--- inserted in multi-line layout.
+-- | Render a collection of elements layout-sensitively using given printer,
+-- inserting semicolons if necessary and respecting 'useBraces' and
+-- 'dontUseBraces' combinators.
+--
+-- > useBraces $ sepSemi txt ["foo", "bar"]
+-- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
+--
+-- > dontUseBraces $ sepSemi txt ["foo", "bar"]
+-- >   == vlayout (txt "foo; bar") (txt "foo\nbar")
+sepSemi ::
+  -- | How to render an element
+  (a -> R ()) ->
+  -- | Elements to render
+  [a] ->
+  R ()
+sepSemi = sepSemi' False
+
+-- | A version of 'sepSemi' that allows to control whether semicolons should
+-- be inserted in multi-line layout.
 --
 -- > useBraces $ sepSemi' False txt ["foo", "bar"]
 -- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
@@ -226,24 +243,10 @@ sepSemi' addMultiColSemi f xs = vlayout singleLine multiLine
               txt "}"
             else sep (txt ";" >> space) f xs'
     multiLine =
-      sep (if addMultiColSemi then txt ";" >> newline else newline) (dontUseBraces . f) xs
-
--- | Render a collection of elements layout-sensitively using given printer,
--- inserting semicolons if necessary and respecting 'useBraces' and
--- 'dontUseBraces' combinators.
---
--- > useBraces $ sepSemi txt ["foo", "bar"]
--- >   == vlayout (txt "{ foo; bar }") (txt "foo\nbar")
---
--- > dontUseBraces $ sepSemi txt ["foo", "bar"]
--- >   == vlayout (txt "foo; bar") (txt "foo\nbar")
-sepSemi ::
-  -- | How to render an element
-  (a -> R ()) ->
-  -- | Elements to render
-  [a] ->
-  R ()
-sepSemi = sepSemi' False
+      sep
+        (if addMultiColSemi then txt ";" >> newline else newline)
+        (dontUseBraces . f)
+        xs
 
 ----------------------------------------------------------------------------
 -- Wrapping

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1176,7 +1176,8 @@ p_pat' inAsPat = \case
             Unboxed -> parensHash S
     parens' $ sep commaDel (sitcc . located' (p_pat' inAsPat)) pats
   OrPat _ pats -> do
-    sepSemi (located' (p_pat' inAsPat)) (NE.toList pats)
+    let renderOrPat = if inAsPat then sepSemi' True else sepSemi
+    renderOrPat (located' (p_pat' inAsPat)) (NE.toList pats)
   SumPat _ pat tag arity ->
     p_unboxedSum S tag arity (located pat (p_pat' inAsPat))
   ConPat _ pat details ->

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1176,7 +1176,7 @@ p_pat' inAsPat = \case
             Unboxed -> parensHash S
     parens' $ sep commaDel (sitcc . located' (p_pat' inAsPat)) pats
   OrPat _ pats -> do
-    let renderOrPat = if inAsPat then sepSemi' True else sepSemi
+    let renderOrPat = if inAsPat then sepSemi' True else sepSemi' False
     renderOrPat (located' (p_pat' inAsPat)) (NE.toList pats)
   SumPat _ pat tag arity ->
     p_unboxedSum S tag arity (located pat (p_pat' inAsPat))

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1149,39 +1149,42 @@ p_let render localBinds e = sitcc $ do
   sitcc (located e render)
 
 p_pat :: Pat GhcPs -> R ()
-p_pat = \case
+p_pat = p_pat' False
+
+p_pat' :: Bool -> Pat GhcPs -> R ()
+p_pat' inAsPat = \case
   WildPat _ -> txt "_"
   VarPat _ name -> p_rdrName name
   LazyPat _ pat -> do
     txt "~"
-    located pat p_pat
+    located pat (p_pat' inAsPat)
   AsPat _ name pat -> do
     p_rdrName name
     txt "@"
-    located pat p_pat
+    located pat (p_pat' True)
   ParPat _ pat ->
-    located pat (parens S . p_pat)
+    located pat (parens S . p_pat' inAsPat)
   BangPat _ pat -> do
     txt "!"
-    located pat p_pat
+    located pat (p_pat' inAsPat)
   ListPat _ pats ->
-    brackets S $ sep commaDel (located' p_pat) pats
+    brackets S $ sep commaDel (located' (p_pat' inAsPat)) pats
   TuplePat _ pats boxing -> do
     let parens' =
           case boxing of
             Boxed -> parens S
             Unboxed -> parensHash S
-    parens' $ sep commaDel (sitcc . located' p_pat) pats
-  OrPat _ pats ->
-    sepSemi (located' p_pat) (NE.toList pats)
+    parens' $ sep commaDel (sitcc . located' (p_pat' inAsPat)) pats
+  OrPat _ pats -> do
+    sepSemi (located' (p_pat' inAsPat)) (NE.toList pats)
   SumPat _ pat tag arity ->
-    p_unboxedSum S tag arity (located pat p_pat)
+    p_unboxedSum S tag arity (located pat (p_pat' inAsPat))
   ConPat _ pat details ->
     case details of
       PrefixCon xs -> sitcc $ do
         p_rdrName pat
         unless (null xs) breakpoint
-        inci . sitcc $ sep breakpoint (sitcc . located' p_pat) xs
+        inci . sitcc $ sep breakpoint (sitcc . located' (p_pat' inAsPat)) xs
       RecCon (HsRecFields _ fields dotdot) -> do
         p_rdrName pat
         breakpoint
@@ -1194,18 +1197,18 @@ p_pat = \case
             Just (L _ (RecFieldsDotDot n)) -> (Just <$> take n fields) ++ [Nothing]
       InfixCon l r -> do
         switchLayout [getLocA l, getLocA r] $ do
-          located l p_pat
+          located l (p_pat' inAsPat)
           breakpoint
           inci $ do
             p_rdrName pat
             space
-            located r p_pat
+            located r (p_pat' inAsPat)
   ViewPat _ expr pat -> sitcc $ do
     located expr p_hsExpr
     space
     txt "->"
     breakpoint
-    inci (located pat p_pat)
+    inci (located pat (p_pat' inAsPat))
   SplicePat _ splice -> p_hsUntypedSplice DollarSplice splice
   LitPat _ p -> atom p
   NPat _ v (isJust -> isNegated) _ -> do
@@ -1222,7 +1225,7 @@ p_pat = \case
       space
       located k (atom . ol_val)
   SigPat _ pat HsPS {..} -> do
-    located pat p_pat
+    located pat (p_pat' inAsPat)
     p_typeAscription (lhsTypeToSigType hsps_body)
   EmbTyPat _ (HsTP _ ty) -> do
     txt "type"

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1176,8 +1176,7 @@ p_pat' inAsPat = \case
             Unboxed -> parensHash S
     parens' $ sep commaDel (sitcc . located' (p_pat' inAsPat)) pats
   OrPat _ pats -> do
-    let renderOrPat = if inAsPat then sepSemi' True else sepSemi' False
-    renderOrPat (located' (p_pat' inAsPat)) (NE.toList pats)
+    sepSemi' inAsPat (located' (p_pat' inAsPat)) (NE.toList pats)
   SumPat _ pat tag arity ->
     p_unboxedSum S tag arity (located pat (p_pat' inAsPat))
   ConPat _ pat details ->


### PR DESCRIPTION
Introduce a new `sepSemi'` combinator for flexible semicolon insertion in multi-line layouts (based on existing `sepSemi`).
`sepSemi` combinator is now defined as `sepSemi'` with the default value of `True` for semicolon insertion in multi-line layouts.
Refactor `p_pat` to maintain context for `AsPat` patterns, enabling conditional rendering for `OrPat` based on this context.
Update tests for or-patterns with multi-line or-patterns within as-patterns.

Fixes #1183.