### PR TITLE
Force multiline layout for export lists with doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Fixed printing of single line export lists with inlined Haddock comments.
+  [Issue 1051](https://github.com/tweag/ormolu/issues/1051).
+
 ## Ormolu 0.8.1.1
 
 * Add missing braces for case expressions in single‑line do blocks. [Issue

--- a/data/examples/module-header/block-haddock-in-export-list-out.hs
+++ b/data/examples/module-header/block-haddock-in-export-list-out.hs
@@ -1,0 +1,5 @@
+module Foo
+  ( -- | asdf
+    foo,
+  )
+where

--- a/data/examples/module-header/block-haddock-in-export-list.hs
+++ b/data/examples/module-header/block-haddock-in-export-list.hs
@@ -1,0 +1,1 @@
+module Foo ({- | asdf -} foo) where

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -31,6 +31,7 @@ module Ormolu.Printer.Combinators
     encloseLocated,
     located',
     switchLayout,
+    enterLayout,
     Layout (..),
     vlayout,
     getLayout,

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -8,6 +8,7 @@
 module Ormolu.Printer.Meat.ImportExport
   ( p_hsmodExports,
     p_hsmodImport,
+    enterMultilineLayoutIfContainsDocEntries,
   )
 where
 
@@ -25,12 +26,13 @@ import Ormolu.Utils (RelativePos (..), attachRelativePos)
 
 p_hsmodExports :: [LIE GhcPs] -> R ()
 p_hsmodExports xs =
-  parens N $ do
-    layout <- getLayout
-    sep
-      breakpoint
-      (\(p, l) -> sitcc (located (addDocSrcSpan l) (p_lie layout p)))
-      (attachRelativePos xs)
+  enterMultilineLayoutIfContainsDocEntries xs $
+    parens N $ do
+      layout <- getLayout
+      sep
+        breakpoint
+        (\(p, l) -> sitcc (located (addDocSrcSpan l) (p_lie layout p)))
+        (attachRelativePos xs)
   where
     -- In order to correctly set the layout when a doc comment is present.
     addDocSrcSpan lie@(L l ie) = case ieExportDoc ie of
@@ -172,3 +174,16 @@ ieExportDoc = \case
   IEGroup {} -> Nothing
   IEDoc {} -> Nothing
   IEDocNamed {} -> Nothing
+
+enterMultilineLayoutIfContainsDocEntries :: [LIE GhcPs] -> R () -> R ()
+enterMultilineLayoutIfContainsDocEntries xs =
+  if any (isDocEntry . unLoc) xs
+    then enterLayout MultiLine
+    else id
+
+isDocEntry :: (IE pass) -> Bool
+isDocEntry = \case
+  IEDoc {} -> True
+  IEGroup {} -> True
+  IEDocNamed {} -> True
+  _ -> False

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -37,35 +37,36 @@ p_hsModule mstackHeader pragmas HsModule {..} = do
   let XModulePs {..} = hsmodExt
       deprecSpan = maybe [] (pure . getLocA) hsmodDeprecMessage
       exportSpans = maybe [] (pure . getLocA) hsmodExports
-  switchLayout (deprecSpan <> exportSpans) $ do
-    forM_ mstackHeader $ \(L spn comment) -> do
-      spitCommentNow spn comment
-      newline
-    newline
-    p_pragmas pragmas
-    newline
-    case hsmodName of
-      Nothing -> return ()
-      Just hsmodName' -> do
-        located hsmodName' $ \name -> do
-          forM_ hsmodHaddockModHeader (p_hsDoc Pipe (With #endNewline))
-          p_hsmodName name
-        breakpoint
-        forM_ hsmodDeprecMessage $ \w -> do
-          located' p_warningTxt w
-          breakpoint
-        case hsmodExports of
-          Nothing -> return ()
-          Just l -> do
-            encloseLocated l $ \exports -> do
-              inci (p_hsmodExports exports)
-            breakpoint
-        txt "where"
+  switchLayout (deprecSpan <> exportSpans) $
+    enterMultilineLayoutIfContainsDocEntries (maybe [] unLoc hsmodExports) $ do
+      forM_ mstackHeader $ \(L spn comment) -> do
+        spitCommentNow spn comment
         newline
-    newline
-    forM_ hsmodImports (located' p_hsmodImport)
-    newline
-    switchLayout (getLocA <$> hsmodDecls) $ do
-      p_hsDecls Free hsmodDecls
       newline
-      spitRemainingComments
+      p_pragmas pragmas
+      newline
+      case hsmodName of
+        Nothing -> return ()
+        Just hsmodName' -> do
+          located hsmodName' $ \name -> do
+            forM_ hsmodHaddockModHeader (p_hsDoc Pipe (With #endNewline))
+            p_hsmodName name
+          breakpoint
+          forM_ hsmodDeprecMessage $ \w -> do
+            located' p_warningTxt w
+            breakpoint
+          case hsmodExports of
+            Nothing -> return ()
+            Just l -> do
+              encloseLocated l $ \exports -> do
+                inci (p_hsmodExports exports)
+              breakpoint
+          txt "where"
+          newline
+      newline
+      forM_ hsmodImports (located' p_hsmodImport)
+      newline
+      switchLayout (getLocA <$> hsmodDecls) $ do
+        p_hsDecls Free hsmodDecls
+        newline
+        spitRemainingComments


### PR DESCRIPTION
This PR forces a multiline layout when export lists contain Haddock comments.

Fixes #1051.
This is the most straightforward way of fixing the aforementioned issue. An alternative approach would be to maintain a block comment in such situations. However, this is not the current expected behavior of ormolu (see #641).