### PR TITLE
Add import level to `ImportId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add missing braces for case expressions in single‑line do blocks. [Issue
   1180](https://github.com/tweag/ormolu/issues/1180).
+* Fix the import grouping logic in the presence of imports with explicit
+  levels. [Issue 1192](https://github.com/tweag/ormolu/issues/1192).
 
 ## Ormolu 0.8.1.0
 

--- a/data/examples/import/explicit-level-imports-out.hs
+++ b/data/examples/import/explicit-level-imports-out.hs
@@ -8,3 +8,6 @@ import qualified D splice
 import Data.ByteString (e)
 import Data.ByteString.Lazy quote (d)
 import splice Data.Text (a, b, c)
+import PyF ()
+import splice PyF (fmt, tmf)
+import quote PyF (abc)

--- a/data/examples/import/explicit-level-imports.hs
+++ b/data/examples/import/explicit-level-imports.hs
@@ -8,3 +8,7 @@ import quote qualified B as QB
 import qualified C splice as SC
 import A splice
 import qualified D splice
+import quote PyF (abc)
+import splice PyF (fmt)
+import splice PyF (tmf)
+import PyF ()

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -71,9 +71,22 @@ data ImportId = ImportId
     importSafe :: Bool,
     importQualified :: Bool,
     importAs :: Maybe ModuleName,
-    importHiding :: Maybe ImportListInterpretationOrd
+    importHiding :: Maybe ImportListInterpretationOrd,
+    importLevel :: Maybe ImportDeclLevelOrd
   }
   deriving (Eq, Ord)
+
+-- | A wrapper for 'ImportDeclLevel' that provides an 'Ord' instance.
+newtype ImportDeclLevelOrd = ImportDeclLevelOrd
+  { unImportDeclLevelOrd :: ImportDeclLevel
+  }
+  deriving stock (Eq)
+
+instance Ord ImportDeclLevelOrd where
+  compare = compare `on` toBool . unImportDeclLevelOrd
+    where
+      toBool ImportDeclSplice = False
+      toBool ImportDeclQuote = True
 
 data ImportPkgQual
   = -- | The import is not qualified by a package name.
@@ -118,11 +131,16 @@ importId (L _ ImportDecl {..}) =
         QualifiedPost -> True
         NotQualified -> False,
       importAs = unLoc <$> ideclAs,
-      importHiding = ImportListInterpretationOrd . fst <$> ideclImportList
+      importHiding = ImportListInterpretationOrd . fst <$> ideclImportList,
+      importLevel = importLevelOf ideclLevelSpec
     }
   where
     isPrelude = moduleNameString moduleName == "Prelude"
     moduleName = unLoc ideclName
+    importLevelOf = \case
+      LevelStylePre l -> Just (ImportDeclLevelOrd l)
+      LevelStylePost l -> Just (ImportDeclLevelOrd l)
+      NotLevelled -> Nothing
 
 -- | Normalize a collection of import items.
 normalizeLies :: [LIE GhcPs] -> [LIE GhcPs]


### PR DESCRIPTION
Introduce an `importLevel` field to `ImportId` that reflects whether or not the import has an explicit level set.
This fixes an issue where imports with an explicit level set were being absorbed by other imports without an explcit level set.

Closes #1192.