### PR TITLE
feat: improve constructor Haddock placement

### DIFF
--- a/data/examples/declaration/data/multiline-out.hs
+++ b/data/examples/declaration/data/multiline-out.hs
@@ -2,11 +2,12 @@ module Main where
 
 -- | Here we have 'Foo'.
 data Foo
-  = -- | One
-    Foo
+  = Foo -- ^ One
   | -- | Two
     Bar Int
-  | -- | Three
-    Baz
+  | Baz -- ^ Three
+  | -- | Four
+    -- more about four
+    Qux
   deriving
     (Eq, Show)

--- a/data/examples/declaration/data/multiline.hs
+++ b/data/examples/declaration/data/multiline.hs
@@ -6,5 +6,8 @@ data Foo
   = Foo -- ^ One
   | Bar Int -- ^ Two
   | Baz -- ^ Three
+  | Qux
+    -- ^ Four
+    -- more about four
   deriving
     (Eq, Show)

--- a/data/examples/declaration/data/partly-documented-out.hs
+++ b/data/examples/declaration/data/partly-documented-out.hs
@@ -1,5 +1,4 @@
 data Optimisation
   = PETransform
-  | -- | partial eval and associated transforms
-    GeneralisedNatHack
+  | GeneralisedNatHack -- ^ partial eval and associated transforms
   deriving (Show, Eq, Generic)

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -192,15 +192,22 @@ p_conDecl _ ConDeclGADT {..} = do
 p_conDecl singleRecCon ConDeclH98 {..} =
   case con_args of
     PrefixCon xs -> do
-      renderConDoc
+      let argsHaveDocs = conArgsHaveHaddocks xs
+          placeConDocAfterConstructor =
+            maybe False (isSingleLineDoc . unLoc) con_doc
+              && null xs
+              && not con_forall
+              && null con_ex_tvs
+              && isNothing con_mb_cxt
+      unless placeConDocAfterConstructor renderConDoc
       renderContext
       switchLayout conDeclSpn $ do
         p_rdrName con_name
-        let argsHaveDocs = conArgsHaveHaddocks xs
-            delimiter = if argsHaveDocs then newline else breakpoint
+        let delimiter = if argsHaveDocs then newline else breakpoint
         unless (null xs) delimiter
         inci . sitcc $
           sep delimiter (sitcc . p_hsConDeclFieldWithDoc) xs
+        when placeConDocAfterConstructor renderConDocAfterConstructor
     RecCon l -> do
       renderConDoc
       renderContext
@@ -240,6 +247,13 @@ p_conDecl singleRecCon ConDeclH98 {..} =
           p_hsConDeclField r
   where
     renderConDoc = mapM_ (p_hsDoc Pipe (With #endNewline)) con_doc
+    renderConDocAfterConstructor =
+      forM_ con_doc $ \doc ->
+        space >> p_hsDoc Caret (Isn't #endNewline) doc
+    isSingleLineDoc str =
+      case splitDocString (hsDocString str) of
+        [_] -> True
+        _ -> False
     renderContext =
       switchLayout conNameWithContextSpn $ do
         when con_forall $ do


### PR DESCRIPTION
Ormolu currently formats nullary constructors with trailing Haddocks by moving the documentation between the sum separator and the constructor name, which makes enum-like declarations harder to scan:

```haskell
data Foo
  = -- | bar
    Bar
  | -- | baz
    Baz
```

This changes the H98 prefix-constructor printer so single-line Haddocks on simple nullary constructors remain next to the constructor name:

```haskell
data Foo
  = Bar -- ^ bar
  | Baz -- ^ baz
```

The change is intentionally limited to single-line docs on constructors with no fields, context, or explicit binders. Constructors with arguments, multi-line constructor docs, records, GADTs, and infix constructors continue to use the existing placement so constructor docs are not confused with argument docs.

Fixes #583.
