### PR TITLE
Print comments preceding let-clause `where` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Fixed printing of single line export lists with inlined Haddock comments.
   [Issue 1051](https://github.com/tweag/ormolu/issues/1051).
 
+* Fixed printing preceding comments of let-clauses `where` keyword.
+  [Issue 784](https://github.com/tweag/ormolu/issues/784).
+
 ## Ormolu 0.8.1.1
 
 * Add missing braces for case expressions in single‑line do blocks. [Issue

--- a/data/examples/declaration/value/function/case-with-comment-before-where-out.hs
+++ b/data/examples/declaration/value/function/case-with-comment-before-where-out.hs
@@ -1,0 +1,14 @@
+foo =
+  case x of
+    _ -> 1
+  -- comment
+  where
+    -- comment 2
+    x = 1
+
+foo = case x of
+  _ -> 1
+  -- comment
+  where
+    -- comment 2
+    x = 1

--- a/data/examples/declaration/value/function/case-with-comment-before-where.hs
+++ b/data/examples/declaration/value/function/case-with-comment-before-where.hs
@@ -1,0 +1,14 @@
+foo =
+  case x of
+    _ -> 1
+    -- comment
+    where
+      -- comment 2
+      x = 1
+
+foo = case x of
+    _ -> 1
+    -- comment
+    where
+      -- comment 2
+      x = 1

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -38,6 +38,7 @@ import GHC.Types.SourceText
 import GHC.Types.SrcLoc
 import Language.Haskell.Syntax.Basic
 import Ormolu.Printer.Combinators
+import Ormolu.Printer.Comments (spitPrecedingComments)
 import Ormolu.Printer.Meat.Common
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.OpTree
@@ -274,9 +275,19 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
           breakpoint
           (located' (p_grhs' placement placer render groupStyle))
           (NE.toList grhssGRHSs)
+      localBindsWhereSpan = case grhssLocalBinds of
+        HsValBinds (EpAnn {anns = AnnList {al_rest}}) _ ->
+          locA al_rest
+        HsIPBinds (EpAnn {anns = AnnList {al_rest}}) _ ->
+          locA al_rest
+        EmptyLocalBinds _ -> noSrcSpan
       p_where = do
         unless (eqEmptyLocalBinds grhssLocalBinds) $ do
           breakpoint
+          case localBindsWhereSpan of
+            RealSrcSpan spn _ -> do
+              spitPrecedingComments spn
+            UnhelpfulSpan _ -> pure ()
           txt "where"
           breakpoint
           inci $ p_hsLocalBinds grhssLocalBinds


### PR DESCRIPTION
This PR fixes an issue where comments preceding the `where` keyword in let-clauses were printed in a wrong location.
Fixes #784.