### PR TITLE
Disable trailing position logic of `infixr 0` operators with preceding comment

### DIFF
--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -12,6 +12,7 @@ module Ormolu.Printer.Combinators
     getEnclosingSpan,
     getEnclosingSpanWhere,
     getEnclosingComments,
+    hasCommentBetween,
     isExtensionEnabled,
 
     -- * Combinators

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -39,6 +39,7 @@ module Ormolu.Printer.Internal
     trimSpanStream,
     nextEltSpan,
     popComment,
+    hasCommentBetween,
     getEnclosingComments,
     getEnclosingSpan,
     getEnclosingSpanWhere,
@@ -518,6 +519,22 @@ popComment f = R $ do
       modify $ \sc -> sc {scCommentStream = CommentStream xs}
       return $ Just x
     _ -> return Nothing
+
+-- | Check if there is a comment that starts on a new line strictly after the
+-- end of 'prevSpan' and ends before the start of 'nextSpan' line.
+hasCommentBetween ::
+  -- | Span of the previous element
+  RealSrcSpan ->
+  -- | Span of the next element (typically an operator)
+  RealSrcSpan ->
+  R Bool
+hasCommentBetween prevSpan nextSpan = do
+  CommentStream cstream <- R $ gets scCommentStream
+  pure $ any isBetween cstream
+  where
+    isBetween (L l _) =
+      srcSpanStartLine l > srcSpanEndLine prevSpan
+        && srcSpanEndLine l < srcSpanStartLine nextSpan
 
 -- | Get the comments contained in the enclosing span.
 getEnclosingComments :: R [LComment]

--- a/src/Ormolu/Printer/Meat/Declaration/OpTree.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/OpTree.hs
@@ -22,6 +22,7 @@ import GHC.Types.Fixity
 import GHC.Types.Name (occNameString)
 import GHC.Types.Name.Reader (RdrName, rdrNameOcc)
 import GHC.Types.SrcLoc
+import GHC.Utils.Monad (allM)
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common (p_rdrName)
 import Ormolu.Printer.Meat.Declaration.Value
@@ -111,22 +112,31 @@ p_exprOpTree s t@(OpBranches exprs@(firstExpr :| otherExprs) ops) = do
         _ -> False
       -- Whether we could place the operator in a trailing position,
       -- followed by a breakpoint before the RHS
-      couldBeTrailing (prevExpr, opi) =
+      couldBeTrailing (prevExpr, opi) = do
+        hasPrecedingComment <-
+          case (opTreeLoc prevExpr, getLocA (opiOp opi)) of
+            (RealSrcSpan prevSpan _, RealSrcSpan nextSpan _) ->
+              hasCommentBetween prevSpan nextSpan
+            _ -> return False
         -- An operator with fixity InfixR 0, like seq, $, and $ variants,
         -- is required
-        isHardSplitterOp (opiFixityApproximation opi)
-          -- the LHS must be single-line
-          && isOneLineSpan (opTreeLoc prevExpr)
-          -- can only happen when a breakpoint would have been added anyway
-          && placement == Normal
-          -- if the node just on the left of the operator (so the rightmost
-          -- node of the subtree prevExpr) is a do-block, then we cannot
-          -- place the operator in a trailing position (because it would be
-          -- read as being part of the do-block)
-          && not (isDoBlock $ rightMostNode prevExpr)
-      -- If all operators at the current level match the conditions to be
-      -- trailing, then put them in a trailing position
-      isTrailing = all couldBeTrailing $ zip (NE.toList exprs) ops
+        return $
+          isHardSplitterOp (opiFixityApproximation opi)
+            -- the LHS must be single-line
+            && isOneLineSpan (opTreeLoc prevExpr)
+            -- can only happen when a breakpoint would have been added anyway
+            && placement == Normal
+            -- if the node just on the left of the operator (so the rightmost
+            -- node of the subtree prevExpr) is a do-block, then we cannot
+            -- place the operator in a trailing position (because it would be
+            -- read as being part of the do-block)
+            && not (isDoBlock $ rightMostNode prevExpr)
+            -- if it has a line comment between the previous expression and the
+            -- operator itself (currently broken, see #1028)
+            && not hasPrecedingComment
+  -- If all operators at the current level match the conditions to be
+  -- trailing, then put them in a trailing position
+  isTrailing <- allM couldBeTrailing $ zip (NE.toList exprs) ops
   ub <- if isTrailing then return useBraces else opBranchBraceStyle placement
   let p_x = ub $ p_exprOpTree s firstExpr
       putOpsExprs prevExpr (opi : ops') (expr : exprs') = do


### PR DESCRIPTION
This PR partially addresses the issue described in #1028.
Altough it does not produce the expected behavior, it mitigates the issue of producing Haskell code with a  different AST, by disabling the broken operator trailing positioning when it finds the scenario described in the reported issue.

```
$ cat repro.hs
foo = do
  bar
    -- txt
    $ baz

$ cabal run ormolu -- repro.hs | diff repro.hs -

```