### PR TITLE
Don't single out Prelude imports when NoImplicitPrelude is on

### DIFF
--- a/data/examples/import/no-implicit-prelude-out.hs
+++ b/data/examples/import/no-implicit-prelude-out.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+import Control.Applicative (Alternative, (<|>))
+import Data.Maybe (Maybe (Nothing), maybe)
+import Prelude ((+))
+import System.IO (IO)

--- a/data/examples/import/no-implicit-prelude-qual-out.hs
+++ b/data/examples/import/no-implicit-prelude-qual-out.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+import "base" Control.Applicative (Alternative, (<|>))
+import "base" Data.Maybe (Maybe (Nothing), maybe)
+import "base" Prelude ((+))
+import "base" System.IO (IO)
+import "yaya" Yaya.Fold (ana, cata)

--- a/data/examples/import/no-implicit-prelude-qual.hs
+++ b/data/examples/import/no-implicit-prelude-qual.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PackageImports #-}
+
+import "base" Control.Applicative (Alternative, (<|>))
+import "base" Data.Maybe (Maybe (Nothing), maybe)
+import "base" System.IO (IO)
+import "yaya" Yaya.Fold (ana, cata)
+import "base" Prelude ((+))

--- a/data/examples/import/no-implicit-prelude.hs
+++ b/data/examples/import/no-implicit-prelude.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+import Control.Applicative (Alternative, (<|>))
+import Data.Maybe (Maybe (Nothing), maybe)
+import System.IO (IO)
+import Prelude ((+))

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -13,7 +13,7 @@ where
 import Data.Bifunctor
 import Data.Char (isAlphaNum)
 import Data.Function (on)
-import Data.List (nubBy, sortBy, sortOn)
+import Data.List (nubBy, partition, sortBy, sortOn)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M
 import Data.Ord (comparing)
@@ -27,9 +27,10 @@ import GHC.Types.SrcLoc
 import Ormolu.Utils (notImplemented, showOutputable)
 
 -- | Sort and normalize imports.
-normalizeImports :: [LImportDecl GhcPs] -> [LImportDecl GhcPs]
-normalizeImports =
+normalizeImports :: Bool -> [LImportDecl GhcPs] -> [LImportDecl GhcPs]
+normalizeImports implicitPrelude =
   fmap snd
+    . relocatePrelude
     . M.toAscList
     . M.fromListWith combineImports
     . fmap (\x -> (importId x, g x))
@@ -42,6 +43,13 @@ normalizeImports =
           { ideclImportList = second (fmap normalizeLies) <$> ideclImportList,
             ..
           }
+
+    relocatePrelude :: [(ImportId, LImportDecl GhcPs)] -> [(ImportId, LImportDecl GhcPs)]
+    relocatePrelude decls
+      | implicitPrelude = otherImports <> preludeImports
+      | otherwise = decls
+      where
+        (preludeImports, otherImports) = partition (importIsPrelude . fst) decls
 
 -- | Combine two import declarations. It should be assumed that 'ImportId's
 -- are equal.
@@ -61,18 +69,18 @@ combineImports (L lx ImportDecl {..}) (L _ y) =
       }
 
 -- | Import id, a collection of all things that justify having a separate
--- import entry. This is used for merging of imports. If two imports have
--- the same 'ImportId' they can be merged.
+-- import entry. This is used for the ordering and merging of imports. If two
+-- imports have the same 'ImportId' they can be merged.
 data ImportId = ImportId
