### PR TITLE
Do not indent body on multiline or-pattern case match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 * Fixed printing of multi-line or-patterns inside as-patterns. [Issue
   1183](https://github.com/tweag/ormolu/issues/1183).
 
+* Fixed an issue where or-patterns would be indented twice. [Issue
+  1188](https://github.com/tweag/ormolu/issues/1188).
+
 ## Ormolu 0.8.0.2
 
 * Fixed a performance regression introduced in 0.8.0.0. [Issue

--- a/data/examples/declaration/value/function/pattern/or-patterns-out.hs
+++ b/data/examples/declaration/value/function/pattern/or-patterns-out.hs
@@ -21,7 +21,8 @@ case e of
 sane e = case e of
   1
   2
-  3 -> a
+  3 ->
+    a
   4
   5
   6 -> b

--- a/data/examples/declaration/value/function/pattern/or-patterns.hs
+++ b/data/examples/declaration/value/function/pattern/or-patterns.hs
@@ -20,7 +20,8 @@ case e of
 sane e = case e of
   1
   2
-  3 -> a
+  3 ->
+    a
   4
   5;6 -> b
   7;8 -> c

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -188,6 +188,10 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
     NoSrcStrict -> return ()
     SrcStrict -> txt "!"
     SrcLazy -> txt "~"
+  let isCase = \case
+        Case -> True
+        LambdaCase -> True
+        _ -> False
   indentBody <- case NE.nonEmpty m_pats of
     Nothing ->
       False <$ case style of
@@ -198,7 +202,10 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
             Function name -> combineSrcSpans (getLocA name) patSpans
             _ -> patSpans
           patSpans = combineSrcSpans' (getLocA <$> ne_pats)
-          indentBody = not (isOneLineSpan combinedSpans)
+          containsOrPat = everything (||) $ \b -> case cast @_ @(Pat GhcPs) b of
+            Just OrPat {} -> True
+            _ -> False
+          indentBody = not (isOneLineSpan combinedSpans) && not (isCase style && containsOrPat ne_pats)
       switchLayout [combinedSpans] $ do
         let stdCase = sep breakpoint (located' p_pat) m_pats
         case style of
@@ -235,10 +242,6 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
           Function name -> Just (getLocA name)
           _ -> Nothing
         Just pats -> (Just . getLocA . NE.last) pats
-      isCase = \case
-        Case -> True
-        LambdaCase -> True
-        _ -> False
       hasGuards = withGuards grhssGRHSs
       grhssSpan =
         combineSrcSpans' $

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -205,7 +205,9 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
           containsOrPat = everything (||) $ \b -> case cast @_ @(Pat GhcPs) b of
             Just OrPat {} -> True
             _ -> False
-          indentBody = not (isOneLineSpan combinedSpans) && not (isCase style && containsOrPat ne_pats)
+          indentBody =
+            not (isOneLineSpan combinedSpans)
+              && not (isCase style && containsOrPat ne_pats)
       switchLayout [combinedSpans] $ do
         let stdCase = sep breakpoint (located' p_pat) m_pats
         case style of


### PR DESCRIPTION
Multiline or-pattern case match would trigger a body indentation, while using `placeHanging Normal` to render the body, resulting in a second unwanted body indentation.
This PR fixes this issue by adding a clause to trigger the body indentation that checks that the we are not in a case with or-patterns.
Test cases were updated to cover a situation affected by this change.
Fixes #1188.