-  { importIsPrelude :: Bool,
-    importPkgQual :: ImportPkgQual,
+  { importPkgQual :: ImportPkgQual,
     importIdName :: ModuleName,
     importSource :: IsBootInterface,
     importSafe :: Bool,
     importQualified :: Bool,
     importAs :: Maybe ModuleName,
     importHiding :: Maybe ImportListInterpretationOrd,
-    importLevel :: Maybe ImportDeclLevelOrd
+    importLevel :: Maybe ImportDeclLevelOrd,
+    importIsPrelude :: Bool
   }
   deriving (Eq, Ord)
 
@@ -121,8 +129,7 @@ instance Ord ImportListInterpretationOrd where
 importId :: LImportDecl GhcPs -> ImportId
 importId (L _ ImportDecl {..}) =
   ImportId
-    { importIsPrelude = isPrelude,
-      importIdName = moduleName,
+    { importIdName = moduleName,
       importPkgQual = mkImportPkgQual ideclPkgQual,
       importSource = ideclSource,
       importSafe = ideclSafe,
@@ -132,7 +139,8 @@ importId (L _ ImportDecl {..}) =
         NotQualified -> False,
       importAs = unLoc <$> ideclAs,
       importHiding = ImportListInterpretationOrd . fst <$> ideclImportList,
-      importLevel = importLevelOf ideclLevelSpec
+      importLevel = importLevelOf ideclLevelSpec,
+      importIsPrelude = isPrelude
     }
   where
     isPrelude = moduleNameString moduleName == "Prelude"

--- a/src/Ormolu/Parser.hs
+++ b/src/Ormolu/Parser.hs
@@ -105,7 +105,7 @@ parseModule config@Config {..} packageFixityMap path rawInput = liftIO $ do
   snippets <- runExceptT . forM (preprocess cppEnabled cfgRegion rawInput) $ \case
     Right region ->
       fmap ParsedSnippet . ExceptT $
-        parseModuleSnippet (config $> region) modFixityMap dynFlags path rawInput
+        parseModuleSnippet (config $> region) modFixityMap dynFlags implicitPrelude path rawInput
     Left raw -> pure $ RawSnippet raw
   pure (warnings, snippets)
 
@@ -114,10 +114,11 @@ parseModuleSnippet ::
   Config RegionDeltas ->
   ModuleFixityMap ->
   DynFlags ->
+  Bool ->
   FilePath ->
   Text ->
   m (Either (SrcSpan, String) ParseResult)
-parseModuleSnippet Config {..} modFixityMap dynFlags path rawInput = liftIO $ do
+parseModuleSnippet Config {..} modFixityMap dynFlags implicitPrelude path rawInput = liftIO $ do
   let (input, indent) = removeIndentation . linesInRegion cfgRegion $ rawInput
   let pStateErrors pstate =
         let errs = bagToList . GHC.getMessages $ GHC.getPsErrorMessages pstate
@@ -148,7 +149,7 @@ parseModuleSnippet Config {..} modFixityMap dynFlags path rawInput = liftIO $ do
           case pStateErrors pstate of
             Just err -> Left err
             Nothing -> error "PFailed does not have an error"
-        GHC.POk pstate (L _ (normalizeModule -> hsModule)) ->
+        GHC.POk pstate (L _ (normalizeModule implicitPrelude -> hsModule)) ->
           case pStateErrors pstate of
             -- Some parse errors (pattern/arrow syntax in expr context)
             -- do not cause a parse error, but they are replaced with "_"
@@ -173,8 +174,8 @@ parseModuleSnippet Config {..} modFixityMap dynFlags path rawInput = liftIO $ do
 
 -- | Normalize a 'HsModule' by sorting its import\/export lists, dropping
 -- blank comments, etc.
-normalizeModule :: HsModule GhcPs -> HsModule GhcPs
-normalizeModule hsmod =
+normalizeModule :: Bool -> HsModule GhcPs -> HsModule GhcPs
+normalizeModule implicitPrelude hsmod =
   everywhere
     ( mkT dropBlankTypeHaddocks
         `extT` dropBlankDataDeclHaddocks
@@ -183,7 +184,7 @@ normalizeModule hsmod =
     )
     hsmod
       { hsmodImports =
-          normalizeImports (hsmodImports hsmod),
+          normalizeImports implicitPrelude (hsmodImports hsmod),
         hsmodDecls =
           filter (not . isBlankDocD . unLoc) (hsmodDecls hsmod),
         hsmodExt =


### PR DESCRIPTION
Closes #1189.

Since `importIsPrelude` came first in the fields of `ImportId`, sorting imports through `ImportId` resulted in the implicit separation between `Prelude` and non-`Prelude` imports, effecting placing non-`Prelude` imports first (because `False < True`). In order to avoid having to define a manual `Ord` instance for `ImportId`, I did two things:
1. Make `importIsPrelude` the last field of `ImportId`, so that the initial sorting does not separate `Prelude` imports, and
2. Explicitly relocate the `Prelude` to the end of the list in `normalizeImports` if `ImplicitPrelude` is on.